### PR TITLE
fix: use explicit type for Image.create() to fix export build

### DIFF
--- a/scenes/main/main_window_tabs.gd
+++ b/scenes/main/main_window_tabs.gd
@@ -186,7 +186,7 @@ func _on_tab_icon_loaded(
 func _create_color_swatch(
 	c: Color, px: int = 16,
 ) -> ImageTexture:
-	var img := Image.create(
+	var img: Image = Image.create(
 		px, px, false, Image.FORMAT_RGBA8,
 	)
 	img.fill(c)


### PR DESCRIPTION
Image.create() returns Variant in exported builds, causing a type
inference failure with :=. Use explicit type annotation instead.

https://claude.ai/code/session_01VWHsKegWBvnUuhMasaH4Y5