### PR TITLE
DAC-21: Restore keyboard focus indicators in discord_dark theme

### DIFF
--- a/assets/theme/discord_dark.tres
+++ b/assets/theme/discord_dark.tres
@@ -1,6 +1,16 @@
 [gd_resource type="Theme" load_steps=23 format=3 uid="uid://s8v788hsibn3"]
 
-[sub_resource type="StyleBoxEmpty" id="no_focus"]
+[sub_resource type="StyleBoxFlat" id="focus_outline"]
+bg_color = Color(0, 0, 0, 0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.345, 0.396, 0.949, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="button_hover"]
 content_margin_left = 8.0
@@ -189,12 +199,12 @@ default_font_size = 14
 Button/colors/font_color = Color(0.863, 0.867, 0.871, 1)
 Button/colors/font_hover_color = Color(1, 1, 1, 1)
 Button/colors/font_pressed_color = Color(1, 1, 1, 1)
-Button/styles/focus = SubResource("no_focus")
+Button/styles/focus = SubResource("focus_outline")
 Button/styles/hover = SubResource("button_hover")
 Button/styles/normal = SubResource("button_normal")
 Button/styles/pressed = SubResource("button_pressed")
-CheckBox/styles/focus = SubResource("no_focus")
-CheckButton/styles/focus = SubResource("no_focus")
+CheckBox/styles/focus = SubResource("focus_outline")
+CheckButton/styles/focus = SubResource("focus_outline")
 HSlider/styles/grabber_area = SubResource("slider_grabber_area")
 HSlider/styles/grabber_area_highlight = SubResource("slider_grabber_area_hl")
 HSlider/styles/slider = SubResource("slider_track")
@@ -203,11 +213,11 @@ Label/font_sizes/font_size = 14
 LineEdit/colors/caret_color = Color(1, 1, 1, 1)
 LineEdit/colors/font_color = Color(0.863, 0.867, 0.871, 1)
 LineEdit/colors/font_placeholder_color = Color(0.58, 0.608, 0.643, 1)
-LineEdit/styles/focus = SubResource("no_focus")
+LineEdit/styles/focus = SubResource("focus_outline")
 LineEdit/styles/normal = SubResource("lineedit_normal")
-MenuButton/styles/focus = SubResource("no_focus")
+MenuButton/styles/focus = SubResource("focus_outline")
 OptionButton/colors/font_color = Color(0.863, 0.867, 0.871, 1)
-OptionButton/styles/focus = SubResource("no_focus")
+OptionButton/styles/focus = SubResource("focus_outline")
 OptionButton/styles/hover = SubResource("optionbutton_hover")
 OptionButton/styles/normal = SubResource("optionbutton_normal")
 OptionButton/styles/pressed = SubResource("optionbutton_normal")
@@ -219,19 +229,19 @@ PopupMenu/styles/panel = SubResource("popup_panel")
 ProgressBar/styles/background = SubResource("progressbar_bg")
 ProgressBar/styles/fill = SubResource("progressbar_fill")
 RichTextLabel/colors/default_color = Color(0.863, 0.867, 0.871, 1)
-RichTextLabel/styles/focus = SubResource("no_focus")
+RichTextLabel/styles/focus = SubResource("focus_outline")
 ScrollContainer/styles/panel = SubResource("panel_default")
-SpinBox/styles/focus = SubResource("no_focus")
+SpinBox/styles/focus = SubResource("focus_outline")
 TabBar/colors/font_hovered_color = Color(0.863, 0.867, 0.871, 1)
 TabBar/colors/font_selected_color = Color(1, 1, 1, 1)
 TabBar/colors/font_unselected_color = Color(0.58, 0.608, 0.643, 1)
-TabBar/styles/tab_focus = SubResource("no_focus")
+TabBar/styles/tab_focus = SubResource("focus_outline")
 TabBar/styles/tab_hovered = SubResource("tabbar_tab_hovered")
 TabBar/styles/tab_selected = SubResource("tabbar_tab_selected")
 TabBar/styles/tab_unselected = SubResource("tabbar_tab_unselected")
 TextEdit/colors/caret_color = Color(1, 1, 1, 1)
 TextEdit/colors/font_color = Color(0.863, 0.867, 0.871, 1)
-TextEdit/styles/focus = SubResource("no_focus")
+TextEdit/styles/focus = SubResource("focus_outline")
 TextEdit/styles/normal = SubResource("textedit_normal")
 VScrollBar/styles/grabber = SubResource("scrollbar_grabber")
 VScrollBar/styles/grabber_highlight = SubResource("scrollbar_grabber_highlight")


### PR DESCRIPTION
## Summary
- Replaced `StyleBoxEmpty` (invisible) focus boxes with `StyleBoxFlat` 2px accent-colored rounded outlines across all 10 interactive widget types in `assets/theme/discord_dark.tres`
- Affected widgets: Button, CheckBox, CheckButton, LineEdit, MenuButton, OptionButton, RichTextLabel, SpinBox, TabBar, TextEdit
- Focus outline uses the existing accent color (`Color(0.345, 0.396, 0.949, 1)`) with transparent background so it overlays naturally on any background
- Prerequisite for WCAG 2.1 AA keyboard navigation compliance

## Test plan
- [ ] Unit tests pass (`./test.sh unit`)
- [ ] Lint clean (`gdlint scripts/ scenes/`)
- [ ] CI passing
- [ ] Manual: Tab through interactive elements — accent-colored 2px outline visible on focused widgets