### PR TITLE
DAC-18: Query 2FA status from server when opening 2FA settings page

### DIFF
--- a/scenes/user/user_settings_twofa.gd
+++ b/scenes/user/user_settings_twofa.gd
@@ -134,6 +134,23 @@ func build(
 	# Check initial 2FA status from user data
 	if user.get("mfa_enabled", false):
 		_show_enabled_state()
+	# Refresh from server to get authoritative status
+	_refresh_mfa_status()
+
+func _refresh_mfa_status() -> void:
+	var client: AccordClient = _get_client()
+	if client == null:
+		return
+	var result: RestResult = await client.users.get_me()
+	if not result.ok:
+		return
+	if not result.data is AccordUser:
+		return
+	var fetched_user: AccordUser = result.data
+	if fetched_user.mfa_enabled:
+		_show_enabled_state()
+	else:
+		_show_disabled_state()
 
 func _show_enabled_state() -> void:
 	_status_label.text = "Two-factor authentication is enabled."


### PR DESCRIPTION
## Summary
- Added `_refresh_mfa_status()` async coroutine to `user_settings_twofa.gd`
- Called fire-and-forget from `build()` after setting initial state from local cache
- Calls `client.users.get_me()` (GET /users/@me) to get authoritative `mfa_enabled` state from server
- Updates status label and button visibility based on the server response
- Local cache is still used for instant initial render; server result overwrites if different

## Test plan
- [ ] Unit tests pass (`./test.sh unit`)
- [ ] Lint clean (`gdlint scripts/ scenes/`)
- [ ] CI passing
- [ ] Manual: open 2FA settings page — status correctly reflects server-side 2FA state