### PR TITLE
DAC-88: Fix gdlint private-member-access in add_friend_dialog.gd

### DIFF
--- a/scenes/sidebar/direct/add_friend_dialog.gd
+++ b/scenes/sidebar/direct/add_friend_dialog.gd
@@ -40,13 +40,7 @@ func _on_send() -> void:
 	_close()
 
 func _find_user_id(username: String) -> String:
-	var lower: String = username.to_lower()
-	for uid: String in Client._user_cache:
-		var u: Dictionary = Client._user_cache[uid]
-		if u.get("username", "").to_lower() == lower \
-				or u.get("display_name", "").to_lower() == lower:
-			return uid
-	return ""
+	return Client.find_user_id_by_username(username)
 
 func _close() -> void:
 	queue_free()

--- a/scripts/autoload/client.gd
+++ b/scripts/autoload/client.gd
@@ -386,6 +386,15 @@ func get_messages_for_channel(cid: String) -> Array:
 func get_user_by_id(uid: String) -> Dictionary:
 	return _user_cache.get(uid, {})
 
+func find_user_id_by_username(username: String) -> String:
+	var lower: String = username.to_lower()
+	for uid: String in _user_cache:
+		var u: Dictionary = _user_cache[uid]
+		if u.get("username", "").to_lower() == lower \
+				or u.get("display_name", "").to_lower() == lower:
+			return uid
+	return ""
+
 func get_active_user() -> Dictionary:
 	var conn = _conn_for_active_view()
 	if conn != null:


### PR DESCRIPTION
## Summary
- Add `Client.find_user_id_by_username()` public method that encapsulates the username search logic previously done inline
- Update `add_friend_dialog.gd` to call the new public method instead of directly accessing `Client._user_cache` (private member)
- This unblocks the Lint CI job which was failing on every PR due to the `private-method-call` gdlint rule violation

## Test plan
- [x] Lint clean (`gdlint scripts/ scenes/`)
- [ ] Unit tests pass (`./test.sh unit`) — CI will verify (Godot not available locally)
- [ ] CI passing
- No functional change to friend request behavior

Fixes DAC-88.