### PR TITLE
DAC-130: Unit tests for profile management dialogs

### DIFF
--- a/tests/unit/test_create_profile_dialog.gd
+++ b/tests/unit/test_create_profile_dialog.gd
@@ -1,0 +1,142 @@
+extends GutTest
+
+var dialog: ColorRect
+
+
+func before_each() -> void:
+	dialog = load("res://scenes/user/create_profile_dialog.tscn").instantiate()
+	add_child(dialog)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	if is_instance_valid(dialog):
+		dialog.queue_free()
+		await get_tree().process_frame
+
+
+# --- UI structure ---
+
+func test_has_name_input() -> void:
+	assert_not_null(dialog._name_input)
+	assert_true(dialog._name_input is LineEdit)
+
+
+func test_has_password_input() -> void:
+	assert_not_null(dialog._password_input)
+
+
+func test_has_confirm_input() -> void:
+	assert_not_null(dialog._confirm_input)
+
+
+func test_has_create_button() -> void:
+	assert_not_null(dialog._create_btn)
+	assert_true(dialog._create_btn is Button)
+
+
+func test_has_error_label() -> void:
+	assert_not_null(dialog._error_label)
+
+
+func test_error_label_hidden_initially() -> void:
+	assert_false(dialog._error_label.visible)
+
+
+func test_confirm_input_hidden_initially() -> void:
+	assert_false(dialog._confirm_input.visible)
+
+
+func test_confirm_label_hidden_initially() -> void:
+	assert_false(dialog._confirm_label.visible)
+
+
+# --- signals ---
+
+func test_has_profile_created_signal() -> void:
+	assert_has_signal(dialog, "profile_created")
+
+
+# --- validation: empty name ---
+
+func test_empty_name_shows_error() -> void:
+	dialog._name_input.text = ""
+	dialog._on_create()
+	await get_tree().process_frame
+	assert_true(dialog._error_label.visible)
+	assert_string_contains(dialog._error_label.text, "required")
+
+
+func test_empty_name_does_not_emit_signal() -> void:
+	watch_signals(dialog)
+	dialog._name_input.text = ""
+	dialog._on_create()
+	await get_tree().process_frame
+	assert_signal_not_emitted(dialog, "profile_created")
+
+
+# --- validation: name too long ---
+
+func test_name_too_long_shows_error() -> void:
+	dialog._name_input.text = "a".repeat(33)
+	dialog._on_create()
+	await get_tree().process_frame
+	assert_true(dialog._error_label.visible)
+	assert_string_contains(dialog._error_label.text, "32")
+
+
+func test_name_at_max_length_clears_error_path() -> void:
+	# 32 chars is valid — error label should NOT be shown for length reason
+	# (may still fail later if Config.profiles is called, but validation passes)
+	dialog._name_input.text = "a".repeat(32)
+	# No password — would pass length validation
+	# We only assert the length error is NOT triggered
+	dialog._error_label.visible = false
+	dialog._on_create()
+	await get_tree().process_frame
+	if dialog._error_label.visible:
+		assert_false(
+			dialog._error_label.text.contains("32"),
+			"A 32-char name should not trigger the length error"
+		)
+
+
+# --- validation: password mismatch ---
+
+func test_password_mismatch_shows_error() -> void:
+	dialog._name_input.text = "Test Profile"
+	dialog._password_input.text = "secret"
+	dialog._confirm_input.text = "different"
+	dialog._on_create()
+	await get_tree().process_frame
+	assert_true(dialog._error_label.visible)
+	assert_string_contains(dialog._error_label.text, "match")
+
+
+func test_password_mismatch_does_not_emit_signal() -> void:
+	watch_signals(dialog)
+	dialog._name_input.text = "Test Profile"
+	dialog._password_input.text = "secret"
+	dialog._confirm_input.text = "different"
+	dialog._on_create()
+	await get_tree().process_frame
+	assert_signal_not_emitted(dialog, "profile_created")
+
+
+# --- password visibility toggle ---
+
+func test_password_typed_shows_confirm_fields() -> void:
+	dialog._password_input.emit_signal("text_changed", "hello")
+	await get_tree().process_frame
+	assert_true(dialog._confirm_label.visible)
+	assert_true(dialog._confirm_input.visible)
+
+
+func test_password_cleared_hides_confirm_fields() -> void:
+	dialog._password_input.emit_signal("text_changed", "hello")
+	await get_tree().process_frame
+	dialog._password_input.emit_signal("text_changed", "")
+	await get_tree().process_frame
+	assert_false(dialog._confirm_label.visible)
+	assert_false(dialog._confirm_input.visible)

--- a/tests/unit/test_profile_password_dialog.gd
+++ b/tests/unit/test_profile_password_dialog.gd
@@ -1,0 +1,118 @@
+extends GutTest
+
+## Inline stub that makes verify_password return false, simulating wrong password.
+class _StubProfilesReject:
+	extends RefCounted
+	func verify_password(_slug: String, _pw: String) -> bool:
+		return false
+
+
+var dialog: ColorRect
+var _original_profiles: Object
+
+
+func before_each() -> void:
+	dialog = load("res://scenes/user/profile_password_dialog.tscn").instantiate()
+	add_child(dialog)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	_original_profiles = Config.profiles
+
+
+func after_each() -> void:
+	Config.profiles = _original_profiles
+	if is_instance_valid(dialog):
+		dialog.queue_free()
+		await get_tree().process_frame
+
+
+# --- UI structure ---
+
+func test_has_profile_label() -> void:
+	assert_not_null(dialog._profile_label)
+	assert_true(dialog._profile_label is Label)
+
+
+func test_has_password_input() -> void:
+	assert_not_null(dialog._password_input)
+
+
+func test_has_unlock_button() -> void:
+	assert_not_null(dialog._unlock_btn)
+	assert_true(dialog._unlock_btn is Button)
+
+
+func test_has_error_label() -> void:
+	assert_not_null(dialog._error_label)
+
+
+func test_error_label_hidden_initially() -> void:
+	assert_false(dialog._error_label.visible)
+
+
+# --- signals ---
+
+func test_has_password_verified_signal() -> void:
+	assert_has_signal(dialog, "password_verified")
+
+
+# --- setup method ---
+
+func test_setup_stores_slug() -> void:
+	dialog.setup("my-profile", "My Profile")
+	assert_eq(dialog._slug, "my-profile")
+
+
+func test_setup_updates_profile_label_when_in_tree() -> void:
+	dialog.setup("my-profile", "Cool Profile")
+	await get_tree().process_frame
+	assert_string_contains(dialog._profile_label.text, "Cool Profile")
+
+
+# --- validation: empty password ---
+
+func test_empty_password_shows_error() -> void:
+	dialog._password_input.text = ""
+	dialog._on_unlock()
+	await get_tree().process_frame
+	assert_true(dialog._error_label.visible)
+	assert_string_contains(dialog._error_label.text, "required")
+
+
+func test_empty_password_does_not_emit_signal() -> void:
+	watch_signals(dialog)
+	dialog._password_input.text = ""
+	dialog._on_unlock()
+	await get_tree().process_frame
+	assert_signal_not_emitted(dialog, "password_verified")
+
+
+# --- wrong password (stub rejects all passwords) ---
+
+func test_wrong_password_shows_error() -> void:
+	Config.profiles = _StubProfilesReject.new()
+	dialog.setup("any-slug", "Test")
+	dialog._password_input.text = "wrongpass"
+	dialog._on_unlock()
+	await get_tree().process_frame
+	assert_true(dialog._error_label.visible)
+	assert_string_contains(dialog._error_label.text, "Incorrect")
+
+
+func test_wrong_password_clears_input() -> void:
+	Config.profiles = _StubProfilesReject.new()
+	dialog.setup("any-slug", "Test")
+	dialog._password_input.text = "wrongpass"
+	dialog._on_unlock()
+	await get_tree().process_frame
+	assert_eq(dialog._password_input.text, "")
+
+
+func test_wrong_password_does_not_emit_signal() -> void:
+	watch_signals(dialog)
+	Config.profiles = _StubProfilesReject.new()
+	dialog.setup("any-slug", "Test")
+	dialog._password_input.text = "wrongpass"
+	dialog._on_unlock()
+	await get_tree().process_frame
+	assert_signal_not_emitted(dialog, "password_verified")


### PR DESCRIPTION
## Summary
- Add `test_create_profile_dialog.gd`: covers UI structure, empty-name validation, too-long-name validation, password mismatch validation, confirm-field visibility toggle, and `profile_created` signal existence
- Add `test_profile_password_dialog.gd`: covers UI structure, `setup()`, empty-password validation, wrong-password path (using an inline `_StubProfilesReject` stub to force `verify_password` to return `false`), and `password_verified` signal existence

## Test plan
- [ ] Unit tests pass (`./test.sh unit`)
- [ ] Lint clean (`gdlint scripts/ scenes/`)
- [ ] CI passing