### PR TITLE
DAC-128: Unit tests for message_action_bar and message_view_banner

### DIFF
--- a/tests/unit/test_message_action_bar.gd
+++ b/tests/unit/test_message_action_bar.gd
@@ -1,0 +1,160 @@
+extends GutTest
+
+const TestDataFactory := preload("res://tests/helpers/test_data_factory.gd")
+
+var component: PanelContainer
+
+
+func before_each() -> void:
+	Client.current_user = {
+		"id": "my_user_1",
+		"display_name": "TestUser",
+		"username": "testuser",
+		"color": Color.WHITE,
+		"status": 0,
+		"avatar": null,
+	}
+	# Ensure no stale space mappings interfere
+	Client._channel_to_space.clear()
+	component = load("res://scenes/messages/message_action_bar.tscn").instantiate()
+	add_child(component)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	if is_instance_valid(component):
+		component.queue_free()
+		await get_tree().process_frame
+
+
+# --- signals ---
+
+func test_has_action_reply_signal() -> void:
+	assert_true(component.has_signal("action_reply"))
+
+
+func test_has_action_edit_signal() -> void:
+	assert_true(component.has_signal("action_edit"))
+
+
+func test_has_action_delete_signal() -> void:
+	assert_true(component.has_signal("action_delete"))
+
+
+func test_has_action_thread_signal() -> void:
+	assert_true(component.has_signal("action_thread"))
+
+
+# --- buttons exist ---
+
+func test_react_button_exists() -> void:
+	assert_true(is_instance_valid(component.react_btn))
+
+
+func test_reply_button_exists() -> void:
+	assert_true(is_instance_valid(component.reply_btn))
+
+
+func test_edit_button_exists() -> void:
+	assert_true(is_instance_valid(component.edit_btn))
+
+
+func test_delete_button_exists() -> void:
+	assert_true(is_instance_valid(component.delete_btn))
+
+
+func test_thread_button_exists() -> void:
+	assert_true(is_instance_valid(component.thread_btn))
+
+
+# --- visibility for other-user messages ---
+
+func test_edit_hidden_for_other_user_no_permissions() -> void:
+	# author id differs from current_user; no manage perms configured
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "other_user"}),
+	})
+	component.show_for_message(component, msg)
+	assert_false(component.edit_btn.visible)
+
+
+func test_delete_hidden_for_other_user_no_permissions() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "other_user"}),
+	})
+	component.show_for_message(component, msg)
+	assert_false(component.delete_btn.visible)
+
+
+# --- visibility for own messages ---
+
+func test_edit_visible_for_own_message() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "my_user_1"}),
+	})
+	component.show_for_message(component, msg)
+	assert_true(component.edit_btn.visible)
+
+
+func test_delete_visible_for_own_message() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "my_user_1"}),
+	})
+	component.show_for_message(component, msg)
+	assert_true(component.delete_btn.visible)
+
+
+# --- signal emission ---
+
+func test_reply_button_emits_action_reply() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({"channel_id": "c_1"})
+	component.show_for_message(component, msg)
+	watch_signals(component)
+	component.reply_btn.pressed.emit()
+	assert_signal_emitted(component, "action_reply")
+
+
+func test_edit_button_emits_action_edit() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "my_user_1"}),
+	})
+	component.show_for_message(component, msg)
+	watch_signals(component)
+	component.edit_btn.pressed.emit()
+	assert_signal_emitted(component, "action_edit")
+
+
+func test_delete_button_emits_action_delete() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({
+		"channel_id": "c_1",
+		"author": TestDataFactory.user_data({"id": "my_user_1"}),
+	})
+	component.show_for_message(component, msg)
+	watch_signals(component)
+	component.delete_btn.pressed.emit()
+	assert_signal_emitted(component, "action_delete")
+
+
+# --- show/hide ---
+
+func test_show_for_message_makes_bar_visible() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({"channel_id": "c_1"})
+	component.show_for_message(component, msg)
+	assert_true(component.visible)
+
+
+func test_hide_bar_hides_component() -> void:
+	var msg: Dictionary = TestDataFactory.msg_data({"channel_id": "c_1"})
+	component.show_for_message(component, msg)
+	component.hide_bar()
+	# Give reduced-motion path time (bar becomes invisible immediately)
+	await get_tree().process_frame
+	# Either visible=false or animation in progress; verify not still showing
+	# We can't rely on tween timing, so test the get_message_node() is cleared
+	assert_null(component.get_message_node())

--- a/tests/unit/test_message_view_banner.gd
+++ b/tests/unit/test_message_view_banner.gd
@@ -1,0 +1,188 @@
+extends GutTest
+
+## Unit tests for MessageViewBanner.
+## MessageViewBanner is a RefCounted class that wraps UI nodes (PanelContainer,
+## Label, Button, Timer) and a space-lookup Callable.
+
+var banner: MessageViewBanner
+var panel: PanelContainer
+var label: Label
+var retry_btn: Button
+var timer: Timer
+var _current_space_id: String = "g_1"
+
+
+func before_each() -> void:
+	panel = PanelContainer.new()
+	label = Label.new()
+	retry_btn = Button.new()
+	timer = Timer.new()
+	add_child(panel)
+	add_child(label)
+	add_child(retry_btn)
+	add_child(timer)
+	await get_tree().process_frame
+	banner = MessageViewBanner.new(
+		panel,
+		label,
+		retry_btn,
+		timer,
+		func() -> String: return _current_space_id,
+	)
+
+
+func after_each() -> void:
+	banner = null
+	for node: Node in [panel, label, retry_btn, timer]:
+		if is_instance_valid(node):
+			node.queue_free()
+	await get_tree().process_frame
+
+
+# --- on_server_disconnected ---
+
+func test_disconnected_shows_banner_for_matching_space() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_disconnected("g_1", 1000, "")
+	assert_true(panel.visible)
+
+
+func test_disconnected_ignores_different_space() -> void:
+	_current_space_id = "g_1"
+	panel.visible = false
+	banner.on_server_disconnected("g_other", 1000, "")
+	assert_false(panel.visible)
+
+
+func test_disconnected_hides_retry_button() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_disconnected("g_1", 1001, "")
+	assert_false(retry_btn.visible)
+
+
+func test_disconnected_sets_status_text() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_disconnected("g_1", 4004, "")
+	assert_true(label.text.length() > 0)
+	assert_true(label.text.contains("Session expired"))
+
+
+func test_disconnected_uses_fallback_reason() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_disconnected("g_1", 9999, "Custom reason")
+	assert_true(label.text.contains("Custom reason"))
+
+
+func test_disconnected_defaults_to_connection_lost() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_disconnected("g_1", 9999, "")
+	assert_true(label.text.contains("Connection lost"))
+
+
+# --- on_server_reconnecting ---
+
+func test_reconnecting_shows_banner() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_reconnecting("g_1", 2, 5)
+	assert_true(panel.visible)
+
+
+func test_reconnecting_ignores_different_space() -> void:
+	_current_space_id = "g_1"
+	panel.visible = false
+	banner.on_server_reconnecting("g_other", 1, 5)
+	assert_false(panel.visible)
+
+
+func test_reconnecting_shows_attempt_info() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_reconnecting("g_1", 3, 10)
+	assert_true(label.text.contains("3"))
+	assert_true(label.text.contains("10"))
+
+
+func test_reconnecting_hides_retry_button() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_reconnecting("g_1", 1, 5)
+	assert_false(retry_btn.visible)
+
+
+# --- on_server_reconnected ---
+
+func test_reconnected_shows_banner() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_reconnected("g_1")
+	assert_true(panel.visible)
+
+
+func test_reconnected_ignores_different_space() -> void:
+	_current_space_id = "g_1"
+	panel.visible = false
+	banner.on_server_reconnected("g_other")
+	assert_false(panel.visible)
+
+
+# --- on_server_synced ---
+
+func test_synced_shows_banner_and_starts_timer() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_synced("g_1")
+	assert_true(panel.visible)
+
+
+func test_synced_ignores_different_space() -> void:
+	_current_space_id = "g_1"
+	panel.visible = false
+	banner.on_server_synced("g_other")
+	assert_false(panel.visible)
+
+
+func test_synced_sets_reconnected_text() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_synced("g_1")
+	assert_true(label.text.contains("Reconnected"))
+
+
+# --- on_server_connection_failed ---
+
+func test_connection_failed_shows_banner() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_connection_failed("g_1", "timeout")
+	assert_true(panel.visible)
+
+
+func test_connection_failed_ignores_different_space() -> void:
+	_current_space_id = "g_1"
+	panel.visible = false
+	banner.on_server_connection_failed("g_other", "timeout")
+	assert_false(panel.visible)
+
+
+func test_connection_failed_shows_retry_button() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_connection_failed("g_1", "timeout")
+	assert_true(retry_btn.visible)
+
+
+func test_connection_failed_includes_reason_in_label() -> void:
+	_current_space_id = "g_1"
+	banner.on_server_connection_failed("g_1", "timeout")
+	assert_true(label.text.contains("timeout"))
+
+
+# --- _code_to_message static ---
+
+func test_code_4003_returns_auth_failed() -> void:
+	assert_eq(MessageViewBanner._code_to_message(4003), "Authentication failed")
+
+
+func test_code_4004_returns_session_expired() -> void:
+	assert_eq(MessageViewBanner._code_to_message(4004), "Session expired")
+
+
+func test_code_1000_returns_server_closed() -> void:
+	assert_eq(MessageViewBanner._code_to_message(1000), "Server closed connection")
+
+
+func test_unknown_code_returns_empty_string() -> void:
+	assert_eq(MessageViewBanner._code_to_message(9999), "")


### PR DESCRIPTION
## Summary
- Add `test_message_action_bar.gd`: tests signal existence, button presence, edit/delete visibility (own vs other-user messages), and signal emission on button press
- Add `test_message_view_banner.gd`: tests all connection state handlers (`on_server_disconnected`, `on_server_reconnecting`, `on_server_reconnected`, `on_server_synced`, `on_server_connection_failed`) including space-filter guard and the static `_code_to_message` helper

## Test plan
- [ ] Unit tests pass (`./test.sh unit`)
- [ ] Lint clean (`gdlint scripts/ scenes/`)
- [ ] CI passing