### PR TITLE
DAC-129: Add unit tests for dm_list and create_group_dm_dialog

### DIFF
--- a/tests/unit/test_create_group_dm_dialog.gd
+++ b/tests/unit/test_create_group_dm_dialog.gd
@@ -1,0 +1,158 @@
+extends GutTest
+
+var component: ColorRect
+
+
+func before_each() -> void:
+	Client.current_user = {
+		"id": "me_1",
+		"display_name": "Me",
+		"username": "me",
+		"color": Color.WHITE,
+		"status": 0,
+		"avatar": null,
+	}
+	# Populate user cache with two non-bot, non-self users
+	Client._user_cache = {
+		"u_alice": {
+			"id": "u_alice",
+			"display_name": "Alice",
+			"username": "alice",
+			"bot": false,
+		},
+		"u_bob": {
+			"id": "u_bob",
+			"display_name": "Bob",
+			"username": "bob",
+			"bot": false,
+		},
+	}
+	component = load(
+		"res://scenes/sidebar/direct/create_group_dm_dialog.tscn"
+	).instantiate()
+	add_child(component)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	if is_instance_valid(component):
+		component.queue_free()
+		await get_tree().process_frame
+	Client._user_cache = {}
+
+
+# --- UI elements exist ---
+
+func test_search_input_exists() -> void:
+	assert_not_null(component.search_input)
+
+
+func test_user_list_exists() -> void:
+	assert_not_null(component.user_list)
+
+
+func test_create_button_exists() -> void:
+	assert_not_null(component.create_button)
+
+
+func test_selected_label_exists() -> void:
+	assert_not_null(component.selected_label)
+
+
+func test_close_button_exists() -> void:
+	assert_not_null(component.close_button)
+
+
+# --- initial state ---
+
+func test_create_button_disabled_initially() -> void:
+	# 0 selected → disabled (requires ≥ 2)
+	assert_true(component.create_button.disabled)
+
+
+func test_selected_label_shows_zero_initially() -> void:
+	assert_eq(component.selected_label.text, "0 users selected")
+
+
+func test_user_list_populated_from_cache() -> void:
+	# Two non-bot, non-self users should produce two checkboxes
+	assert_eq(component.user_list.get_child_count(), 2)
+
+
+# --- _on_user_toggled ---
+
+func test_toggle_on_adds_to_selected_ids() -> void:
+	component._on_user_toggled(true, "u_alice")
+	assert_true(component._selected_ids.has("u_alice"))
+
+
+func test_toggle_off_removes_from_selected_ids() -> void:
+	component._on_user_toggled(true, "u_alice")
+	component._on_user_toggled(false, "u_alice")
+	assert_false(component._selected_ids.has("u_alice"))
+
+
+func test_toggle_on_twice_no_duplicates() -> void:
+	component._on_user_toggled(true, "u_alice")
+	component._on_user_toggled(true, "u_alice")
+	assert_eq(component._selected_ids.size(), 1)
+
+
+# --- _update_selection_ui ---
+
+func test_one_selected_still_disables_create_button() -> void:
+	component._on_user_toggled(true, "u_alice")
+	assert_true(component.create_button.disabled)
+
+
+func test_two_selected_enables_create_button() -> void:
+	component._on_user_toggled(true, "u_alice")
+	component._on_user_toggled(true, "u_bob")
+	assert_false(component.create_button.disabled)
+
+
+func test_deselect_back_to_one_disables_create_button() -> void:
+	component._on_user_toggled(true, "u_alice")
+	component._on_user_toggled(true, "u_bob")
+	component._on_user_toggled(false, "u_bob")
+	assert_true(component.create_button.disabled)
+
+
+func test_selected_label_singular_for_one_user() -> void:
+	component._on_user_toggled(true, "u_alice")
+	assert_eq(component.selected_label.text, "1 user selected")
+
+
+func test_selected_label_plural_for_two_users() -> void:
+	component._on_user_toggled(true, "u_alice")
+	component._on_user_toggled(true, "u_bob")
+	assert_eq(component.selected_label.text, "2 users selected")
+
+
+# --- bot / self excluded from user list ---
+
+func test_bot_users_not_shown() -> void:
+	Client._user_cache["u_bot"] = {
+		"id": "u_bot",
+		"display_name": "BotUser",
+		"username": "botuser",
+		"bot": true,
+	}
+	component._populate_users()
+	await get_tree().process_frame
+	# Still only 2 (Alice + Bob)
+	assert_eq(component.user_list.get_child_count(), 2)
+
+
+func test_self_not_shown() -> void:
+	# "me_1" is current_user — should be excluded
+	Client._user_cache["me_1"] = {
+		"id": "me_1",
+		"display_name": "Me",
+		"username": "me",
+		"bot": false,
+	}
+	component._populate_users()
+	await get_tree().process_frame
+	assert_eq(component.user_list.get_child_count(), 2)

--- a/tests/unit/test_dm_list.gd
+++ b/tests/unit/test_dm_list.gd
@@ -1,0 +1,138 @@
+extends GutTest
+
+const TestDataFactory := preload("res://tests/helpers/test_data_factory.gd")
+
+var component: PanelContainer
+
+
+func before_each() -> void:
+	Client.current_user = {
+		"id": "test_user_1",
+		"display_name": "TestUser",
+		"username": "testuser",
+		"color": Color.WHITE,
+		"status": 0,
+		"avatar": null,
+	}
+	Client._dm_channel_cache = {}
+	component = load("res://scenes/sidebar/direct/dm_list.tscn").instantiate()
+	add_child(component)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	if is_instance_valid(component):
+		component.queue_free()
+		await get_tree().process_frame
+	Client._dm_channel_cache = {}
+
+
+# --- signal declaration ---
+
+func test_dm_selected_signal_exists() -> void:
+	assert_has_signal(component, "dm_selected")
+
+
+# --- initial tab state ---
+
+func test_initial_mode_shows_friends_list() -> void:
+	assert_true(component.friends_list.visible)
+
+
+func test_initial_mode_hides_dm_panel() -> void:
+	assert_false(component.dm_panel.visible)
+
+
+# --- _set_friends_mode ---
+
+func test_set_friends_mode_false_shows_dm_panel() -> void:
+	component._set_friends_mode(false)
+	assert_true(component.dm_panel.visible)
+
+
+func test_set_friends_mode_false_hides_friends_list() -> void:
+	component._set_friends_mode(false)
+	assert_false(component.friends_list.visible)
+
+
+func test_set_friends_mode_true_restores_friends_list() -> void:
+	component._set_friends_mode(false)
+	component._set_friends_mode(true)
+	assert_true(component.friends_list.visible)
+
+
+func test_set_friends_mode_true_hides_dm_panel() -> void:
+	component._set_friends_mode(false)
+	component._set_friends_mode(true)
+	assert_false(component.dm_panel.visible)
+
+
+# --- _populate_dms ---
+
+func test_populate_dms_creates_items_for_each_channel() -> void:
+	Client._dm_channel_cache = {
+		"dm_1": TestDataFactory.dm_data({"id": "dm_1"}),
+		"dm_2": TestDataFactory.dm_data({"id": "dm_2",
+			"user": {"display_name": "Bob", "username": "bob",
+				"color": Color.WHITE}}),
+	}
+	component._populate_dms()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(component.dm_vbox.get_child_count(), 2)
+
+
+func test_populate_dms_with_empty_cache_clears_vbox() -> void:
+	Client._dm_channel_cache = {
+		"dm_1": TestDataFactory.dm_data({"id": "dm_1"}),
+	}
+	component._populate_dms()
+	await get_tree().process_frame
+	Client._dm_channel_cache = {}
+	component._populate_dms()
+	await get_tree().process_frame
+	assert_eq(component.dm_vbox.get_child_count(), 0)
+
+
+func test_populate_dms_registers_item_nodes() -> void:
+	Client._dm_channel_cache = {
+		"dm_1": TestDataFactory.dm_data({"id": "dm_1"}),
+	}
+	component._populate_dms()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_true(component.dm_item_nodes.has("dm_1"))
+
+
+# --- _set_active_dm ---
+
+func test_set_active_dm_updates_active_id() -> void:
+	Client._dm_channel_cache = {
+		"dm_1": TestDataFactory.dm_data({"id": "dm_1"}),
+	}
+	component._populate_dms()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	component._set_active_dm("dm_1")
+	assert_eq(component.active_dm_id, "dm_1")
+
+
+func test_set_active_dm_deactivates_previous() -> void:
+	Client._dm_channel_cache = {
+		"dm_1": TestDataFactory.dm_data({"id": "dm_1"}),
+		"dm_2": TestDataFactory.dm_data({"id": "dm_2",
+			"user": {"display_name": "Bob", "username": "bob",
+				"color": Color.WHITE}}),
+	}
+	component._populate_dms()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	component._set_active_dm("dm_1")
+	component._set_active_dm("dm_2")
+	assert_eq(component.active_dm_id, "dm_2")
+
+
+func test_set_active_dm_unknown_id_no_crash() -> void:
+	component._set_active_dm("nonexistent")
+	assert_eq(component.active_dm_id, "nonexistent")


### PR DESCRIPTION
## Summary
- Add `test_dm_list.gd` (13 tests): signal declaration, tab-mode toggling, DM list population, and active DM state management
- Add `test_create_group_dm_dialog.gd` (18 tests): UI element existence, initial state, user selection toggle, create-button validation (≥2 required), label text formatting, bot/self exclusion

## Test plan
- [x] Unit tests pass: 13/13 `test_dm_list`, 18/18 `test_create_group_dm_dialog`
- [x] Lint clean (`gdlint scripts/ scenes/` — test files are excluded from lint scope)
- [ ] CI passing