### PR TITLE
Add mobile/touch support to channel column items

### DIFF
--- a/scenes/sidebar/channels/category_item.gd
+++ b/scenes/sidebar/channels/category_item.gd
@@ -21,6 +21,8 @@ var _drop_above: bool = false
 var _drop_hovered: bool = false
 var _drop_channel_hover: bool = false
 var _drop_style: StyleBoxFlat
+var _long_press: LongPressDetector
+var _is_mobile: bool = OS.has_feature("mobile")
 
 @onready var header: Button = $Header
 @onready var chevron: TextureRect = $Header/HBox/Chevron
@@ -54,6 +56,7 @@ func _ready() -> void:
 	add_child(_context_menu)
 
 	header.gui_input.connect(_on_header_gui_input)
+	_long_press = LongPressDetector.new(header, _show_context_menu)
 	header.mouse_entered.connect(_on_header_mouse_entered)
 	header.mouse_exited.connect(_on_header_mouse_exited)
 	AppState.channel_mutes_updated.connect(_on_mutes_updated)
@@ -100,8 +103,8 @@ func setup(data: Dictionary, child_channels: Array) -> void:
 	if space_id != "" and Client.has_permission(space_id, AccordPermission.MANAGE_CHANNELS):
 		_plus_btn = Button.new()
 		_plus_btn.flat = true
-		_plus_btn.visible = false
-		_plus_btn.custom_minimum_size = Vector2(16, 16)
+		_plus_btn.visible = _is_mobile
+		_plus_btn.custom_minimum_size = Vector2(36, 36) if _is_mobile else Vector2(16, 16)
 		_plus_btn.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		_plus_btn.icon = PLUS_ICON
 		_plus_btn.icon_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -148,11 +151,11 @@ func get_channel_items() -> Array:
 	return items
 
 func _on_header_mouse_entered() -> void:
-	if _plus_btn:
+	if _plus_btn and not _is_mobile:
 		_plus_btn.visible = true
 
 func _on_header_mouse_exited() -> void:
-	if _plus_btn:
+	if _plus_btn and not _is_mobile:
 		_plus_btn.visible = false
 
 func _on_header_gui_input(event: InputEvent) -> void:

--- a/scenes/sidebar/channels/channel_item.gd
+++ b/scenes/sidebar/channels/channel_item.gd
@@ -25,6 +25,8 @@ var _drop_hovered: bool = false
 var _has_unread: bool = false
 var _is_active: bool = false
 var _is_rules_channel: bool = false
+var _long_press: LongPressDetector
+var _is_mobile: bool = OS.has_feature("mobile")
 
 @onready var type_icon: TextureRect = $HBox/TypeIcon
 @onready var channel_name: Label = $HBox/ChannelName
@@ -51,6 +53,7 @@ func _ready() -> void:
 	add_child(_context_menu)
 
 	gui_input.connect(_on_gui_input)
+	_long_press = LongPressDetector.new(self, _show_context_menu)
 	mouse_entered.connect(_on_mouse_entered)
 	mouse_exited.connect(_on_mouse_exited)
 	active_bg.visible = false
@@ -71,6 +74,8 @@ func setup(data: Dictionary) -> void:
 	space_id = data.get("space_id", "")
 	_channel_data = data
 	channel_name.text = data.get("name", "")
+	if _is_mobile:
+		custom_minimum_size.y = 44.0
 	tooltip_text = data.get("name", "")
 
 	# Locked channels are visible to admins in imposter mode but not interactive.
@@ -138,8 +143,8 @@ func setup(data: Dictionary) -> void:
 		_gear_btn = Button.new()
 		_gear_btn.text = "\u2699"
 		_gear_btn.flat = true
-		_gear_btn.visible = false
-		_gear_btn.custom_minimum_size = Vector2(20, 20)
+		_gear_btn.visible = _is_mobile
+		_gear_btn.custom_minimum_size = Vector2(36, 36) if _is_mobile else Vector2(20, 20)
 		_gear_btn.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		_gear_btn.mouse_filter = Control.MOUSE_FILTER_PASS
 		ThemeManager.style_label(_gear_btn, 14, "text_muted")
@@ -190,14 +195,14 @@ func _apply_icon_color() -> void:
 		type_icon.modulate = _icon_color_default
 
 func _on_mouse_entered() -> void:
-	if _gear_btn:
+	if _gear_btn and not _is_mobile:
 		_gear_btn.visible = true
 	if not _is_active and not _channel_data.get("nsfw", false) \
 			and not _is_rules_channel:
 		type_icon.modulate = _icon_color_hover
 
 func _on_mouse_exited() -> void:
-	if _gear_btn:
+	if _gear_btn and not _is_mobile:
 		_gear_btn.visible = false
 	_apply_icon_color()
 

--- a/scenes/sidebar/channels/voice_channel_item.gd
+++ b/scenes/sidebar/channels/voice_channel_item.gd
@@ -22,6 +22,8 @@ var _has_unread: bool = false
 var _drop_above: bool = false
 var _drop_hovered: bool = false
 var _participant_avatars: Dictionary = {} # user_id -> Avatar node ref
+var _long_press: LongPressDetector
+var _is_mobile: bool = OS.has_feature("mobile")
 
 @onready var channel_button: Button = $ChannelButton
 @onready var type_icon: TextureRect = $ChannelButton/HBox/TypeIcon
@@ -66,6 +68,7 @@ func _ready() -> void:
 
 	add_to_group("themed")
 	channel_button.gui_input.connect(_on_gui_input)
+	_long_press = LongPressDetector.new(channel_button, _show_context_menu)
 	channel_button.mouse_entered.connect(_on_mouse_entered)
 	channel_button.mouse_exited.connect(_on_mouse_exited)
 	AppState.channel_mutes_updated.connect(_on_mutes_updated)
@@ -99,8 +102,8 @@ func setup(data: Dictionary) -> void:
 	_chat_btn = Button.new()
 	_chat_btn.icon = CHAT_ICON
 	_chat_btn.flat = true
-	_chat_btn.visible = false
-	_chat_btn.custom_minimum_size = Vector2(20, 20)
+	_chat_btn.visible = _is_mobile
+	_chat_btn.custom_minimum_size = Vector2(36, 36) if _is_mobile else Vector2(20, 20)
 	_chat_btn.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	_chat_btn.mouse_filter = Control.MOUSE_FILTER_PASS
 	_chat_btn.add_theme_color_override("icon_normal_color", ThemeManager.get_color("text_muted"))
@@ -114,8 +117,8 @@ func setup(data: Dictionary) -> void:
 		_gear_btn = Button.new()
 		_gear_btn.text = "\u2699"
 		_gear_btn.flat = true
-		_gear_btn.visible = false
-		_gear_btn.custom_minimum_size = Vector2(20, 20)
+		_gear_btn.visible = _is_mobile
+		_gear_btn.custom_minimum_size = Vector2(36, 36) if _is_mobile else Vector2(20, 20)
 		_gear_btn.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		_gear_btn.mouse_filter = Control.MOUSE_FILTER_PASS
 		ThemeManager.style_label(_gear_btn, 14, "text_muted")
@@ -169,7 +172,7 @@ func _refresh_participants() -> void:
 	for vs in voice_users:
 		var user: Dictionary = vs.get("user", {})
 		var row := HBoxContainer.new()
-		row.custom_minimum_size = Vector2(0, 24)
+		row.custom_minimum_size = Vector2(0, 36) if _is_mobile else Vector2(0, 24)
 
 		# Indent spacer
 		var spacer := Control.new()
@@ -287,18 +290,18 @@ func _on_chat_pressed() -> void:
 	AppState.toggle_voice_text(channel_id)
 
 func _on_mouse_entered() -> void:
-	if _chat_btn:
+	if _chat_btn and not _is_mobile:
 		_chat_btn.visible = true
-	if _gear_btn:
+	if _gear_btn and not _is_mobile:
 		_gear_btn.visible = true
 	if AppState.voice_channel_id != channel_id:
 		type_icon.modulate = ThemeManager.get_color("icon_hover")
 	channel_name.add_theme_color_override("font_color", ThemeManager.get_color("text_white"))
 
 func _on_mouse_exited() -> void:
-	if _chat_btn:
+	if _chat_btn and not _is_mobile:
 		_chat_btn.visible = false
-	if _gear_btn:
+	if _gear_btn and not _is_mobile:
 		_gear_btn.visible = false
 	if AppState.voice_channel_id != channel_id:
 		type_icon.modulate = ThemeManager.get_color("icon_default")


### PR DESCRIPTION
- Add long-press context menus via LongPressDetector to channel_item,
  voice_channel_item, and category_item (previously right-click only)
- Show gear, chat, and plus buttons permanently on mobile (hover-based
  show/hide doesn't work on touch devices)
- Increase touch targets on mobile: channel items 44px, participant
  rows 36px, action buttons 36x36 (was 20x20 / 16x16)

https://claude.ai/code/session_015BU4krs38meqzt1Hu8dhae