### PR TITLE
Fix wave emoji rendering as "Ǵ4b" on welcome buttons

### DIFF
--- a/scenes/messages/message_content.gd
+++ b/scenes/messages/message_content.gd
@@ -231,7 +231,7 @@ func _add_wave_button(data: Dictionary) -> void:
 	if ch_id.is_empty() or msg_id.is_empty():
 		return
 	var btn := Button.new()
-	btn.text = "\U0001f44b " + tr("Wave to welcome!")
+	btn.text = "\U01f44b " + tr("Wave to welcome!")
 	btn.custom_minimum_size = Vector2(0, 28)
 	btn.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 	var accent: Color = ThemeManager.get_color("accent")
@@ -251,8 +251,8 @@ func _add_wave_button(data: Dictionary) -> void:
 	btn.add_theme_stylebox_override("hover", hover_sb)
 	btn.add_theme_color_override("font_color", Color.WHITE)
 	btn.pressed.connect(func() -> void:
-		Client.add_reaction(ch_id, msg_id, "\U0001f44b")
-		btn.text = "\U0001f44b " + tr("Waved!")
+		Client.add_reaction(ch_id, msg_id, "\U01f44b")
+		btn.text = "\U01f44b " + tr("Waved!")
 		btn.disabled = true
 	)
 	add_child(btn)


### PR DESCRIPTION
## Summary

Welcome buttons were rendering as `Ǵ4b Wave to welcome!` instead of `👋 Wave to welcome!`.

GDScript's `\U` escape parses **up to 6 hex digits** (max `U+10FFFF`). The literal `\U0001f44b` (8 digits) was being read as `\U0001f4` → `Ǵ` (U+01F4), with the trailing `4b` left as literal text — exactly matching the broken output.

Three occurrences in `scenes/messages/message_content.gd` updated to `\U01f44b`:
- the welcome button label
- the reaction sent on press
- the post-press "Waved!" label

## Test plan
- [ ] Trigger a join event in a server and confirm the welcome button shows `👋 Wave to welcome!`
- [ ] Click the button and confirm a 👋 reaction is added (not `Ǵ4b`)
- [ ] After clicking, confirm the button updates to `👋 Waved!` and is disabled

Fixes #55