### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-05-12
+
+### Added
+- Right-click context menu on channel tabs
+- Copy `https://daccord.gg/open/` share URLs from context menus
+
+### Fixed
+- Spring clean: 5 failing tests, lint issues, refactor, missing signal wiring
+- Restore website rebuild trigger on stable releases (#53)
+
 ## [0.1.17] - 2026-03-26
 
 ### Added

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Daccord"
-config/version="0.1.17"
+config/version="0.1.18"
 run/main_scene="res://scenes/main/main_window.tscn"
 config/features=PackedStringArray("4.5", "GL Compatibility")
 run/low_processor_mode=true


### PR DESCRIPTION
## Summary
- Bump version 0.1.17 → 0.1.18
- Update CHANGELOG with channel tab context menu, share URL copy, and spring-clean fixes

## Test plan
- [x] `project.godot` reflects new version
- [x] `CHANGELOG.md` entry added under [0.1.18]

🤖 Generated with [Claude Code](https://claude.com/claude-code)