### PR TITLE
Add developer Reset Local User Data button (v0.1.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-05-13
+
+### Added
+- Developer settings: "Reset Local User Data" button to wipe local profiles, credentials, and caches for testing fresh-install flows
+
 ## [0.1.18] - 2026-05-12
 
 ### Added

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Daccord"
-config/version="0.1.18"
+config/version="0.1.19"
 run/main_scene="res://scenes/main/main_window.tscn"
 config/features=PackedStringArray("4.5", "GL Compatibility")
 run/low_processor_mode=true

--- a/scenes/user/app_settings_developer_page.gd
+++ b/scenes/user/app_settings_developer_page.gd
@@ -217,7 +217,47 @@ func build() -> VBoxContainer:
 	ThemeManager.style_label(cli_note, 11, "text_muted")
 	vbox.add_child(cli_note)
 
+	vbox.add_child(HSeparator.new())
+
+	# --- Reset Local Data section ---
+	vbox.add_child(_section_label.call(tr("RESET LOCAL DATA")))
+
+	var reset_desc := Label.new()
+	reset_desc.text = tr(
+		"Wipe all profiles, credentials, and cached data on this device, "
+		+ "then quit. The next launch starts as a fresh install. "
+		+ "Your server account is not affected."
+	)
+	reset_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	ThemeManager.style_label(reset_desc, 11, "text_muted")
+	vbox.add_child(reset_desc)
+
+	var reset_btn := SettingsBase.create_danger_button(
+		tr("Reset Local User Data")
+	)
+	reset_btn.pressed.connect(_on_reset_pressed)
+	vbox.add_child(reset_btn)
+
 	return vbox
+
+
+func _on_reset_pressed() -> void:
+	var dlg := ConfirmationDialog.new()
+	dlg.title = tr("Reset Local User Data")
+	dlg.dialog_text = tr(
+		"This will delete every locally stored profile, credential, and "
+		+ "cache, then quit the app. The server account is not affected. "
+		+ "Continue?"
+	)
+	dlg.ok_button_text = tr("Reset and Quit")
+	dlg.confirmed.connect(func() -> void:
+		Config.wipe_all_local_data()
+		dlg.queue_free()
+		_host.get_tree().quit()
+	)
+	dlg.canceled.connect(dlg.queue_free)
+	_host.add_child(dlg)
+	dlg.popup_centered()
 
 
 func _on_test_api_toggled(pressed: bool) -> void:

--- a/scripts/autoload/config.gd
+++ b/scripts/autoload/config.gd
@@ -721,6 +721,26 @@ func set_draft_text(channel_id: String, text: String) -> void:
 func get_draft_text(channel_id: String) -> String:
 	return _config.get_value("drafts", channel_id, "")
 
+## Wipes ALL locally stored client data: every profile directory, the profile
+## registry, and legacy config/emoji files. Intended for developer-mode use
+## (Developer settings → Reset Local User Data) so the next launch behaves as
+## a fresh install. Does not touch the server account.
+func wipe_all_local_data() -> void:
+	_save_pending = false
+	if DirAccess.dir_exists_absolute("user://profiles"):
+		ConfigDirUtils.remove_directory_recursive("user://profiles")
+	var reg_global := ProjectSettings.globalize_path(REGISTRY_PATH)
+	DirAccess.remove_absolute(reg_global)
+	# Legacy locations (pre-profile migration)
+	var legacy_cfg := ProjectSettings.globalize_path("user://config.cfg")
+	DirAccess.remove_absolute(legacy_cfg)
+	if DirAccess.dir_exists_absolute("user://emoji_cache"):
+		ConfigDirUtils.remove_directory_recursive("user://emoji_cache")
+	_config = ConfigFile.new()
+	_registry = ConfigFile.new()
+	_load_ok = false
+
+
 ## Wipes the active profile's local data (config, emoji cache) and removes
 ## it from the registry. Called after a successful account deletion so no
 ## stale credentials remain on disk.


### PR DESCRIPTION
## Summary

- Adds a "Reset Local User Data" danger button under Settings → Developer that wipes every locally stored profile, credential, and cache (`user://profiles`, profile registry, legacy `config.cfg` / `emoji_cache`) and then quits. Next launch starts as a fresh install — the server account is not touched.
- Adds `Config.wipe_all_local_data()` to centralise the wipe and disable pending in-memory saves so nothing flushes back to disk before quit.
- Bumps to **0.1.19**.

## Why

Lets us re-test the Add-a-Server / registration flow without leaving the app to manually purge `user://` data.

## Test plan

- [ ] Open Settings → Developer → scroll to "RESET LOCAL DATA"
- [ ] Click "Reset Local User Data" → confirm "Reset and Quit"
- [ ] Confirm the app quits
- [ ] Relaunch and verify it boots as a fresh install (no profiles, register/join prompt appears)
- [ ] Confirm the server account itself is unaffected (login from a different device still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)