### PR TITLE
ci: skip website rebuild dispatch when GH_PAT is unset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -975,7 +975,7 @@ jobs:
           files: artifacts/*
 
       - name: Trigger website rebuild
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') && env.GH_TOKEN != '' }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |


### PR DESCRIPTION
## Summary
- The v0.1.19 release [failed at the final step](https://github.com/DaccordProject/daccord/actions/runs/25789878788/job/75754259359) because `secrets.GH_PAT` is empty, so `gh api .../dispatches` exited with code 4
- Guard the **Trigger website rebuild** step with `env.GH_TOKEN != ''` so releases complete cleanly when the secret is unset
- Once `GH_PAT` is added (fine-grained PAT with `repo:dispatch` on `DaccordProject/accordwebsite`), the dispatch resumes automatically — no further code change needed

## Test plan
- [ ] Next tagged release succeeds without the dispatch step erroring
- [ ] After adding `GH_PAT`, confirm the dispatch fires and `accordwebsite` rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)