### PR TITLE
Move reset local data feature from developer to profiles settings

### DIFF
--- a/scenes/user/app_settings_developer_page.gd
+++ b/scenes/user/app_settings_developer_page.gd
@@ -217,47 +217,7 @@ func build() -> VBoxContainer:
 	ThemeManager.style_label(cli_note, 11, "text_muted")
 	vbox.add_child(cli_note)
 
-	vbox.add_child(HSeparator.new())
-
-	# --- Reset Local Data section ---
-	vbox.add_child(_section_label.call(tr("RESET LOCAL DATA")))
-
-	var reset_desc := Label.new()
-	reset_desc.text = tr(
-		"Wipe all profiles, credentials, and cached data on this device, "
-		+ "then quit. The next launch starts as a fresh install. "
-		+ "Your server account is not affected."
-	)
-	reset_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	ThemeManager.style_label(reset_desc, 11, "text_muted")
-	vbox.add_child(reset_desc)
-
-	var reset_btn := SettingsBase.create_danger_button(
-		tr("Reset Local User Data")
-	)
-	reset_btn.pressed.connect(_on_reset_pressed)
-	vbox.add_child(reset_btn)
-
 	return vbox
-
-
-func _on_reset_pressed() -> void:
-	var dlg := ConfirmationDialog.new()
-	dlg.title = tr("Reset Local User Data")
-	dlg.dialog_text = tr(
-		"This will delete every locally stored profile, credential, and "
-		+ "cache, then quit the app. The server account is not affected. "
-		+ "Continue?"
-	)
-	dlg.ok_button_text = tr("Reset and Quit")
-	dlg.confirmed.connect(func() -> void:
-		Config.wipe_all_local_data()
-		dlg.queue_free()
-		_host.get_tree().quit()
-	)
-	dlg.canceled.connect(dlg.queue_free)
-	_host.add_child(dlg)
-	dlg.popup_centered()
 
 
 func _on_test_api_toggled(pressed: bool) -> void:

--- a/scenes/user/user_settings_profiles_page.gd
+++ b/scenes/user/user_settings_profiles_page.gd
@@ -44,10 +44,52 @@ func build() -> VBoxContainer:
 	import_btn.pressed.connect(_on_import_profile)
 	btn_row.add_child(import_btn)
 
+	vbox.add_child(HSeparator.new())
+
+	# --- Reset Local Data section ---
+	vbox.add_child(_section_label.call(tr("RESET LOCAL DATA")))
+
+	var reset_desc := Label.new()
+	reset_desc.text = tr(
+		"Log out of every connected server, then wipe all profiles, "
+		+ "credentials, and cached data on this device and quit. The next "
+		+ "launch starts as a fresh install. Your server account is not "
+		+ "affected."
+	)
+	reset_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	ThemeManager.style_label(reset_desc, 11, "text_muted")
+	vbox.add_child(reset_desc)
+
+	var reset_btn := SettingsBase.create_danger_button(
+		tr("Reset Local User Data")
+	)
+	reset_btn.pressed.connect(_on_reset_pressed)
+	vbox.add_child(reset_btn)
+
 	# Close settings on profile switch
 	AppState.profile_switched.connect(_host.queue_free)
 
 	return vbox
+
+
+func _on_reset_pressed() -> void:
+	var dlg := ConfirmationDialog.new()
+	dlg.title = tr("Reset Local User Data")
+	dlg.dialog_text = tr(
+		"This will log out of every connected server, delete every "
+		+ "locally stored profile, credential, and cache, then quit the "
+		+ "app. The server account is not affected. Continue?"
+	)
+	dlg.ok_button_text = tr("Reset and Quit")
+	dlg.confirmed.connect(func() -> void:
+		Client.disconnect_all()
+		Config.wipe_all_local_data()
+		dlg.queue_free()
+		_host.get_tree().quit()
+	)
+	dlg.canceled.connect(dlg.queue_free)
+	_host.add_child(dlg)
+	dlg.popup_centered()
 
 
 func _refresh_profiles_list() -> void:

--- a/scripts/autoload/config.gd
+++ b/scripts/autoload/config.gd
@@ -722,9 +722,10 @@ func get_draft_text(channel_id: String) -> String:
 	return _config.get_value("drafts", channel_id, "")
 
 ## Wipes ALL locally stored client data: every profile directory, the profile
-## registry, and legacy config/emoji files. Intended for developer-mode use
-## (Developer settings → Reset Local User Data) so the next launch behaves as
-## a fresh install. Does not touch the server account.
+## registry, and legacy config/emoji files. Invoked from Profiles settings
+## (Reset Local User Data) so the next launch behaves as a fresh install.
+## Callers should log out of connected servers via Client.disconnect_all()
+## first; this does not touch the server account.
 func wipe_all_local_data() -> void:
 	_save_pending = false
 	if DirAccess.dir_exists_absolute("user://profiles"):


### PR DESCRIPTION
## Summary
Relocates the "Reset Local User Data" feature from the Developer settings page to the Profiles settings page, making it more discoverable for regular users. Updates the reset flow to disconnect from all servers before wiping local data.

## Changes
- **user_settings_profiles_page.gd**: Added "Reset Local Data" section with description and button; implemented `_on_reset_pressed()` handler that shows confirmation dialog and calls `Client.disconnect_all()` before wiping data
- **app_settings_developer_page.gd**: Removed the "Reset Local Data" section and `_on_reset_pressed()` handler (40 lines deleted)
- **config.gd**: Updated `wipe_all_local_data()` docstring to reflect new location (Profiles settings) and clarify that callers should invoke `Client.disconnect_all()` first

## Implementation Details
- Reset button uses `SettingsBase.create_danger_button()` for visual prominence
- Confirmation dialog explicitly warns users about server logout and data deletion
- Flow: User confirms → `Client.disconnect_all()` → `Config.wipe_all_local_data()` → app quits
- Description text updated to mention server disconnection as part of the reset process

https://claude.ai/code/session_01NXtPSiMeK2ZadxQEVVFAPU