### PR TITLE
ci: harden apt-get installs against transient mirror failures

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Robust apt-get install for CI runners.
+#
+# The bare `sudo apt-get update && sudo apt-get install` pattern fails
+# regularly in CI because:
+#   1. Ubuntu mirrors occasionally return slow or partial responses, and
+#      apt's default of zero retries surfaces those as hard failures.
+#   2. With `-qq`, apt produces no output, so a hang looks identical to
+#      a slow download until the step's timeout fires.
+#   3. Wine + i386 pulls a few hundred MB of packages on a cold runner,
+#      which is enough to outrun a 10-minute step timeout if a single
+#      mirror is degraded.
+#
+# This wrapper:
+#   - Configures apt to retry transport errors (Acquire::Retries) and
+#     to time out hung connections quickly so retries actually trigger.
+#   - Retries the whole `update + install` cycle up to 3 times with
+#     exponential backoff between attempts.
+#   - Drops `-qq` so failures leave a useful tail in the log.
+#
+# Usage:  apt-install.sh <pkg> [pkg ...]
+# Env:    APT_INSTALL_EXTRA_FLAGS (e.g. "--no-install-recommends")
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "::error::apt-install.sh requires at least one package name"
+  exit 2
+fi
+
+EXTRA_FLAGS="${APT_INSTALL_EXTRA_FLAGS:-}"
+
+# Apt config: retry network ops, fail fast on stuck mirrors so retries kick in.
+sudo tee /etc/apt/apt.conf.d/99-ci-robust >/dev/null <<'EOF'
+Acquire::Retries "5";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+Acquire::http::No-Cache "true";
+APT::Get::Assume-Yes "true";
+EOF
+
+export DEBIAN_FRONTEND=noninteractive
+
+attempt=1
+max_attempts=3
+delay=15
+while :; do
+  echo "::group::apt install (attempt ${attempt}/${max_attempts}): $*"
+  if sudo -E apt-get update && \
+     sudo -E apt-get install -y ${EXTRA_FLAGS} "$@"; then
+    echo "::endgroup::"
+    echo "apt install succeeded on attempt ${attempt}"
+    exit 0
+  fi
+  echo "::endgroup::"
+
+  if [ "${attempt}" -ge "${max_attempts}" ]; then
+    echo "::error::apt install failed after ${max_attempts} attempts"
+    exit 1
+  fi
+
+  echo "apt install attempt ${attempt} failed; recovering and retrying in ${delay}s"
+  # Recover potentially-broken dpkg/apt state between attempts.
+  sudo dpkg --configure -a || true
+  sudo apt-get -f install -y || true
+  sleep "${delay}"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,7 @@ jobs:
           lfs: true
 
       - name: Install audio libraries
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
+        run: .github/scripts/apt-install.sh libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
 
       - name: Install godot-livekit addon (latest release)
         run: |
@@ -178,9 +176,7 @@ jobs:
           path: .accordserver_repo
 
       - name: Install audio libraries
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
+        run: .github/scripts/apt-install.sh libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
 
       - name: Install godot-livekit addon (latest release)
         run: |
@@ -409,9 +405,7 @@ jobs:
           lfs: true
 
       - name: Install system libraries
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev libpipewire-0.3-dev
+        run: .github/scripts/apt-install.sh libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
 
       - name: Install godot-livekit addon (latest release)
         run: |
@@ -578,8 +572,7 @@ jobs:
 
       - name: Install system libraries
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
+          .github/scripts/apt-install.sh \
             libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev \
             chromium-browser python3
 
@@ -776,13 +769,12 @@ jobs:
           lfs: true
 
       - name: Install system libraries and Wine
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
-          DEBIAN_FRONTEND: noninteractive
+          APT_INSTALL_EXTRA_FLAGS: "--no-install-recommends"
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
+          .github/scripts/apt-install.sh \
             libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev \
             wine64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,7 @@ jobs:
 
       - name: Install audio libraries (Linux)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
+        run: .github/scripts/apt-install.sh libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
 
       - name: Set up Java JDK (Android)
         if: matrix.platform == 'android'
@@ -637,7 +635,7 @@ jobs:
           WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
         run: |
-          sudo apt-get install -y osslsigncode
+          .github/scripts/apt-install.sh osslsigncode
           echo "$WINDOWS_CERT_BASE64" | base64 -d > cert.pfx
           # Re-extract, sign, re-package
           mkdir -p signed_windows


### PR DESCRIPTION
The Windows Export & Smoke Test job has been failing intermittently on
"Install system libraries and Wine" — apt-get hangs (mirror or i386
dependency resolution) and the 10-minute step timeout fires before the
install can complete. The bare `apt-get update && apt-get install -qq`
pattern has no retries and `-qq` hides any progress, so transient
network issues become hard failures with no diagnostic output.

Introduces `.github/scripts/apt-install.sh`, a wrapper that:
  - Configures apt with Acquire::Retries=5 and short connection
    timeouts so apt fails fast on stuck mirrors and retries internally.
  - Retries the full `update + install` cycle up to 3 times with
    exponential backoff, recovering dpkg/apt state between attempts.
  - Drops `-qq` so a hang leaves a useful tail in the log.

Routes every apt-get install in ci.yml and release.yml through the
wrapper, and bumps the Wine step's timeout from 10 to 15 minutes to
absorb the slowest healthy cold-cache install.