### PR TITLE
Remove preview button from server browser

### DIFF
--- a/scenes/discovery/discovery_detail.gd
+++ b/scenes/discovery/discovery_detail.gd
@@ -2,10 +2,8 @@ extends VBoxContainer
 
 signal back_pressed()
 signal join_pressed(server_url: String, space_id: String, space_slug: String)
-signal preview_pressed(server_url: String, space_id: String)
 
 var _data: Dictionary = {}
-var _preview_button: Button
 
 @onready var _back_button: Button = $Header/BackButton
 @onready var _banner: TextureRect = $BannerContainer/Banner
@@ -24,7 +22,6 @@ func _ready() -> void:
 	add_to_group("themed")
 	_back_button.pressed.connect(func(): back_pressed.emit())
 	_join_button.pressed.connect(_on_join_pressed)
-	_create_preview_button()
 	_apply_style()
 
 func _apply_theme() -> void:
@@ -66,13 +63,6 @@ func setup(data: Dictionary, joined: bool = false) -> void:
 
 	_ping_label.text = tr("Measuring...")
 	_ping_label.add_theme_color_override("font_color", ThemeManager.get_color("text_muted"))
-
-	# Disable preview if guest access is not allowed
-	if not data.get("allow_guest_access", true):
-		_preview_button.disabled = true
-		_preview_button.tooltip_text = tr(
-			"Guest preview is disabled for this space"
-		)
 
 	# Load banner
 	var banner_url: String = data.get("banner_url", "")
@@ -138,28 +128,6 @@ func _apply_style() -> void:
 	# Back button
 	_back_button.add_theme_color_override("font_color", ThemeManager.get_color("text_muted"))
 	_back_button.add_theme_color_override("font_hover_color", ThemeManager.get_color("text_body"))
-
-func _create_preview_button() -> void:
-	_preview_button = Button.new()
-	_preview_button.text = tr("Preview")
-	_preview_button.pressed.connect(_on_preview_pressed)
-	# Insert just before the join button
-	_join_button.get_parent().add_child(_preview_button)
-	_join_button.get_parent().move_child(
-		_preview_button,
-		_join_button.get_index()
-	)
-
-func _on_preview_pressed() -> void:
-	var server_url: String = _data.get("server_url", "")
-	var space_id: String = _data.get("space_id", _data.get("id", ""))
-	if server_url.is_empty() or space_id.is_empty():
-		_status_label.text = tr("Missing server information")
-		_status_label.visible = true
-		return
-	_preview_button.disabled = true
-	_preview_button.text = tr("Loading...")
-	preview_pressed.emit(server_url, space_id)
 
 func _on_join_pressed() -> void:
 	var server_url: String = _data.get("server_url", "")

--- a/scenes/discovery/discovery_panel.gd
+++ b/scenes/discovery/discovery_panel.gd
@@ -312,7 +312,6 @@ func _on_card_clicked(space_data: Dictionary) -> void:
 	_detail_view.setup(space_data, _is_space_joined(space_data))
 	_detail_view.back_pressed.connect(_on_detail_back)
 	_detail_view.join_pressed.connect(_on_detail_join_with_slug)
-	_detail_view.preview_pressed.connect(_on_detail_preview)
 
 	# Apply cached ping to detail view
 	var server_url: String = space_data.get("server_url", "")
@@ -402,49 +401,6 @@ func _join_and_connect(
 	AppState.close_discovery()
 	if not joined_space_id.is_empty():
 		AppState.select_space(joined_space_id)
-
-func _on_detail_preview(server_url: String, space_id: String) -> void:
-	# Connect as guest to preview the space without creating an account
-	var api_url := server_url + AccordConfig.API_BASE_PATH
-	var rest := AccordRest.new(api_url)
-	add_child(rest)
-	var auth := AuthApi.new(rest)
-	var result: RestResult = await auth.guest()
-	rest.queue_free()
-
-	if not is_instance_valid(self):
-		return
-
-	if not result.ok:
-		var msg: String = (
-			result.error.message if result.error else "Preview not available"
-		)
-		if _detail_view and is_instance_valid(_detail_view):
-			_detail_view.show_error(msg)
-		return
-
-	var token: String = result.data.get("token", "")
-	var expires_at: String = result.data.get("expires_at", "")
-	if token.is_empty():
-		if _detail_view and is_instance_valid(_detail_view):
-			_detail_view.show_error("Failed to get guest token")
-		return
-
-	# Close discovery and connect as guest
-	AppState.close_discovery()
-	var connect_result: Dictionary = await Client.connect_guest(
-		server_url, token, space_id, expires_at
-	)
-
-	if not is_instance_valid(self):
-		return
-
-	if connect_result.has("error"):
-		push_warning("[Discovery] Guest preview failed: ", connect_result["error"])
-		return
-
-	if not connect_result.get("space_id", "").is_empty():
-		AppState.select_space(connect_result["space_id"])
 
 func _on_close() -> void:
 	if not _embedded:


### PR DESCRIPTION
Drops the guest-preview affordance from the discovery detail view since
guest preview is not a workflow we want to surface here. Join remains
the only action on a discovered space.