### PR TITLE
Hide typing indicator for own user across all servers

### DIFF
--- a/scripts/client/client_gateway.gd
+++ b/scripts/client/client_gateway.gd
@@ -521,10 +521,20 @@ func on_message_delete_bulk(data: Dictionary) -> void:
 		i -= 1
 	AppState.messages_updated.emit(channel_id)
 
+func _is_own_user_id(user_id: String) -> bool:
+	if user_id.is_empty():
+		return false
+	if user_id == _c.current_user.get("id", ""):
+		return true
+	for conn in _c._connections:
+		if conn != null and conn.get("user_id", "") == user_id:
+			return true
+	return false
+
 func on_typing_start(data: Dictionary) -> void:
 	var user_id: String = data.get("user_id", "")
 	var channel_id: String = data.get("channel_id", "")
-	if user_id == _c.current_user.get("id", ""):
+	if _is_own_user_id(user_id):
 		return
 	var user_dict: Dictionary = _c.get_user_by_id(user_id)
 	var username: String = user_dict.get("display_name", "Someone")


### PR DESCRIPTION
## Summary

- `on_typing_start` in `scripts/client/client_gateway.gd` already filtered out the user's own `typing.start` echoes, but only against `Client.current_user.id` — which is set from the first connected server.
- In multi-server setups (or any state where a connection's `user_id` wasn't the primary `current_user`), your own typing was getting through and showing the "X is typing…" bubble.
- Extracted the check into `_is_own_user_id()` which also iterates `_c._connections` and matches any connection's `user_id`.

## Test plan

- [ ] Type in a channel on your primary server — no self typing indicator
- [ ] Type in a channel on a secondary (second-added) server — no self typing indicator
- [ ] Type in a DM — no self typing indicator
- [ ] Have another user type in a channel — their indicator still appears
- [ ] Existing unit tests in `tests/unit/test_client_gateway.gd` (`test_on_typing_start_emits_signal`, `test_on_typing_start_skips_own_user`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)