### PR TITLE
Add @-mention autocomplete to message composer

### DIFF
--- a/scenes/messages/composer/composer.gd
+++ b/scenes/messages/composer/composer.gd
@@ -1,6 +1,7 @@
 extends PanelContainer
 
 const EmojiPickerScene := preload("res://scenes/messages/composer/emoji_picker.tscn")
+const MentionPopupScene := preload("res://scenes/messages/composer/mention_popup.tscn")
 const MAX_FILE_SIZE := 25 * 1024 * 1024 # 25 MB
 const MAX_ATTACHMENT_COUNT := 10
 const LARGE_TEXT_THRESHOLD := 4096 # 4 KB — offer to convert to .txt
@@ -12,6 +13,9 @@ var _emoji_picker: PanelContainer = null
 var _saved_placeholder: String = ""
 var _pending_files: Array = [] # Array of {filename, content, content_type, size}
 var _file_dialog: FileDialog = null
+var _mention_popup: PanelContainer = null
+var _mention_line: int = -1
+var _mention_start_col: int = -1
 
 @onready var upload_button: Button = $VBox/HBox/UploadButton
 @onready var text_input: TextEdit = $VBox/HBox/TextInput
@@ -29,6 +33,7 @@ func _ready() -> void:
 	emoji_button.pressed.connect(_on_emoji_button)
 	text_input.gui_input.connect(_on_text_input)
 	text_input.text_changed.connect(_on_text_changed)
+	text_input.caret_changed.connect(_on_caret_changed)
 	cancel_reply_button.pressed.connect(_on_cancel_reply)
 	AppState.reply_initiated.connect(_on_reply_initiated)
 	AppState.reply_cancelled.connect(_on_reply_cancelled)
@@ -101,6 +106,25 @@ func _on_text_input(event: InputEvent) -> void:
 			GuestPrompt.show_if_guest()
 		return
 	if event is InputEventKey and event.pressed:
+		# Mention popup keyboard nav takes priority.
+		if _is_mention_popup_visible():
+			match event.keycode:
+				KEY_DOWN:
+					_mention_popup.move_selection(1)
+					get_viewport().set_input_as_handled()
+					return
+				KEY_UP:
+					_mention_popup.move_selection(-1)
+					get_viewport().set_input_as_handled()
+					return
+				KEY_ENTER, KEY_KP_ENTER, KEY_TAB:
+					if _mention_popup.pick_selected():
+						get_viewport().set_input_as_handled()
+						return
+				KEY_ESCAPE:
+					_hide_mention_popup()
+					get_viewport().set_input_as_handled()
+					return
 		if event.keycode in [KEY_ENTER, KEY_KP_ENTER] and not event.shift_pressed:
 			_on_send()
 			get_viewport().set_input_as_handled()
@@ -137,6 +161,10 @@ func _on_text_changed() -> void:
 		Client.send_typing(AppState.current_channel_id)
 	# Warn if typing @everyone without permission
 	_check_everyone_permission()
+	_update_mention_state()
+
+func _on_caret_changed() -> void:
+	_update_mention_state()
 
 func _check_everyone_permission() -> void:
 	var text := text_input.text
@@ -540,6 +568,160 @@ func _on_channel_selected_restore_draft(channel_id: String) -> void:
 		text_input.set_caret_column(draft.length())
 		Config.set_draft_text(channel_id, "")
 
+# --- Mention autocomplete ---
+
+func _is_mention_popup_visible() -> bool:
+	return _mention_popup != null \
+			and is_instance_valid(_mention_popup) \
+			and _mention_popup.visible
+
+func _update_mention_state() -> void:
+	var line: int = text_input.get_caret_line()
+	var col: int = text_input.get_caret_column()
+	var line_text: String = text_input.get_line(line)
+	var trigger: int = _find_mention_trigger(line_text, col)
+	if trigger == -1:
+		_hide_mention_popup()
+		return
+	var prefix: String = line_text.substr(trigger + 1, col - trigger - 1)
+	_mention_line = line
+	_mention_start_col = trigger
+	if _is_mention_popup_visible():
+		if not _mention_popup.filter(prefix):
+			_hide_mention_popup()
+	else:
+		_show_mention_popup(prefix)
+
+## Returns the column index of the active "@" trigger on [param line_text]
+## relative to caret [param col], or -1 if no active mention is being typed.
+## A trigger is valid when:
+##   - "@" is immediately preceded by start-of-line or a non-word char.
+##   - the run between "@" and the caret contains no whitespace.
+func _find_mention_trigger(line_text: String, col: int) -> int:
+	var i: int = col - 1
+	while i >= 0:
+		var ch: String = line_text.substr(i, 1)
+		if ch == "@":
+			if i == 0:
+				return i
+			var prev: String = line_text.substr(i - 1, 1)
+			if _is_word_char(prev):
+				return -1
+			return i
+		if ch == " " or ch == "\t":
+			return -1
+		i -= 1
+	return -1
+
+static func _is_word_char(ch: String) -> bool:
+	if ch.is_empty():
+		return false
+	var c: int = ch.unicode_at(0)
+	# Letters, digits, underscore.
+	if c >= 0x30 and c <= 0x39:
+		return true
+	if c >= 0x41 and c <= 0x5A:
+		return true
+	if c >= 0x61 and c <= 0x7A:
+		return true
+	if c == 0x5F:
+		return true
+	# Treat any non-ASCII letter-like codepoint as a word char.
+	return c > 0x7F
+
+func _show_mention_popup(prefix: String) -> void:
+	var members: Array = _get_mention_candidates()
+	if members.is_empty():
+		return
+	if _mention_popup == null or not is_instance_valid(_mention_popup):
+		_mention_popup = MentionPopupScene.instantiate()
+		get_tree().root.add_child(_mention_popup)
+		_mention_popup.member_picked.connect(_on_mention_picked)
+		_mention_popup.dismissed.connect(_hide_mention_popup)
+	_mention_popup.setup(members, prefix)
+	if not _mention_popup.has_results():
+		_hide_mention_popup()
+		return
+	_position_mention_popup()
+	_mention_popup.visible = true
+
+func _hide_mention_popup() -> void:
+	_mention_line = -1
+	_mention_start_col = -1
+	if _mention_popup and is_instance_valid(_mention_popup):
+		_mention_popup.visible = false
+
+func _position_mention_popup() -> void:
+	if not _mention_popup:
+		return
+	var input_rect := text_input.get_global_rect()
+	var size := _mention_popup.size
+	# Use the panel's minimum size on first frame before layout has settled.
+	if size.x <= 0 or size.y <= 0:
+		size = _mention_popup.custom_minimum_size
+		if size.y <= 0:
+			size.y = 200
+	var vp_size := get_viewport().get_visible_rect().size
+	# Anchor above the text input, left-aligned with it.
+	var x: float = input_rect.position.x
+	var y: float = input_rect.position.y - size.y - 4
+	if y < 4:
+		# Not enough room above — fall back to below the input.
+		y = input_rect.position.y + input_rect.size.y + 4
+	x = clampf(x, 4, vp_size.x - size.x - 4)
+	y = clampf(y, 4, vp_size.y - size.y - 4)
+	_mention_popup.position = Vector2(x, y)
+
+func _get_mention_candidates() -> Array:
+	var my_id: String = Client.current_user.get("id", "")
+	var out: Array = []
+	if AppState.is_dm_mode:
+		var ch_id: String = AppState.current_channel_id
+		for dm in Client.dm_channels:
+			if dm.get("id", "") != ch_id:
+				continue
+			for r in dm.get("recipients", []):
+				if r is Dictionary and r.get("id", "") != my_id:
+					out.append(r)
+			break
+		return out
+	var space_id: String = AppState.current_space_id
+	if space_id.is_empty():
+		return out
+	for m in Client.get_members_for_space(space_id):
+		if m is Dictionary and m.get("id", "") != my_id:
+			out.append(m)
+	return out
+
+func _on_mention_picked(member: Dictionary) -> void:
+	if _mention_line < 0 or _mention_start_col < 0:
+		_hide_mention_popup()
+		return
+	var line: int = _mention_line
+	var start: int = _mention_start_col
+	var caret_col: int = text_input.get_caret_column()
+	var line_text: String = text_input.get_line(line)
+	if start >= line_text.length() or line_text.substr(start, 1) != "@":
+		_hide_mention_popup()
+		return
+	# Prefer username for the wire format; fall back to display_name.
+	var handle: String = str(member.get("username", ""))
+	if handle.is_empty():
+		handle = str(member.get("display_name", ""))
+	if handle.is_empty():
+		_hide_mention_popup()
+		return
+	var insert: String = "@%s " % handle
+	var before: String = line_text.substr(0, start)
+	var after: String = line_text.substr(caret_col)
+	text_input.set_line(line, before + insert + after)
+	text_input.set_caret_line(line)
+	text_input.set_caret_column(start + insert.length())
+	_hide_mention_popup()
+	text_input.grab_focus()
+
 func _exit_tree() -> void:
 	if _emoji_picker and is_instance_valid(_emoji_picker):
 		_emoji_picker.queue_free()
+	if _mention_popup and is_instance_valid(_mention_popup):
+		_mention_popup.queue_free()

--- a/scenes/messages/composer/mention_popup.gd
+++ b/scenes/messages/composer/mention_popup.gd
@@ -1,0 +1,196 @@
+extends PanelContainer
+
+signal member_picked(member: Dictionary)
+signal dismissed
+
+const MAX_VISIBLE: int = 8
+const ROW_HEIGHT: int = 32
+
+var _candidates: Array = []
+var _filtered: Array = []
+var _selected_index: int = 0
+var _row_buttons: Array[Button] = []
+
+@onready var header_label: Label = $VBox/Header
+@onready var rows: VBoxContainer = $VBox/Rows
+
+func _ready() -> void:
+	add_to_group("themed")
+	_apply_theme()
+
+func _apply_theme() -> void:
+	var style: StyleBox = get_theme_stylebox("panel")
+	if style is StyleBoxFlat:
+		style.bg_color = ThemeManager.get_color("modal_bg")
+	header_label.add_theme_color_override(
+		"font_color", ThemeManager.get_color("text_muted")
+	)
+
+## Populate with the list of selectable members.
+## [param members] is an Array of user-shaped Dictionaries (id, display_name,
+## username, color, avatar).
+func setup(members: Array, prefix: String) -> void:
+	_candidates = members
+	_filter(prefix)
+
+## Re-filter the candidate list against [param prefix]. Returns whether any
+## results remain after filtering.
+func filter(prefix: String) -> bool:
+	_filter(prefix)
+	return not _filtered.is_empty()
+
+func _filter(prefix: String) -> void:
+	var lower: String = prefix.strip_edges().to_lower()
+	_filtered.clear()
+	for member in _candidates:
+		if not (member is Dictionary):
+			continue
+		if lower.is_empty():
+			_filtered.append(member)
+			continue
+		var dn: String = str(member.get("display_name", "")).to_lower()
+		var un: String = str(member.get("username", "")).to_lower()
+		if dn.begins_with(lower) or un.begins_with(lower):
+			_filtered.append(member)
+	# Stable sort: display_name starts-with first, then username starts-with.
+	_filtered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		var an: String = str(a.get("display_name", "")).to_lower()
+		var bn: String = str(b.get("display_name", "")).to_lower()
+		if lower.is_empty():
+			return an < bn
+		var a_dn_match: bool = an.begins_with(lower)
+		var b_dn_match: bool = bn.begins_with(lower)
+		if a_dn_match != b_dn_match:
+			return a_dn_match
+		return an < bn
+	)
+	if _filtered.size() > MAX_VISIBLE:
+		_filtered.resize(MAX_VISIBLE)
+	_selected_index = 0
+	_rebuild_rows()
+
+func _rebuild_rows() -> void:
+	NodeUtils.free_children(rows)
+	_row_buttons.clear()
+	for i in _filtered.size():
+		var member: Dictionary = _filtered[i]
+		var btn := _make_row(member, i)
+		rows.add_child(btn)
+		_row_buttons.append(btn)
+	_update_selection_highlight()
+
+func _make_row(member: Dictionary, index: int) -> Button:
+	var btn := Button.new()
+	btn.flat = true
+	btn.focus_mode = Control.FOCUS_NONE
+	btn.custom_minimum_size = Vector2(0, ROW_HEIGHT)
+	btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+	btn.clip_text = true
+
+	var hbox := HBoxContainer.new()
+	hbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	hbox.add_theme_constant_override("separation", 8)
+	hbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	hbox.offset_left = 8
+	hbox.offset_right = -8
+	btn.add_child(hbox)
+
+	var swatch := ColorRect.new()
+	swatch.custom_minimum_size = Vector2(20, 20)
+	swatch.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	var col: Color = member.get("color", ThemeManager.get_color("accent"))
+	swatch.color = col
+	hbox.add_child(swatch)
+
+	var letter := Label.new()
+	var dn_full: String = str(member.get("display_name", "?"))
+	letter.text = dn_full.substr(0, 1).to_upper() if not dn_full.is_empty() else "?"
+	letter.add_theme_font_size_override("font_size", 11)
+	letter.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	letter.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	letter.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	letter.set_anchors_preset(Control.PRESET_FULL_RECT)
+	# Pick legible text color over the swatch.
+	var luminance: float = 0.299 * col.r + 0.587 * col.g + 0.114 * col.b
+	letter.add_theme_color_override(
+		"font_color", Color.BLACK if luminance > 0.5 else Color.WHITE
+	)
+	swatch.add_child(letter)
+
+	var name_label := Label.new()
+	name_label.text = dn_full
+	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	name_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	hbox.add_child(name_label)
+
+	var un_str: String = str(member.get("username", ""))
+	if not un_str.is_empty() and un_str.to_lower() != dn_full.to_lower():
+		var un_label := Label.new()
+		un_label.text = "@" + un_str
+		un_label.add_theme_font_size_override("font_size", 11)
+		un_label.add_theme_color_override(
+			"font_color", ThemeManager.get_color("text_muted")
+		)
+		un_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		hbox.add_child(un_label)
+
+	btn.pressed.connect(func() -> void:
+		_pick_index(index)
+	)
+	btn.mouse_entered.connect(func() -> void:
+		_set_selected(index, false)
+	)
+	return btn
+
+func _update_selection_highlight() -> void:
+	var hover_color: Color = ThemeManager.get_color("button_hover")
+	for i in _row_buttons.size():
+		var btn := _row_buttons[i]
+		if i == _selected_index:
+			var sb := StyleBoxFlat.new()
+			sb.bg_color = hover_color
+			sb.corner_radius_top_left = 4
+			sb.corner_radius_top_right = 4
+			sb.corner_radius_bottom_left = 4
+			sb.corner_radius_bottom_right = 4
+			btn.add_theme_stylebox_override("normal", sb)
+		else:
+			btn.remove_theme_stylebox_override("normal")
+
+func _set_selected(index: int, _scroll: bool = true) -> void:
+	if index < 0 or index >= _row_buttons.size():
+		return
+	_selected_index = index
+	_update_selection_highlight()
+
+## Move the highlighted row by [param delta] (typically -1 or +1).
+func move_selection(delta: int) -> void:
+	if _row_buttons.is_empty():
+		return
+	var count: int = _row_buttons.size()
+	_selected_index = (_selected_index + delta + count) % count
+	_update_selection_highlight()
+
+## Pick the currently highlighted row. Returns true if a pick was emitted.
+func pick_selected() -> bool:
+	if _selected_index < 0 or _selected_index >= _filtered.size():
+		return false
+	_pick_index(_selected_index)
+	return true
+
+func _pick_index(index: int) -> void:
+	if index < 0 or index >= _filtered.size():
+		return
+	member_picked.emit(_filtered[index])
+
+## Whether the popup currently has any visible results.
+func has_results() -> bool:
+	return not _filtered.is_empty()
+
+func _input(event: InputEvent) -> void:
+	if not visible:
+		return
+	if event is InputEventMouseButton and event.pressed:
+		var global_rect := get_global_rect()
+		if not global_rect.has_point(event.global_position):
+			dismissed.emit()

--- a/scenes/messages/composer/mention_popup.tscn
+++ b/scenes/messages/composer/mention_popup.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scenes/messages/composer/mention_popup.gd" id="1"]
+
+[sub_resource type="StyleBoxFlat" id="popup_bg"]
+bg_color = Color(0.184, 0.192, 0.212, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+
+[node name="MentionPopup" type="PanelContainer"]
+visible = false
+custom_minimum_size = Vector2(260, 0)
+theme_override_styles/panel = SubResource("popup_bg")
+script = ExtResource("1")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="Header" type="Label" parent="VBox"]
+layout_mode = 2
+text = "MEMBERS"
+theme_override_font_sizes/font_size = 10
+metadata/theme_font_color = "text_muted"
+
+[node name="Rows" type="VBoxContainer" parent="VBox"]
+layout_mode = 2
+theme_override_constants/separation = 0


### PR DESCRIPTION
## Summary

- Typing \`@\` in the message composer now opens a small autocomplete popup of channel members, anchored above the text input.
- Members are sourced from the space's member cache for guild channels and from the DM channel's recipients for DMs; the current user is filtered out.
- Filtering matches \`display_name\` and \`username\` (prefix match), with \`display_name\` matches ranked first. Capped to 8 visible rows.
- Picking a row (click, Enter, or Tab) replaces the active \`@<prefix>\` run with \`@<username> \` and re-focuses the input.

## Behavior

- Trigger detection walks backwards from the caret to find an \`@\` preceded by start-of-line or a non-word character; whitespace inside the run cancels it (so \`hello@john\` won't open the popup, but \`hello @john\` will).
- While the popup is open, the text input's key handler intercepts:
  - ↑ / ↓ — move highlight
  - Enter / Tab — pick the highlighted row
  - Escape — dismiss
  Enter no longer sends the message while the popup is visible.
- Clicking outside the popup, moving the caret out of the run, or typing whitespace dismisses it.
- Popup positions above the text input, falling back below if there isn't room above; clamped to the viewport.

## Files

- \`scenes/messages/composer/mention_popup.tscn\` / \`mention_popup.gd\` — new popup scene with avatar swatch, display name, and dim \`@username\`.
- \`scenes/messages/composer/composer.gd\` — trigger detection, popup lifecycle, keyboard interception, and insertion logic.

## Notes for reviewer

- Server-side mention parsing isn't implemented yet (the \`mentions\` column is stored but never populated from text), so this is currently a typing aid. The existing visual mention highlight in \`cozy_message.gd\` keys off \`data.mentions\`, so it won't light up from autocompleted text until the server side lands. Wire format chosen is \`@<username>\` since usernames are unique and immutable.
- \`gdlint\` passes on the whole tree. GUT suite was not run — \`addons/gut/\` is gitignored and not installed in this worktree.

## Test plan

- [ ] Type \`@\` in a guild channel composer — popup shows channel members.
- [ ] Type \`@a\` — list filters to names starting with \"a\".
- [ ] Use ↑/↓ to move highlight, Enter to insert; verify text becomes \`@<username> \` with caret after the space.
- [ ] Tab also inserts; Escape dismisses without inserting.
- [ ] Type \`@\` inside a DM — popup shows the other recipient(s) only.
- [ ] Type \`@\` inside a group DM — popup shows all recipients except yourself.
- [ ] Type \`hello@bob\` (no leading space) — popup does NOT open.
- [ ] Type \`@foo bar\` — popup dismisses when space is typed.
- [ ] With popup open, Enter inserts the mention instead of sending the message.
- [ ] Click elsewhere in the input — popup dismisses; retyping \`@\` reopens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)