### PR TITLE
Handle missing audio input device on voice join

### DIFF
--- a/scripts/voice/livekit_adapter.gd
+++ b/scripts/voice/livekit_adapter.gd
@@ -121,6 +121,12 @@ func set_muted(muted: bool) -> void:
 			_local_audio_track.mute()
 		else:
 			_local_audio_track.unmute()
+	elif not muted and _state == VOICE_STATE.CONNECTED:
+		# Joined listen-only because no input device was available;
+		# remind the user why unmuting has no effect.
+		AppState.voice_error.emit(
+			tr("No microphone detected — joined as listen-only")
+		)
 
 func set_deafened(deafened: bool) -> void:
 	_deafened = deafened
@@ -470,8 +476,22 @@ func _on_data_received(
 
 # --- Local audio publishing ---
 
+func _has_audio_input() -> bool:
+	# Touching AudioStreamMicrophone with no capture device crashes the
+	# audio thread on PulseAudio/PipeWire. Pre-check the device list.
+	var devices: PackedStringArray = AudioServer.get_input_device_list()
+	return not devices.is_empty()
+
 func _publish_local_audio() -> void:
 	if _room == null:
+		return
+	if not _has_audio_input():
+		push_warning(
+			"[LiveKitAdapter] No audio input device — joining as listen-only"
+		)
+		AppState.voice_error.emit(
+			tr("No microphone detected — joined as listen-only")
+		)
 		return
 	var mix_rate: int = int(AudioServer.get_mix_rate())
 	_local_audio_source = LiveKitAudioSource.create(mix_rate, 1, 200)


### PR DESCRIPTION
## Summary

- Joining a voice channel on a system with no audio input device was silently crashing the app — Godot's `AudioStreamMicrophone` hits an unrecoverable state on PulseAudio/PipeWire when `audio/driver/enable_input=true` and no capture device exists.
- Pre-check `AudioServer.get_input_device_list()` in `LiveKitAdapter._publish_local_audio()`. When empty, skip mic source/track creation and emit `AppState.voice_error` with `"No microphone detected — joined as listen-only"`. The user stays in the channel and can still hear other participants.
- `set_muted(false)` now also re-emits the toast when `_local_audio_track` is null and the session is connected, so users who try to unmute after a listen-only join see why nothing happens.
- Pure GDScript fix — `godot-livekit` only consumes already-captured float frames via `LiveKitAudioSource.capture_frame()`, so no C++ changes were needed.

## Test plan

- [ ] Linux: `pactl unload-module module-alsa-source` (or run inside an environment with no input source) → launch daccord → join any voice channel → app stays alive, toast reads "No microphone detected — joined as listen-only", and remote participants are still audible.
- [ ] Windows: disable all recording devices in *Sound Settings → Input* → repeat above.
- [ ] Recovery: leave the channel, re-enable / plug in a microphone, re-join — mic publishes normally.
- [ ] Listen-only unmute: while in listen-only state click the unmute button → toast re-fires, no crash.
- [ ] `./test.sh unit` — pre-existing `SyncAPI` autoload parse errors are unrelated; all suites pass.
- [ ] `gdlint scripts/voice/livekit_adapter.gd` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)