### PR TITLE
ci: make Wine install non-fatal and drop i386 to fix Windows smoke test

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -35,7 +35,6 @@ sudo tee /etc/apt/apt.conf.d/99-ci-robust >/dev/null <<'EOF'
 Acquire::Retries "5";
 Acquire::http::Timeout "30";
 Acquire::https::Timeout "30";
-Acquire::http::No-Cache "true";
 APT::Get::Assume-Yes "true";
 EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,15 +768,27 @@ jobs:
         with:
           lfs: true
 
-      - name: Install system libraries and Wine
-        timeout-minutes: 15
+      - name: Install audio libraries
+        run: .github/scripts/apt-install.sh libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev
+
+      # Wine is only needed for the optional Windows-binary smoke test below.
+      # The export itself (which is the core thing this job validates) does not
+      # depend on Wine, so installation is soft-fail: if the mirror is degraded
+      # and Wine can't be installed within the timeout, we skip the smoke test
+      # with a warning rather than failing the whole job.
+      #
+      # Note: we deliberately do NOT enable the i386 architecture. wine64 alone
+      # runs 64-bit Windows binaries (which is what Godot's Windows export is),
+      # and adding i386 roughly doubles the apt manifest download and pulls in
+      # hundreds of MB of i386 dependencies — that was the actual cause of the
+      # previous 15-minute step timeouts.
+      - name: Install Wine (optional)
+        id: install_wine
+        continue-on-error: true
+        timeout-minutes: 10
         env:
           APT_INSTALL_EXTRA_FLAGS: "--no-install-recommends"
-        run: |
-          sudo dpkg --add-architecture i386
-          .github/scripts/apt-install.sh \
-            libasound2-dev libpulse-dev libopus-dev libpipewire-0.3-dev \
-            wine64
+        run: .github/scripts/apt-install.sh wine64
 
       - name: Install godot-livekit addon (latest release)
         run: |
@@ -911,8 +923,13 @@ jobs:
           echo "All addon binaries verified in Windows build"
 
       - name: Validate Windows binary starts (Wine)
+        if: steps.install_wine.outcome == 'success'
         run: |
           cd dist/build/windows
+          if ! command -v wine64 >/dev/null 2>&1; then
+            echo "::warning::wine64 not on PATH despite successful install — skipping smoke test"
+            exit 0
+          fi
           # Use Wine to run the Windows binary in headless mode
           timeout 30 wine64 daccord.exe --headless --quit 2>&1 | tee /tmp/wine_startup.log || true
           # Check for fatal errors that indicate broken export
@@ -926,6 +943,13 @@ jobs:
           fi
           echo "Windows binary started and quit successfully under Wine"
         timeout-minutes: 2
+
+      - name: Note skipped Wine smoke test
+        if: steps.install_wine.outcome != 'success'
+        run: |
+          echo "::warning::Wine install failed or timed out — Windows binary smoke test was skipped. The export itself (and addon-binary verification) still ran and passed; this is a degraded-mirror workaround, not an export failure."
+          echo "## Windows Smoke Test" >> $GITHUB_STEP_SUMMARY
+          echo "Wine install failed or timed out — binary smoke test skipped. Export and addon-binary checks still passed." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Windows build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The previous hardening (#65) addressed transient apt-get failures but
the Windows Export & Smoke Test job is still timing out at 15 minutes
in "Install system libraries and Wine". The root cause isn't transient
mirror noise — it's structural:

  - `dpkg --add-architecture i386` roughly doubles the apt manifest
    download and pulls hundreds of MB of i386 dependencies on top of
    wine64 itself.
  - Retrying inside a 15-minute step timeout cannot fix a >15-minute
    install regardless of how many backoff attempts we make.

This commit takes a more complete workaround: Wine is only needed for
the optional "Validate Windows binary starts (Wine)" step. The Windows
export itself, addon-binary verification, and artifact upload — the
real value of this job — all work without Wine. So:

  - Split the install: audio libraries become a separate hard-fail
    step; Wine becomes a soft-fail step with `continue-on-error` and
    a 10-minute timeout.
  - Drop `dpkg --add-architecture i386`. wine64 is a pure 64-bit
    runtime, and Godot's Windows export is 64-bit, so i386 wasn't
    actually needed.
  - Gate the smoke test on the Wine install having succeeded, and
    emit a clear warning + step summary entry when it gets skipped
    so degraded-mirror skips don't look like green-on-broken-export.

Also removes `Acquire::http::No-Cache "true"` from apt-install.sh —
that directive was forcing apt to re-download manifests on every
retry attempt, which is the opposite of what we want when recovering
from a flaky mirror.

Co-authored-by: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01JYWykzyHjAnM24hANLgwyX