### PR TITLE
Release v0.1.20: Harden CI apt-get installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-05-13
+
+### Fixed
+- CI: harden apt-get installs against transient mirror failures (#65)
+
 ## [0.1.19] - 2026-05-13
 
 ### Added

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Daccord"
-config/version="0.1.19"
+config/version="0.1.20"
 run/main_scene="res://scenes/main/main_window.tscn"
 config/features=PackedStringArray("4.5", "GL Compatibility")
 run/low_processor_mode=true


### PR DESCRIPTION
## Summary

This release hardens the CI pipeline against transient mirror failures during `apt-get` installs.

## Changes

- **Version bump**: Updated `config/version` in `project.godot` from `0.1.19` to `0.1.20`
- **Changelog**: Added entry for v0.1.20 documenting the CI hardening fix

## Details

The CI improvements (referenced in #65) make `apt-get` installs more resilient to temporary package mirror outages or network issues, reducing flaky test runs and build failures caused by transient infrastructure problems rather than code issues.

https://claude.ai/code/session_01NxAYpA6ntU9TC9V17Wta6j