### PR TITLE
Fix missing emoji on wave-to-welcome reactions

### DIFF
--- a/scenes/messages/message_content.gd
+++ b/scenes/messages/message_content.gd
@@ -258,7 +258,7 @@ func _add_wave_button(data: Dictionary) -> void:
 	btn.add_theme_stylebox_override("hover", hover_sb)
 	btn.add_theme_color_override("font_color", Color.WHITE)
 	btn.pressed.connect(func() -> void:
-		Client.add_reaction(ch_id, msg_id, "\U01f44b")
+		Client.add_reaction(ch_id, msg_id, "wave")
 		btn.text = "\U01f44b " + tr("Waved!")
 		btn.disabled = true
 	)

--- a/scenes/messages/reaction_pill.gd
+++ b/scenes/messages/reaction_pill.gd
@@ -25,23 +25,25 @@ func _apply_theme() -> void:
 
 func setup(data: Dictionary) -> void:
 	_in_setup = true
-	emoji_key = data.get("emoji", "")
+	var raw_emoji: String = data.get("emoji", "")
+	# Normalise to canonical name so all code paths (texture lookup, server
+	# calls, reaction_failed matching) use the same identifier.
+	var resolved_name := EmojiData.resolve_name(raw_emoji)
+	emoji_key = resolved_name if not resolved_name.is_empty() else raw_emoji
 	reaction_count = data.get("count", 0)
 	channel_id = data.get("channel_id", "")
 	message_id = data.get("message_id", "")
 	button_pressed = data.get("active", false)
 
 	var skin_tone: int = Config.get_emoji_skin_tone()
-	var resolved_name := EmojiData.resolve_name(emoji_key)
-	var lookup_key := resolved_name if not resolved_name.is_empty() else emoji_key
-	var tone_tex: Texture2D = EmojiData.get_texture(lookup_key, skin_tone)
+	var tone_tex: Texture2D = EmojiData.get_texture(emoji_key, skin_tone)
 	if tone_tex:
 		icon = tone_tex
 	elif ClientModels.custom_emoji_textures.has(emoji_key):
 		icon = ClientModels.custom_emoji_textures[emoji_key]
 
 	text = str(reaction_count)
-	tooltip_text = ":%s:" % lookup_key
+	tooltip_text = ":%s:" % emoji_key
 	_update_active_style()
 	_in_setup = false
 

--- a/scenes/messages/reaction_pill.gd
+++ b/scenes/messages/reaction_pill.gd
@@ -32,14 +32,16 @@ func setup(data: Dictionary) -> void:
 	button_pressed = data.get("active", false)
 
 	var skin_tone: int = Config.get_emoji_skin_tone()
-	var tone_tex: Texture2D = EmojiData.get_texture(emoji_key, skin_tone)
+	var resolved_name := EmojiData.resolve_name(emoji_key)
+	var lookup_key := resolved_name if not resolved_name.is_empty() else emoji_key
+	var tone_tex: Texture2D = EmojiData.get_texture(lookup_key, skin_tone)
 	if tone_tex:
 		icon = tone_tex
 	elif ClientModels.custom_emoji_textures.has(emoji_key):
 		icon = ClientModels.custom_emoji_textures[emoji_key]
 
 	text = str(reaction_count)
-	tooltip_text = ":%s:" % emoji_key
+	tooltip_text = ":%s:" % lookup_key
 	_update_active_style()
 	_in_setup = false
 

--- a/scripts/helpers/emoji_data.gd
+++ b/scripts/helpers/emoji_data.gd
@@ -37,6 +37,7 @@ static var _catalog: Dictionary = {}
 static var _initialized := false
 static var _name_lookup: Dictionary = {}
 static var _char_to_name_lookup: Dictionary = {} # raw unicode char -> emoji name
+static var _char_to_name_built := false
 static var _texture_cache: Dictionary = {} # "emoji_name" -> Texture2D
 static var _skin_tone_textures: Dictionary = {} # "codepoint" -> Texture2D
 
@@ -85,7 +86,8 @@ static func resolve_name(input: String) -> String:
 	_build_name_lookup()
 	if _name_lookup.has(input):
 		return input
-	if _char_to_name_lookup.is_empty():
+	if not _char_to_name_built:
+		_char_to_name_built = true
 		for entry in _name_lookup.values():
 			_char_to_name_lookup[codepoint_to_char(entry["codepoint"])] = entry["name"]
 	return _char_to_name_lookup.get(input, "")

--- a/scripts/helpers/emoji_data.gd
+++ b/scripts/helpers/emoji_data.gd
@@ -36,6 +36,7 @@ static var _category_icons: Dictionary = {}
 static var _catalog: Dictionary = {}
 static var _initialized := false
 static var _name_lookup: Dictionary = {}
+static var _char_to_name_lookup: Dictionary = {} # raw unicode char -> emoji name
 static var _texture_cache: Dictionary = {} # "emoji_name" -> Texture2D
 static var _skin_tone_textures: Dictionary = {} # "codepoint" -> Texture2D
 
@@ -74,6 +75,20 @@ static func get_all_for_category(category: Category) -> Array:
 static func get_by_name(emoji_name: String) -> Dictionary:
 	_build_name_lookup()
 	return _name_lookup.get(emoji_name, {})
+
+## Resolves an emoji identifier to its canonical name. Accepts either the
+## emoji name itself (e.g. "wave") or the raw unicode character ("\U01f44b").
+## Returns an empty string if no match is found.
+static func resolve_name(input: String) -> String:
+	if input.is_empty():
+		return ""
+	_build_name_lookup()
+	if _name_lookup.has(input):
+		return input
+	if _char_to_name_lookup.is_empty():
+		for entry in _name_lookup.values():
+			_char_to_name_lookup[codepoint_to_char(entry["codepoint"])] = entry["name"]
+	return _char_to_name_lookup.get(input, "")
 
 ## Returns true if the emoji supports skin tone variants.
 static func supports_skin_tone(emoji_name: String) -> bool:


### PR DESCRIPTION
## Summary

- Reactions added via the "Wave to welcome!" button on join messages rendered as a bare count with no emoji icon, and the tooltip showed Godot's missing-glyph fallback (a tiny box with the hex codepoint) on hover.
- The button was sending the raw unicode wave character (`"\U01f44b"`) as the reaction's emoji name, but `EmojiData.get_texture()` only resolves emoji by name (e.g. `"wave"`), like every other reaction code path. Lookup failed and no icon was set.

## Changes

- [scenes/messages/message_content.gd](scenes/messages/message_content.gd:261) — wave button now sends `"wave"`, matching the emoji picker convention.
- [scripts/helpers/emoji_data.gd](scripts/helpers/emoji_data.gd) — added `EmojiData.resolve_name()` with a lazily-built raw-char → emoji-name lookup, so callers can accept either form.
- [scenes/messages/reaction_pill.gd](scenes/messages/reaction_pill.gd:35) — normalizes the incoming emoji key via `resolve_name()` before fetching the texture and building the tooltip, so legacy reactions already stored with the raw codepoint also render correctly.

## Reviewer notes

- Legacy "wave" reactions stored under the raw codepoint will now display the correct emoji, but they won't merge with new `"wave"`-keyed reactions on the same message — they'll appear as two pills until the old ones are removed.
- No new tests: GUT isn't installed in the worktree (gitignored per CLAUDE.md). `gdlint` passes on the changed files, and a headless Godot script-check shows no parse errors.

## Test plan

- [ ] Open the `#introductions` channel on a server that has existing waves; confirm reaction pills now show the wave glyph.
- [ ] Click "Wave to welcome!" on a fresh join message; confirm the new reaction pill renders with the wave icon and a `:wave:` tooltip.
- [ ] Toggle the new pill off and on; confirm counts update and the optimistic style flips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)