### PR TITLE
chore: bump version to 0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.20] - 2026-05-13
+## [0.1.21] - 2026-05-20
+
+## [0.1.20] - 2026-05-20
 
 ### Fixed
+- Missing emoji on wave-to-welcome reactions (#72)
 - CI: harden apt-get installs against transient mirror failures (#65)
 
 ## [0.1.19] - 2026-05-13

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Daccord"
-config/version="0.1.20"
+config/version="0.1.21"
 run/main_scene="res://scenes/main/main_window.tscn"
 config/features=PackedStringArray("4.5", "GL Compatibility")
 run/low_processor_mode=true


### PR DESCRIPTION
## Summary

- Cuts release v0.1.20 (tagged separately, includes the wave-emoji fix from #72).
- Bumps `config/version` to 0.1.21 for the next development cycle.
- Adds the empty `[0.1.21]` heading to `CHANGELOG.md` and folds the missing #72 entry under `[0.1.20]` (the release that actually contains it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)