### PR TITLE
Fix modal sidebar overflow on narrow viewports

### DIFF
--- a/scenes/admin/channel_permissions_dialog.gd
+++ b/scenes/admin/channel_permissions_dialog.gd
@@ -73,6 +73,9 @@ const PERM_GROUPS: Array = [
 	},
 ]
 
+## Sidebar collapses to a dropdown below this viewport width.
+const _COMPACT_THRESHOLD: float = 600.0
+
 var _selected_bg: Color:
 	get: return ThemeManager.get_color("secondary_button")
 
@@ -91,8 +94,17 @@ var _overwrite_types: Dictionary = {}
 var _original_overwrite_data: Dictionary = {}
 var _original_overwrite_types: Dictionary = {}
 
+# Compact-mode sidebar replacement
+var _compact_row: HBoxContainer
+var _compact_dropdown: OptionButton
+var _compact_dropdown_keys: Array = []
+var _is_compact_layout: bool = false
+
 @onready var _close_btn: Button = $CenterContainer/Panel/VBox/Header/CloseButton
 @onready var _title: Label = $CenterContainer/Panel/VBox/Header/Title
+@onready var _vbox: VBoxContainer = $CenterContainer/Panel/VBox
+@onready var _role_scroll: ScrollContainer = \
+	$CenterContainer/Panel/VBox/Content/RoleScroll
 @onready var _role_list: VBoxContainer = \
 	$CenterContainer/Panel/VBox/Content/RoleScroll/RoleList
 @onready var _perm_list: VBoxContainer = \
@@ -106,6 +118,8 @@ func _ready() -> void:
 	_close_btn.pressed.connect(_try_close)
 	_save_btn.pressed.connect(_on_save)
 	_reset_btn.pressed.connect(_on_reset)
+	_build_compact_row()
+	_update_compact_layout()
 
 func setup(channel: Dictionary, space_id: String) -> void:
 	_channel = channel
@@ -206,6 +220,7 @@ func _rebuild_role_list() -> void:
 	_role_list.add_child(add_btn)
 
 	_update_role_selection()
+	_rebuild_compact_dropdown()
 
 func _add_member_button(user_id: String) -> void:
 	var btn := Button.new()
@@ -241,6 +256,7 @@ func _update_role_selection() -> void:
 			btn.add_theme_stylebox_override("normal", sb)
 		else:
 			btn.remove_theme_stylebox_override("normal")
+	_sync_compact_dropdown_selection()
 
 func _on_entity_selected(
 	entity_id: String, entity_type: String
@@ -465,3 +481,111 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		_try_close()
 		get_viewport().set_input_as_handled()
+
+# --- Compact-mode sidebar collapse ---
+
+func _build_compact_row() -> void:
+	_compact_row = HBoxContainer.new()
+	_compact_row.add_theme_constant_override("separation", 8)
+	_compact_row.visible = false
+
+	_compact_dropdown = OptionButton.new()
+	_compact_dropdown.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_compact_dropdown.item_selected.connect(_on_compact_dropdown_selected)
+	_compact_row.add_child(_compact_dropdown)
+
+	var add_btn := Button.new()
+	add_btn.text = tr("+ Member")
+	add_btn.pressed.connect(_on_add_member_overwrite)
+	_compact_row.add_child(add_btn)
+
+	# Insert directly after the header (index 1) so it appears above Content.
+	_vbox.add_child(_compact_row)
+	_vbox.move_child(_compact_row, 1)
+
+func _rebuild_compact_dropdown() -> void:
+	if not is_instance_valid(_compact_dropdown):
+		return
+	_compact_dropdown.clear()
+	_compact_dropdown_keys.clear()
+
+	var roles: Array = Client.get_roles_for_space(_space_id)
+	roles.sort_custom(func(a: Dictionary, b: Dictionary):
+		return a.get("position", 0) > b.get("position", 0)
+	)
+
+	var has_roles: bool = not roles.is_empty()
+	if has_roles:
+		_compact_dropdown.add_separator(tr("Roles"))
+	for role in roles:
+		var rid: String = role.get("id", "")
+		_compact_dropdown.add_item(role.get("name", ""))
+		_compact_dropdown_keys.append(rid)
+
+	var user_ids: Array = []
+	for eid in _overwrite_types:
+		if _overwrite_types[eid] == "user":
+			user_ids.append(eid)
+
+	if not user_ids.is_empty():
+		_compact_dropdown.add_separator(tr("Members"))
+		var members: Array = Client.get_members_for_space(_space_id)
+		for uid in user_ids:
+			var display_name: String = uid
+			for m in members:
+				if m.get("id", "") == uid:
+					display_name = m.get("display_name", uid)
+					break
+			_compact_dropdown.add_item(display_name)
+			_compact_dropdown_keys.append(uid)
+
+	_sync_compact_dropdown_selection()
+
+func _sync_compact_dropdown_selection() -> void:
+	if not is_instance_valid(_compact_dropdown):
+		return
+	if _selected_role_id.is_empty():
+		_compact_dropdown.selected = -1
+		return
+	var key_idx: int = _compact_dropdown_keys.find(_selected_role_id)
+	if key_idx == -1:
+		return
+	# Account for separator items inserted before the matching entry.
+	var visible_idx: int = 0
+	for i in _compact_dropdown.item_count:
+		if _compact_dropdown.is_item_separator(i):
+			continue
+		if visible_idx == key_idx:
+			_compact_dropdown.selected = i
+			return
+		visible_idx += 1
+
+func _on_compact_dropdown_selected(idx: int) -> void:
+	if _compact_dropdown.is_item_separator(idx):
+		return
+	# Convert the OptionButton index (which includes separators) into the
+	# matching _compact_dropdown_keys position.
+	var visible_idx: int = 0
+	for i in idx:
+		if not _compact_dropdown.is_item_separator(i):
+			visible_idx += 1
+	if visible_idx < 0 or visible_idx >= _compact_dropdown_keys.size():
+		return
+	var entity_id: String = _compact_dropdown_keys[visible_idx]
+	var entity_type: String = _overwrite_types.get(entity_id, "role")
+	_on_entity_selected(entity_id, entity_type)
+
+func _update_compact_layout() -> void:
+	if not is_instance_valid(_compact_row) or not is_instance_valid(_role_scroll):
+		return
+	var vp_w: float = get_viewport_rect().size.x
+	var should_compact: bool = vp_w < _COMPACT_THRESHOLD
+	if should_compact == _is_compact_layout:
+		return
+	_is_compact_layout = should_compact
+	_role_scroll.visible = not should_compact
+	_compact_row.visible = should_compact
+
+func _on_viewport_resized() -> void:
+	super._on_viewport_resized()
+	_update_compact_layout()

--- a/scenes/admin/role_management_dialog.gd
+++ b/scenes/admin/role_management_dialog.gd
@@ -3,12 +3,23 @@ extends ModalBase
 const ConfirmDialogScene := preload("res://scenes/admin/confirm_dialog.tscn")
 const RoleRowScene := preload("res://scenes/admin/role_row.tscn")
 
+## Sidebar collapses to a dropdown below this viewport width.
+const _COMPACT_THRESHOLD: float = 600.0
+
 var _space_id: String = ""
 var _selected_role: Dictionary = {}
 var _perm_checks: Dictionary = {} # perm_string -> CheckBox
 var _all_roles: Array = []
+var _visible_roles: Array = [] # currently displayed (filtered) role list
 var _dirty: bool = false
 
+# Compact-mode sidebar replacement
+var _compact_dropdown: OptionButton
+var _is_compact_layout: bool = false
+
+@onready var _vbox: VBoxContainer = $CenterContainer/Panel/VBox
+@onready var _role_scroll: ScrollContainer = \
+	$CenterContainer/Panel/VBox/Content/RoleScroll
 @onready var _close_btn: Button = \
 	$CenterContainer/Panel/VBox/Header/CloseButton
 @onready var _new_role_btn: Button = \
@@ -45,6 +56,8 @@ func _ready() -> void:
 	_search_input.text_changed.connect(_on_search_changed)
 	_editor.visible = false
 	_build_perm_checkboxes()
+	_build_compact_dropdown()
+	_update_compact_layout()
 	AppState.roles_updated.connect(_on_roles_updated)
 
 	# Track dirty state
@@ -82,6 +95,7 @@ func _rebuild_role_list() -> void:
 func _build_role_buttons(roles: Array) -> void:
 	_clear_children(_role_list)
 
+	_visible_roles = roles
 	var role_counts: Dictionary = _compute_role_member_counts()
 
 	for i in roles.size():
@@ -93,6 +107,8 @@ func _build_role_buttons(roles: Array) -> void:
 		row.setup(role, i, roles.size(), count)
 		row.move_requested.connect(_on_move_role)
 		row.selected.connect(_select_role)
+
+	_rebuild_compact_dropdown()
 
 func _compute_role_member_counts() -> Dictionary:
 	var counts: Dictionary = {}
@@ -157,6 +173,7 @@ func _select_role(role: Dictionary) -> void:
 	_editor.visible = true
 	_error_label.visible = false
 	_dirty = false
+	_sync_compact_dropdown_selection()
 
 	_name_input.text = role.get("name", "")
 
@@ -276,3 +293,56 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		_try_close()
 		get_viewport().set_input_as_handled()
+
+# --- Compact-mode sidebar collapse ---
+
+func _build_compact_dropdown() -> void:
+	_compact_dropdown = OptionButton.new()
+	_compact_dropdown.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_compact_dropdown.visible = false
+	_compact_dropdown.item_selected.connect(_on_compact_dropdown_selected)
+	# Insert directly after the SearchInput (index 2) so it sits above Content.
+	_vbox.add_child(_compact_dropdown)
+	_vbox.move_child(_compact_dropdown, 2)
+
+func _rebuild_compact_dropdown() -> void:
+	if not is_instance_valid(_compact_dropdown):
+		return
+	_compact_dropdown.clear()
+	for role in _visible_roles:
+		_compact_dropdown.add_item(role.get("name", ""))
+	_sync_compact_dropdown_selection()
+
+func _sync_compact_dropdown_selection() -> void:
+	if not is_instance_valid(_compact_dropdown):
+		return
+	if _selected_role.is_empty():
+		_compact_dropdown.selected = -1
+		return
+	var sel_id: String = _selected_role.get("id", "")
+	for i in _visible_roles.size():
+		if _visible_roles[i].get("id", "") == sel_id:
+			_compact_dropdown.selected = i
+			return
+	_compact_dropdown.selected = -1
+
+func _on_compact_dropdown_selected(idx: int) -> void:
+	if idx < 0 or idx >= _visible_roles.size():
+		return
+	_select_role(_visible_roles[idx])
+
+func _update_compact_layout() -> void:
+	if not is_instance_valid(_compact_dropdown) \
+			or not is_instance_valid(_role_scroll):
+		return
+	var vp_w: float = get_viewport_rect().size.x
+	var should_compact: bool = vp_w < _COMPACT_THRESHOLD
+	if should_compact == _is_compact_layout:
+		return
+	_is_compact_layout = should_compact
+	_role_scroll.visible = not should_compact
+	_compact_dropdown.visible = should_compact
+
+func _on_viewport_resized() -> void:
+	super._on_viewport_resized()
+	_update_compact_layout()

--- a/scenes/user/settings_base.gd
+++ b/scenes/user/settings_base.gd
@@ -136,6 +136,11 @@ func _ready() -> void:
 
 	_show_page(initial_page)
 
+	# Initial compact-nav check: _setup_modal()'s _start_responsive() call
+	# fires before _nav_panel exists, so the first _update_compact_nav() bails
+	# out. Run it again now that the nav nodes are wired up.
+	_update_compact_nav()
+
 func _on_nav_pressed(index: int) -> void:
 	_show_page(index)
 


### PR DESCRIPTION
Three related fixes for sidebars overflowing modal panels on narrow viewports.

## `scenes/user/settings_base.gd`
The compact-nav check ran during `_setup_modal()` (via `_start_responsive()`) before `_nav_panel` was created, so it bailed out and never re-ran. Modals opened on narrow viewports kept the sidebar visible, overflowing the panel. Re-call `_update_compact_nav()` after the nav nodes are wired up.

## `scenes/admin/channel_permissions_dialog.gd`
The role/member sidebar (`RoleScroll`) had no compact-mode handling, so it overflowed on narrow viewports the same way Settings did. Added a compact dropdown row (with role/member separators and an inline "+ Member" button) that replaces the sidebar below a 600px viewport width.

## `scenes/admin/role_management_dialog.gd`
Same overflow as the channel permissions dialog. Added a compact `OptionButton` populated from the currently-filtered role list that replaces the `RoleScroll` sidebar below 600px.

All three dialogs now share the same `_COMPACT_THRESHOLD` (600.0) and follow the same pattern: build the compact replacement in `_ready()`, swap visibility in `_on_viewport_resized()`.