### PR TITLE
Disable channel drag-reorder on mobile so list can scroll

### DIFF
--- a/scenes/sidebar/channels/category_item.gd
+++ b/scenes/sidebar/channels/category_item.gd
@@ -229,7 +229,8 @@ func get_category_id() -> String:
 # --- Drag-and-drop reordering ---
 
 func _get_drag_data(_at_position: Vector2) -> Variant:
-	if AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
+	# Disable drag on touch devices so the channel list can be scrolled.
+	if _is_mobile or AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
 		return null
 	if space_id == "" or not Client.has_permission(space_id, AccordPermission.MANAGE_CHANNELS):
 		return null

--- a/scenes/sidebar/channels/channel_item.gd
+++ b/scenes/sidebar/channels/channel_item.gd
@@ -290,7 +290,8 @@ func _on_delete_channel() -> void:
 # --- Drag-and-drop reordering ---
 
 func _get_drag_data(_at_position: Vector2) -> Variant:
-	if AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
+	# Disable drag on touch devices so the channel list can be scrolled.
+	if _is_mobile or AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
 		return null
 	if space_id == "" or not Client.has_permission(space_id, AccordPermission.MANAGE_CHANNELS):
 		return null

--- a/scenes/sidebar/channels/voice_channel_item.gd
+++ b/scenes/sidebar/channels/voice_channel_item.gd
@@ -353,7 +353,8 @@ func _on_delete_channel() -> void:
 # --- Drag-and-drop reordering ---
 
 func _get_drag_data(_at_position: Vector2) -> Variant:
-	if AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
+	# Disable drag on touch devices so the channel list can be scrolled.
+	if _is_mobile or AppState.current_layout_mode == AppState.LayoutMode.COMPACT:
 		return null
 	if space_id == "" or not Client.has_permission(space_id, AccordPermission.MANAGE_CHANNELS):
 		return null


### PR DESCRIPTION
Touch drags on Android/iOS were starting a drag-to-reorder instead of
scrolling the channel list. The existing guard only checked the COMPACT
layout mode, which doesn't cover wider touch screens (e.g. tablets in
MEDIUM layout). Extending the guard to OS.has_feature("mobile") matches
how the items already gate other mobile-only behaviors.

https://claude.ai/code/session_01LA9fSbCZyDdPuXwhwphMjU