### PR TITLE
Space-menu parity + self-update (#82–#88, #91)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,15 @@ jobs:
           pattern: daccord-*
           merge-multiple: true
 
+      - name: Generate checksums
+        # SHA256SUMS.txt lets the in-app self-updater verify a downloaded bundle
+        # before swapping it in (see update_controller._expectedSha), and gives
+        # manual downloaders an integrity check. Format: "<sha256>  <filename>".
+        run: |
+          cd artifacts
+          sha256sum $(find . -maxdepth 1 -type f -printf '%P\n' | sort) > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,6 +39,9 @@ android {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+    // FileProvider, used by MainActivity to hand a downloaded APK to the system
+    // installer for the in-app self-update.
+    implementation 'androidx.core:core-ktx:1.13.1'
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,10 +25,24 @@
         android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission
         android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- In-app self-update: install a downloaded APK via the system installer. -->
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <application
         android:label="Daccord"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <!-- Grants the system package installer read access to the downloaded
+             APK handed off by the in-app updater (MainActivity.installApk). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/kotlin/com/daccord_projects/daccord/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/daccord_projects/daccord/MainActivity.kt
@@ -1,5 +1,74 @@
 package com.daccord_projects.daccord
 
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.FileProvider
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
 
-class MainActivity: FlutterActivity()
+/// Hosts the `com.daccord.app/installer` method channel used by the in-app
+/// self-updater (see `lib/features/updates/services/update_installer.dart`).
+/// `installApk` opens a downloaded APK with the system package installer via a
+/// FileProvider content URI, routing the user to grant "install unknown apps"
+/// first when needed.
+class MainActivity : FlutterActivity() {
+    private val channelName = "com.daccord.app/installer"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "installApk" -> {
+                        val path = call.argument<String>("path")
+                        if (path.isNullOrEmpty()) {
+                            result.error("no_path", "Missing APK path.", null)
+                        } else {
+                            try {
+                                installApk(path)
+                                result.success(null)
+                            } catch (e: Exception) {
+                                result.error("install_failed", e.message, null)
+                            }
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    private fun installApk(path: String) {
+        // Android O+ gates sideloading behind a per-app "install unknown apps"
+        // permission. Send the user to grant it rather than failing silently.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            !packageManager.canRequestPackageInstalls()
+        ) {
+            startActivity(
+                Intent(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    Uri.parse("package:$packageName"),
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+            throw IllegalStateException(
+                "Allow installing apps from Daccord, then tap Update again.",
+            )
+        }
+
+        val file = File(path)
+        val uri = FileProvider.getUriForFile(
+            this,
+            "$packageName.fileprovider",
+            file,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+    }
+}

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- FileProvider roots for the in-app self-updater. getTemporaryDirectory()
+     (path_provider) maps to the app's internal cache dir, where the downloaded
+     APK is written; the external entries cover devices that back it externally. -->
+<paths>
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+    <external-cache-path name="external_cache" path="." />
+    <external-files-path name="external_files" path="." />
+</paths>

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,56 @@
+# Migrating to the public `DaccordProject/daccord` URL (hard cutover)
+
+Tracks issue #86. The Flutter client (this repo) ships under the **existing
+public URL** `github.com/DaccordProject/daccord` — already shared widely — rather
+than from a new/second repo, with a **hard cutover** for existing users (no
+auto-update bridge from the old Godot client).
+
+## Why a hard cutover, not an auto-update migration
+
+The Godot client's deployed auto-updater can't safely install a Flutter desktop
+build: its apply step copies only flat files next to the binary and skips
+subdirectories. A Flutter desktop bundle is a tree (`data/flutter_assets/`, etc.),
+so those directories would be dropped and the updated app would launch broken.
+Bridging would require single-file packaging or a rewritten recursive-copy
+updater in a "bridge" Godot release. We skip all of that and announce manually.
+
+> The Flutter self-updater added in #87 copies the **whole bundle tree**, fixing
+> the flat-copy bug for everyone who is already on a Flutter build.
+
+## Cutover checklist
+
+- [ ] Freeze the Godot client in `DaccordProject/daccord`: branch current `main`
+      → `legacy-godot` and tag it (e.g. `godot-final`). History stays in place.
+- [ ] Move this Flutter codebase onto `main` of `DaccordProject/daccord`.
+- [ ] Leave existing Godot GitHub Releases untouched — they stay downloadable
+      (releases attach to the repo, not a branch).
+- [ ] First Flutter release tag must be strictly higher than the last Godot tag
+      (`0.1.21`) so GitHub treats it as **Latest**. This repo is at `0.2.0`.
+- [ ] Confirm the release workflow's asset names and self-updater target
+      (`kGithubRepo = DaccordProject/daccord` in `lib/shared/app_info.dart`).
+- [ ] Post the Discord announcement: "If you installed before <DATE>, download
+      the new version here: <LINK>."
+
+## Release artifacts the updater expects
+
+`.github/workflows/release.yml` publishes, per tag `v<version>` (must match
+`pubspec.yaml`):
+
+| Platform | Asset | Self-update path |
+|----------|-------|------------------|
+| Windows  | `daccord-windows-x86_64.zip`, `daccord-windows-x86_64-setup.exe` | in-place binary swap (#87) |
+| macOS    | `daccord-macos-universal.dmg` | replace `.app`, strip quarantine (#87) |
+| Linux    | `daccord-linux-x86_64.tar.gz`, `daccord-linux-x86_64.deb` | replace bundle tree (#87) |
+| Android  | `daccord-android.apk` | system installer (#88) |
+| Web      | `daccord-web.zip` | service-worker reload (#91) |
+| All      | `SHA256SUMS.txt` | integrity check before swap (#87) |
+
+Code signing / notarization (#90) and an iOS distribution path (#89) are tracked
+separately and are **not** part of this cutover.
+
+## Notes
+
+- License stays GPL-3.0.
+- Self-update to a system-protected install location (e.g. Windows
+  `Program Files`, system `/opt`) needs elevation and may fail without it — the
+  same limitation the Godot updater had. Per-user installs update cleanly.

--- a/lib/features/events/utils/accord_event_handler.dart
+++ b/lib/features/events/utils/accord_event_handler.dart
@@ -274,6 +274,8 @@ VoidCallback handleAccordEvents(
       isVisibleChannel: message.channelId == accordVisibleChannelId,
       mentionsMe: message.mentions.contains(me),
       mentionEveryone: message.mentionEveryone,
+      spaceMuted:
+          message.spaceId != null && settings.isSpaceMuted(message.spaceId!),
       channelLevel: settings.channelNotificationLevel(message.channelId),
     );
     if (!notify) return;
@@ -295,6 +297,10 @@ VoidCallback handleAccordEvents(
     if (!isActive()) return;
     final settings = ref.read(settingsControllerProvider);
     if (!settings.soundsEnabled) return;
+    // A muted space stays silent — no chime, mirroring the suppressed banner.
+    if (message.spaceId != null && settings.isSpaceMuted(message.spaceId!)) {
+      return;
+    }
 
     final me = currentUserId;
     if (message.authorId == me) return;

--- a/lib/features/notifications/utils/notification_gate.dart
+++ b/lib/features/notifications/utils/notification_gate.dart
@@ -24,6 +24,9 @@ class MessageNotificationGate {
   /// (kept for clarity), `'nothing'` suppresses unconditionally. `null` falls
   /// back to the default. Mirrors the reference client's per-channel level
   /// (`Config.get_channel_notification_level`).
+  /// [spaceMuted] mirrors a per-space mute (`AccordSettings.isSpaceMuted`): when
+  /// true the message's space is muted and no notification is shown, regardless
+  /// of mentions — matching the old client's "Mute Server" action.
   static bool shouldNotify({
     required bool notificationsEnabled,
     required bool suppressEveryone,
@@ -31,11 +34,13 @@ class MessageNotificationGate {
     required bool isVisibleChannel,
     required bool mentionsMe,
     required bool mentionEveryone,
+    bool spaceMuted = false,
     String? channelLevel,
   }) {
     if (!notificationsEnabled) return false;
     if (isOwnMessage) return false;
     if (isVisibleChannel) return false;
+    if (spaceMuted) return false;
     // The user-set per-channel level overrides the mention default, but is
     // still gated by the higher-priority knobs above (global enable, self,
     // visible channel) so a single setting can't accidentally re-enable an

--- a/lib/features/settings/controllers/settings.dart
+++ b/lib/features/settings/controllers/settings.dart
@@ -207,6 +207,44 @@ class SettingsController extends _$SettingsController {
     _update(state.copyWith(spaceFolders: next));
   }
 
+  /// Mutes or unmutes [spaceId]'s notifications (per-space suppression). No-op
+  /// when already in the requested state.
+  void setSpaceMuted(String spaceId, bool muted) {
+    final isMuted = state.mutedSpaces.contains(spaceId);
+    if (muted == isMuted) return;
+    _update(
+      state.copyWith(
+        mutedSpaces: muted
+            ? [...state.mutedSpaces, spaceId]
+            : [
+                for (final s in state.mutedSpaces)
+                  if (s != spaceId) s,
+              ],
+      ),
+    );
+  }
+
+  /// Toggles the muted state of [spaceId].
+  void toggleSpaceMuted(String spaceId) =>
+      setSpaceMuted(spaceId, !state.mutedSpaces.contains(spaceId));
+
+  /// Hides [spaceId] from the rail without leaving it, or restores it. No-op
+  /// when already in the requested state.
+  void setSpaceHidden(String spaceId, bool hidden) {
+    final isHidden = state.hiddenSpaces.contains(spaceId);
+    if (hidden == isHidden) return;
+    _update(
+      state.copyWith(
+        hiddenSpaces: hidden
+            ? [...state.hiddenSpaces, spaceId]
+            : [
+                for (final s in state.hiddenSpaces)
+                  if (s != spaceId) s,
+              ],
+      ),
+    );
+  }
+
   void _mutateFolder(String id, SpaceFolder Function(SpaceFolder) fn) =>
       _update(
         state.copyWith(

--- a/lib/features/settings/models/accord_settings.dart
+++ b/lib/features/settings/models/accord_settings.dart
@@ -78,6 +78,8 @@ class AccordSettings {
     this.uiScale = 1.0,
     this.spaceOrder = const <String>[],
     this.spaceFolders = const <SpaceFolder>[],
+    this.mutedSpaces = const <String>[],
+    this.hiddenSpaces = const <String>[],
   });
 
   /// Minimum / maximum UI text scale, matching the reference's `ui_scale` range.
@@ -224,6 +226,16 @@ class AccordSettings {
   /// User-defined rail folders. Mirrors the reference's `folders`.
   final List<SpaceFolder> spaceFolders;
 
+  /// Space IDs the user has muted (per-space notification suppression). Stored
+  /// client-side like [spaceFolders] — accordkit exposes no server-synced
+  /// notification settings. Mirrors the old client's space "Mute Server" action.
+  final List<String> mutedSpaces;
+
+  /// Space IDs hidden from the rail *without leaving membership* — the local
+  /// "Remove Server" action. The space stays joined on the server; it just isn't
+  /// rendered until unhidden. Stored client-side like [spaceFolders].
+  final List<String> hiddenSpaces;
+
   AccordSettings copyWith({
     AppThemePreset? themePreset,
     int? accentColor,
@@ -263,6 +275,8 @@ class AccordSettings {
     double? uiScale,
     List<String>? spaceOrder,
     List<SpaceFolder>? spaceFolders,
+    List<String>? mutedSpaces,
+    List<String>? hiddenSpaces,
   }) {
     return AccordSettings(
       themePreset: themePreset ?? this.themePreset,
@@ -304,8 +318,16 @@ class AccordSettings {
       uiScale: uiScale ?? this.uiScale,
       spaceOrder: spaceOrder ?? this.spaceOrder,
       spaceFolders: spaceFolders ?? this.spaceFolders,
+      mutedSpaces: mutedSpaces ?? this.mutedSpaces,
+      hiddenSpaces: hiddenSpaces ?? this.hiddenSpaces,
     );
   }
+
+  /// Whether [spaceId]'s notifications are muted.
+  bool isSpaceMuted(String spaceId) => mutedSpaces.contains(spaceId);
+
+  /// Whether [spaceId] is hidden from the rail (still joined on the server).
+  bool isSpaceHidden(String spaceId) => hiddenSpaces.contains(spaceId);
 
   /// Whether the rules interstitial for [spaceId] has been accepted.
   bool isRulesAccepted(String spaceId) => acceptedRuleSpaces.contains(spaceId);
@@ -396,6 +418,8 @@ class AccordSettings {
     'uiScale': uiScale,
     'spaceOrder': spaceOrder,
     'spaceFolders': [for (final f in spaceFolders) f.toJson()],
+    'mutedSpaces': mutedSpaces,
+    'hiddenSpaces': hiddenSpaces,
   };
 
   factory AccordSettings.fromJson(Map<dynamic, dynamic> json) {
@@ -473,6 +497,14 @@ class AccordSettings {
       spaceFolders: [
         for (final f in (json['spaceFolders'] as List? ?? const []))
           if (f is Map) SpaceFolder.fromJson(f),
+      ],
+      mutedSpaces: [
+        for (final s in (json['mutedSpaces'] as List? ?? const []))
+          s.toString(),
+      ],
+      hiddenSpaces: [
+        for (final s in (json['hiddenSpaces'] as List? ?? const []))
+          s.toString(),
       ],
     );
   }

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -49,6 +49,7 @@ import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/spaces/views/accord_space_settings.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/views/update_banner.dart';
+import 'package:bonfire/features/updates/views/web_update_prompt.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/shared/utils/platform.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
@@ -590,6 +591,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
     return Column(
       children: [
         const UpdateBanner(),
+        const WebUpdatePrompt(),
         const RolePreviewBanner(),
         Expanded(child: body),
       ],

--- a/lib/features/spaces/views/accord_home_rail.dart
+++ b/lib/features/spaces/views/accord_home_rail.dart
@@ -61,13 +61,20 @@ class _SpaceRail extends ConsumerWidget {
     // taps route to the right server even though the rail isn't grouped by one.
     final byId = <String, AccordSpace>{};
     final connOf = <String, _SpaceConn>{};
+    // Spaces the user hid from the rail (still joined) — collected so an "N
+    // hidden" affordance can offer to restore them.
+    final hidden = <AccordSpace>[];
     for (final conn in connections.connections) {
       final isActive = conn.key == activeKey;
       final spaces = isActive ? (liveActiveSpaces ?? conn.spaces) : conn.spaces;
       final cdnUrl = conn.session.server.cdnUrl;
       for (final s in spaces) {
-        byId[s.id] = s;
         connOf[s.id] = _SpaceConn(conn.key, cdnUrl, isActive);
+        if (settings.isSpaceHidden(s.id)) {
+          hidden.add(s);
+        } else {
+          byId[s.id] = s;
+        }
       }
     }
 
@@ -124,6 +131,18 @@ class _SpaceRail extends ConsumerWidget {
         child: _AddServerButton(onTap: onAddServer),
       ),
     );
+
+    if (hidden.isNotEmpty) {
+      railItems.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: _HiddenServersButton(
+            count: hidden.length,
+            onTap: () => _showHiddenServers(context, ref, hidden, connOf),
+          ),
+        ),
+      );
+    }
 
     return Container(
       width: 72,
@@ -307,6 +326,53 @@ class _SpaceRail extends ConsumerWidget {
     );
   }
 
+  /// Lists the spaces hidden from the rail with a one-tap restore each — the
+  /// counterpart to the "Hide from list" action so a hidden space is always
+  /// reachable again without leaving and rejoining.
+  Future<void> _showHiddenServers(
+    BuildContext context,
+    WidgetRef ref,
+    List<AccordSpace> hidden,
+    Map<String, _SpaceConn> connOf,
+  ) async {
+    final ctl = ref.read(settingsControllerProvider.notifier);
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text('Hidden servers'),
+              ),
+            ),
+            const Divider(height: 1),
+            for (final space in hidden)
+              ListTile(
+                leading: _SpaceIcon(
+                  space: space,
+                  selected: false,
+                  cdnUrl: connOf[space.id]?.cdnUrl,
+                  onTap: () {},
+                ),
+                title: Text(space.name, overflow: TextOverflow.ellipsis),
+                trailing: TextButton.icon(
+                  icon: const Icon(Icons.visibility_outlined, size: 18),
+                  label: const Text('Unhide'),
+                  onPressed: () {
+                    ctl.setSpaceHidden(space.id, false);
+                    Navigator.of(ctx).pop();
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 /// The invite / settings / leave tiles shared by the standalone-space menu and
@@ -341,7 +407,31 @@ List<Widget> _serverActionTiles(
       accordHasPermission(perms, AccordPermission.viewAuditLog);
   final isOwner = userId != null && space.ownerId == userId;
   final colors = BonfireThemeExtension.of(context);
+  final settingsCtl = ref.read(settingsControllerProvider.notifier);
+  final muted = ref.read(settingsControllerProvider).isSpaceMuted(space.id);
   return [
+    ListTile(
+      leading: Icon(
+        muted ? Icons.notifications_active_outlined : Icons.notifications_off_outlined,
+      ),
+      title: Text(muted ? 'Unmute server' : 'Mute server'),
+      subtitle: muted
+          ? null
+          : const Text('Silence notifications from this server'),
+      onTap: () {
+        settingsCtl.toggleSpaceMuted(space.id);
+        Navigator.of(sheetContext).pop();
+      },
+    ),
+    if (canInvite)
+      ListTile(
+        leading: const Icon(Icons.link_outlined),
+        title: const Text('Copy server link'),
+        onTap: () {
+          Navigator.of(sheetContext).pop();
+          _copyServerLink(context, ref, space, serverKey);
+        },
+      ),
     if (canInvite)
       ListTile(
         leading: const Icon(Icons.person_add_outlined),
@@ -361,6 +451,15 @@ List<Widget> _serverActionTiles(
         },
       ),
     ListTile(
+      leading: const Icon(Icons.visibility_off_outlined),
+      title: const Text('Hide from list'),
+      subtitle: const Text('Remove from your rail without leaving'),
+      onTap: () {
+        settingsCtl.setSpaceHidden(space.id, true);
+        Navigator.of(sheetContext).pop();
+      },
+    ),
+    ListTile(
       enabled: !isOwner,
       leading: Icon(Icons.logout, color: isOwner ? null : colors.red),
       title: Text(
@@ -377,8 +476,139 @@ List<Widget> _serverActionTiles(
               _leaveSpace(context, ref, space, serverKey);
             },
     ),
+    ListTile(
+      enabled: !isOwner,
+      leading: Icon(
+        Icons.delete_forever_outlined,
+        color: isOwner ? null : colors.red,
+      ),
+      title: Text(
+        'Leave & delete data',
+        style: isOwner ? null : TextStyle(color: colors.red),
+      ),
+      subtitle: isOwner
+          ? null
+          : const Text('Permanently delete your messages & data here'),
+      onTap: isOwner
+          ? null
+          : () {
+              Navigator.of(sheetContext).pop();
+              _leaveAndDeleteSpace(context, ref, space, serverKey);
+            },
+    ),
     const Divider(height: 1),
   ];
+}
+
+/// Copies a shareable invite link for [space] to the clipboard, reusing an
+/// existing invite when one exists or minting a default 7-day one otherwise.
+/// Gated on `createInvites` by the caller. The quick equivalent of opening the
+/// full invite dialog just to copy a link.
+Future<void> _copyServerLink(
+  BuildContext context,
+  WidgetRef ref,
+  AccordSpace space,
+  String serverKey,
+) async {
+  final conn = ref.read(connectionsControllerProvider).connectionFor(serverKey);
+  final client = ref.read(accordAuthProvider.notifier).clientForKey(serverKey);
+  final baseUrl = conn?.session.server.baseUrl;
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  if (client == null) return;
+
+  String? code;
+  final existing = await client.invites.listSpace(space.id);
+  final existingData = existing.data;
+  if (existing.ok && existingData is List) {
+    final invites = existingData.whereType<AccordInvite>().toList();
+    if (invites.isNotEmpty) code = invites.first.code;
+  }
+  if (code == null) {
+    final created = await client.invites.createSpace(
+      space.id,
+      data: {'max_age': 604800, 'max_uses': 0, 'temporary': false},
+    );
+    final createdData = created.data;
+    if (created.ok && createdData is AccordInvite) {
+      code = createdData.code;
+    } else if (created.ok) {
+      // Some servers return no body on create; refetch to recover the code.
+      final refetch = await client.invites.listSpace(space.id);
+      final refetchData = refetch.data;
+      if (refetch.ok && refetchData is List) {
+        final invites = refetchData.whereType<AccordInvite>().toList();
+        if (invites.isNotEmpty) code = invites.first.code;
+      }
+    }
+  }
+  if (code == null) {
+    messenger?.showSnackBar(
+      const SnackBar(content: Text('Could not create an invite link')),
+    );
+    return;
+  }
+  final link = baseUrl == null ? code : '$baseUrl/invite/$code';
+  await Clipboard.setData(ClipboardData(text: link));
+  messenger?.showSnackBar(
+    const SnackBar(content: Text('Server link copied')),
+  );
+}
+
+/// Confirms then leaves [space] *and deletes all the user's data* on its own
+/// connection (`deleteData: true`). The destructive sibling of [_leaveSpace],
+/// surfaced from the space menu as well as Privacy & Data. Owner-guarded by the
+/// caller (the tile is disabled for owners).
+Future<void> _leaveAndDeleteSpace(
+  BuildContext context,
+  WidgetRef ref,
+  AccordSpace space,
+  String serverKey,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Leave & delete data'),
+      content: Text(
+        "This will permanently leave '${space.name}' and delete all your "
+        'messages, reactions, and data from this server. Your account stays '
+        'active. This cannot be undone.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(ctx).colorScheme.error,
+          ),
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: const Text('Leave & delete'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  final client = ref.read(accordAuthProvider.notifier).clientForKey(serverKey);
+  if (client == null) return;
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  final result = await client.members.leaveMe(space.id, deleteData: true);
+  if (!result.ok) {
+    messenger?.showSnackBar(
+      SnackBar(
+        content: Text('Failed to leave: ${result.error ?? 'unknown error'}'),
+      ),
+    );
+    return;
+  }
+  ref
+      .read(connectionsControllerProvider.notifier)
+      .removeSpace(serverKey, space.id);
+  ref.read(spacesControllerProvider.notifier).removeSpace(space.id);
+  messenger?.showSnackBar(
+    SnackBar(content: Text("Left '${space.name}' and deleted your data")),
+  );
 }
 
 /// Confirms then leaves [space] on its own connection, without deleting any
@@ -851,6 +1081,42 @@ class _AddServerButton extends StatelessWidget {
             ),
             alignment: Alignment.center,
             child: const Icon(Icons.add, color: Color(0xFF43B581)),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A small affordance at the foot of the rail showing how many servers are
+/// hidden; tapping it opens the restore sheet.
+class _HiddenServersButton extends StatelessWidget {
+  const _HiddenServersButton({required this.count, required this.onTap});
+
+  final int count;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Center(
+      child: Tooltip(
+        message: '$count hidden ${count == 1 ? 'server' : 'servers'}',
+        child: GestureDetector(
+          onTap: onTap,
+          child: Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: colors.darkGray,
+              borderRadius: BorderRadius.circular(24),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              Icons.visibility_off_outlined,
+              size: 20,
+              color: colors.dirtyWhite,
+            ),
           ),
         ),
       ),

--- a/lib/features/updates/controllers/update_controller.dart
+++ b/lib/features/updates/controllers/update_controller.dart
@@ -3,13 +3,21 @@ import 'dart:convert';
 
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/updates/models/app_release.dart';
+import 'package:bonfire/features/updates/services/update_installer.dart';
 import 'package:bonfire/shared/app_info.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 part 'update_controller.g.dart';
+
+/// Where an in-place install currently is. Drives the update UI's progress and
+/// disabled states; [idle] also covers "not started" and "completed on Android"
+/// (where the system installer takes over and the app keeps running).
+enum UpdatePhase { idle, downloading, verifying, installing, failed }
 
 /// Snapshot of the update checker.
 @immutable
@@ -20,6 +28,9 @@ class UpdateState {
     this.error,
     this.checkedOnce = false,
     this.dismissedVersion,
+    this.phase = UpdatePhase.idle,
+    this.progress = 0.0,
+    this.installError,
   });
 
   /// The latest release fetched, or null if none/unknown.
@@ -39,6 +50,21 @@ class UpdateState {
   /// Distinct from the persistent "skip this version" preference.
   final String? dismissedVersion;
 
+  /// Current phase of an in-place install (download → verify → swap).
+  final UpdatePhase phase;
+
+  /// Download progress (0..1) while [phase] is [UpdatePhase.downloading].
+  final double progress;
+
+  /// The last install failure's user-facing message, or null.
+  final String? installError;
+
+  /// Whether an install is actively in flight (download/verify/swap).
+  bool get installing =>
+      phase == UpdatePhase.downloading ||
+      phase == UpdatePhase.verifying ||
+      phase == UpdatePhase.installing;
+
   /// Whether [latest] is a newer build than the running one. Pre-releases are
   /// ignored unless this build is itself a pre-release (matching the reference
   /// updater); GitHub's `/releases/latest` already excludes pre-releases, so
@@ -57,12 +83,19 @@ class UpdateState {
     bool clearError = false,
     bool? checkedOnce,
     String? dismissedVersion,
+    UpdatePhase? phase,
+    double? progress,
+    String? installError,
+    bool clearInstallError = false,
   }) => UpdateState(
     latest: latest ?? this.latest,
     checking: checking ?? this.checking,
     error: clearError ? null : (error ?? this.error),
     checkedOnce: checkedOnce ?? this.checkedOnce,
     dismissedVersion: dismissedVersion ?? this.dismissedVersion,
+    phase: phase ?? this.phase,
+    progress: progress ?? this.progress,
+    installError: clearInstallError ? null : (installError ?? this.installError),
   );
 }
 
@@ -72,10 +105,12 @@ class UpdateState {
 /// throttled), a manual check, session-dismiss + persistent skip, and
 /// platform-aware download links.
 ///
-/// In-place self-replacement (binary swap + relaunch on desktop, APK install on
-/// Android) is intentionally deferred — it needs untestable per-platform native
-/// machinery. For now an available update links straight to the matching
-/// platform asset's download (or the release page), and web prompts a refresh.
+/// In-place self-replacement is handled by [installUpdate]: on desktop it
+/// downloads + verifies the matching bundle and a detached helper swaps the
+/// binary tree and relaunches (see [UpdateInstaller]); on Android it hands the
+/// APK to the system installer. Platforms without an in-place path (or older
+/// releases) still fall back to a plain download link, and web prompts a
+/// service-worker reload.
 @Riverpod(keepAlive: true)
 class UpdateController extends _$UpdateController {
   static const _throttle = Duration(hours: 1);
@@ -206,6 +241,104 @@ class UpdateController extends _$UpdateController {
     }
     for (final a in assets) {
       if (hasExt(a, exts)) return a.url;
+    }
+    return null;
+  }
+
+  /// The release asset matching the current platform (the object behind
+  /// [platformAssetUrl]), or null when none applies.
+  AppReleaseAsset? platformAsset() {
+    final url = platformAssetUrl();
+    if (url == null) return null;
+    return (state.latest?.assets ?? const []).firstWhereOrNull(
+      (a) => a.url == url,
+    );
+  }
+
+  /// Whether the running platform supports an in-place download-and-install
+  /// (desktop binary swap or Android APK install), and a matching asset exists.
+  bool get canInstallInPlace =>
+      UpdateInstaller.isSupported && platformAsset() != null;
+
+  /// Downloads the matching platform asset, verifies it against the release's
+  /// published checksums (when present), and installs it in place. On desktop
+  /// the app quits and the swap helper relaunches the new build; on Android the
+  /// system package installer takes over. Surfaces progress/errors via [state].
+  Future<void> installUpdate() async {
+    if (state.installing) return;
+    final asset = platformAsset();
+    if (asset == null) {
+      state = state.copyWith(
+        phase: UpdatePhase.failed,
+        installError: 'No downloadable build for this platform.',
+      );
+      return;
+    }
+    final installer = UpdateInstaller();
+    try {
+      state = state.copyWith(
+        phase: UpdatePhase.downloading,
+        progress: 0,
+        clearInstallError: true,
+      );
+      final archivePath = await installer.download(
+        asset.url,
+        fileName: asset.name,
+        onProgress: (value) => state = state.copyWith(progress: value),
+      );
+
+      final expected = await _expectedSha(asset.name);
+      if (expected != null) {
+        state = state.copyWith(phase: UpdatePhase.verifying);
+        await installer.verify(archivePath, expected);
+      } else {
+        debugPrint('No published checksum for ${asset.name}; skipping verify.');
+      }
+
+      state = state.copyWith(phase: UpdatePhase.installing);
+      // Desktop: install() quits the process and never returns here. Android:
+      // returns once the system installer has been launched.
+      await installer.install(archivePath, onReadyToQuit: () async {});
+      state = state.copyWith(phase: UpdatePhase.idle);
+    } on UpdateInstallException catch (e) {
+      state = state.copyWith(
+        phase: UpdatePhase.failed,
+        installError: e.message,
+      );
+    } catch (e) {
+      debugPrint('Install failed: $e');
+      state = state.copyWith(
+        phase: UpdatePhase.failed,
+        installError: 'Update failed. Try downloading it manually instead.',
+      );
+    }
+  }
+
+  /// Looks up the expected SHA-256 for [assetName] from the release's
+  /// `SHA256SUMS` asset (lines of `<hex>  <filename>`). Returns null when the
+  /// release publishes no checksums or the file isn't listed — callers then
+  /// proceed without verification (older releases predate checksums).
+  Future<String?> _expectedSha(String assetName) async {
+    final sums = (state.latest?.assets ?? const []).firstWhereOrNull(
+      (a) => a.name.toUpperCase().contains('SHA256SUMS'),
+    );
+    if (sums == null) return null;
+    try {
+      final res = await http
+          .get(
+            Uri.parse(sums.url),
+            headers: {'User-Agent': 'daccord/$kAppVersion'},
+          )
+          .timeout(const Duration(seconds: 15));
+      if (res.statusCode != 200) return null;
+      for (final line in const LineSplitter().convert(res.body)) {
+        final parts = line.trim().split(RegExp(r'\s+'));
+        if (parts.length >= 2 && p.basename(parts.last) == assetName) {
+          return parts.first;
+        }
+      }
+    } catch (e) {
+      debugPrint('Checksum fetch failed: $e');
     }
     return null;
   }

--- a/lib/features/updates/services/update_installer.dart
+++ b/lib/features/updates/services/update_installer.dart
@@ -1,0 +1,8 @@
+/// Self-update installer facade. Resolves to the native `dart:io` implementation
+/// on desktop/mobile and to a no-op stub on web (where updates come from the
+/// service worker instead). Importers use [UpdateInstaller] /
+/// [UpdateInstallException] without caring which backs them.
+library;
+
+export 'update_installer_stub.dart'
+    if (dart.library.io) 'update_installer_io.dart';

--- a/lib/features/updates/services/update_installer_io.dart
+++ b/lib/features/updates/services/update_installer_io.dart
@@ -1,0 +1,314 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:universal_platform/universal_platform.dart';
+
+/// Thrown when an in-place install can't complete; carries a user-facing message.
+class UpdateInstallException implements Exception {
+  UpdateInstallException(this.message);
+  final String message;
+  @override
+  String toString() => 'UpdateInstallException: $message';
+}
+
+/// Downloads a release asset, verifies it, and installs it in place — the
+/// desktop binary-swap / Android APK-install machinery behind the update UI.
+///
+/// Ports the reference client's `updater.gd` apply steps, with the fix called
+/// out in #87: the Godot updater copied flat files only and would drop Flutter's
+/// `data/` subtree; this copies the **whole bundle tree**. The actual swap +
+/// relaunch is delegated to a small detached helper script (per platform) that
+/// waits for this process to exit first — a running binary can't replace itself.
+///
+/// Paths are passed as plain strings so this stays free of `dart:io` types in
+/// its public surface; the web build gets the no-op stub instead (see
+/// `update_installer.dart`'s conditional export).
+class UpdateInstaller {
+  UpdateInstaller({http.Client? client}) : _http = client ?? http.Client();
+
+  final http.Client _http;
+
+  /// Platform channel mirrored by `MainActivity.kt` for the Android APK install.
+  static const _androidChannel = MethodChannel('com.daccord.app/installer');
+
+  /// Whether an in-place install is implemented for the current platform.
+  static bool get isSupported =>
+      UniversalPlatform.isWindows ||
+      UniversalPlatform.isMacOS ||
+      UniversalPlatform.isLinux ||
+      UniversalPlatform.isAndroid;
+
+  /// Streams [url] to a temp file, reporting fractional progress (0..1) when the
+  /// server sends a Content-Length. Returns the downloaded file's path.
+  Future<String> download(
+    String url, {
+    String? fileName,
+    void Function(double progress)? onProgress,
+  }) async {
+    final dir = await getTemporaryDirectory();
+    final staging = Directory(p.join(dir.path, 'daccord-update'));
+    if (staging.existsSync()) staging.deleteSync(recursive: true);
+    staging.createSync(recursive: true);
+
+    final name = fileName ?? p.basename(Uri.parse(url).path);
+    final out = File(p.join(staging.path, name.isEmpty ? 'download' : name));
+
+    final req = http.Request('GET', Uri.parse(url))
+      ..headers['User-Agent'] = 'daccord-updater'
+      ..followRedirects = true;
+    final resp = await _http.send(req);
+    if (resp.statusCode != 200) {
+      throw UpdateInstallException('Download failed (HTTP ${resp.statusCode}).');
+    }
+    final total = resp.contentLength ?? 0;
+    var received = 0;
+    final sink = out.openWrite();
+    try {
+      await for (final chunk in resp.stream) {
+        sink.add(chunk);
+        received += chunk.length;
+        if (total > 0) onProgress?.call((received / total).clamp(0.0, 1.0));
+      }
+    } finally {
+      await sink.close();
+    }
+    return out.path;
+  }
+
+  /// Verifies the file at [path] against [expectedHex] (case-insensitive,
+  /// streamed). Throws on mismatch so a corrupt or tampered download never
+  /// reaches the swap step.
+  Future<void> verify(String path, String expectedHex) async {
+    final digest = await sha256.bind(File(path).openRead()).first;
+    if (digest.toString().toLowerCase() != expectedHex.toLowerCase()) {
+      throw UpdateInstallException(
+        'Integrity check failed — the download may be corrupt.',
+      );
+    }
+  }
+
+  /// Installs the downloaded asset at [path] for the current platform. On
+  /// desktop this spawns the detached swap helper and then quits the app (the
+  /// helper relaunches the new build); on Android it hands the APK to the system
+  /// package installer and returns. Throws [UpdateInstallException] on failure.
+  Future<void> install(
+    String path, {
+    required Future<void> Function() onReadyToQuit,
+  }) async {
+    final asset = File(path);
+    if (UniversalPlatform.isAndroid) {
+      await _installAndroid(asset);
+      return;
+    }
+    if (UniversalPlatform.isWindows) {
+      await _installWindows(asset);
+    } else if (UniversalPlatform.isMacOS) {
+      await _installMacOs(asset);
+    } else if (UniversalPlatform.isLinux) {
+      await _installLinux(asset);
+    } else {
+      throw UpdateInstallException('Self-update is not supported here.');
+    }
+    // Helper is now armed and polling for our exit — flush state, then quit.
+    await onReadyToQuit();
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    exit(0);
+  }
+
+  // ── Android ────────────────────────────────────────────────────────────────
+
+  Future<void> _installAndroid(File apk) async {
+    try {
+      await _androidChannel.invokeMethod<void>('installApk', {
+        'path': apk.path,
+      });
+    } on PlatformException catch (e) {
+      throw UpdateInstallException(
+        e.message ?? 'Could not open the installer.',
+      );
+    } on MissingPluginException {
+      throw UpdateInstallException('Installer is unavailable on this build.');
+    }
+  }
+
+  // ── Desktop: extract → stage → detached swap helper ─────────────────────────
+
+  /// Decodes a zip / tar.gz [archiveFile] into [dest], preserving the directory
+  /// tree (the #87 fix — never flatten). Returns [dest].
+  Future<Directory> _extract(File archiveFile, Directory dest) async {
+    final bytes = await archiveFile.readAsBytes();
+    final name = archiveFile.path.toLowerCase();
+    final Archive archive;
+    if (name.endsWith('.tar.gz') || name.endsWith('.tgz')) {
+      archive = TarDecoder().decodeBytes(GZipDecoder().decodeBytes(bytes));
+    } else if (name.endsWith('.zip')) {
+      archive = ZipDecoder().decodeBytes(bytes);
+    } else {
+      throw UpdateInstallException('Unsupported archive: ${p.basename(name)}');
+    }
+    if (dest.existsSync()) dest.deleteSync(recursive: true);
+    dest.createSync(recursive: true);
+    for (final entry in archive) {
+      final outPath = p.join(dest.path, entry.name);
+      if (entry.isFile) {
+        File(outPath)
+          ..createSync(recursive: true)
+          ..writeAsBytesSync(entry.content as List<int>);
+      } else {
+        Directory(outPath).createSync(recursive: true);
+      }
+    }
+    return dest;
+  }
+
+  /// The directory that holds the running desktop bundle (everything the swap
+  /// must replace). On macOS this is the `.app` bundle itself.
+  String get _installRoot {
+    final exe = Platform.resolvedExecutable;
+    if (UniversalPlatform.isMacOS) {
+      // …/Daccord.app/Contents/MacOS/daccord → …/Daccord.app
+      return p.dirname(p.dirname(p.dirname(exe)));
+    }
+    return p.dirname(exe);
+  }
+
+  Future<File> _writeHelper(String name, String contents) async {
+    final dir = await getTemporaryDirectory();
+    final helper = File(p.join(dir.path, 'daccord-update', name));
+    helper.parent.createSync(recursive: true);
+    helper.writeAsStringSync(contents);
+    if (!UniversalPlatform.isWindows) {
+      await Process.run('chmod', ['+x', helper.path]);
+    }
+    return helper;
+  }
+
+  /// The current process id, guarded so an unexpected platform can't crash the
+  /// updater (the helper's `kill -0` loop just falls through on 0).
+  int get _pid {
+    try {
+      return pid;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  Future<void> _installWindows(File zip) async {
+    final dir = await getTemporaryDirectory();
+    final staged = await _extract(
+      zip,
+      Directory(p.join(dir.path, 'daccord-update', 'staged')),
+    );
+    final dst = _installRoot;
+    final pid = _pid;
+    // rename-to-.old → move new → relaunch, restoring on failure (#87 rollback).
+    final bat = await _writeHelper('apply.bat', '''
+@echo off
+:wait
+tasklist /FI "PID eq $pid" 2>NUL | find "$pid" >NUL
+if "%ERRORLEVEL%"=="0" ( ping -n 2 127.0.0.1 >NUL & goto wait )
+if exist "$dst.old" rmdir /S /Q "$dst.old" >NUL 2>&1
+move "$dst" "$dst.old" >NUL 2>&1
+move "${staged.path}" "$dst" >NUL 2>&1
+if not exist "$dst\\daccord.exe" (
+  rmdir /S /Q "$dst" >NUL 2>&1
+  move "$dst.old" "$dst" >NUL 2>&1
+) else (
+  rmdir /S /Q "$dst.old" >NUL 2>&1
+)
+start "" "$dst\\daccord.exe"
+del "%~f0"
+''');
+    await Process.start('cmd.exe', [
+      '/c',
+      'start',
+      '',
+      '/min',
+      bat.path,
+    ], mode: ProcessStartMode.detached);
+  }
+
+  Future<void> _installLinux(File tarball) async {
+    final dir = await getTemporaryDirectory();
+    final staged = await _extract(
+      tarball,
+      Directory(p.join(dir.path, 'daccord-update', 'staged')),
+    );
+    final dst = _installRoot;
+    final pid = _pid;
+    final sh = await _writeHelper('apply.sh', '''
+#!/usr/bin/env bash
+set -u
+while kill -0 $pid 2>/dev/null; do sleep 0.5; done
+rm -rf "$dst.old"
+if mv "$dst" "$dst.old" 2>/dev/null; then
+  if mv "${staged.path}" "$dst" 2>/dev/null && [ -f "$dst/daccord" ]; then
+    chmod +x "$dst/daccord" 2>/dev/null
+    rm -rf "$dst.old"
+  else
+    rm -rf "$dst"; mv "$dst.old" "$dst"
+  fi
+fi
+nohup "$dst/daccord" >/dev/null 2>&1 &
+rm -f "\$0"
+''');
+    await Process.start('bash', [
+      sh.path,
+    ], mode: ProcessStartMode.detached);
+  }
+
+  Future<void> _installMacOs(File dmg) async {
+    // Attach the read-only image, locate the bundled .app, then let the helper
+    // copy it over the running bundle once we exit. Quarantine is stripped so
+    // Gatekeeper doesn't re-prompt on the freshly-copied bundle.
+    final mountPoint = p.join(
+      (await getTemporaryDirectory()).path,
+      'daccord-update',
+      'mnt',
+    );
+    Directory(mountPoint).createSync(recursive: true);
+    final attach = await Process.run('hdiutil', [
+      'attach',
+      dmg.path,
+      '-nobrowse',
+      '-mountpoint',
+      mountPoint,
+    ]);
+    if (attach.exitCode != 0) {
+      throw UpdateInstallException('Could not open the disk image.');
+    }
+    final srcApp = p.join(mountPoint, 'Daccord.app');
+    if (!Directory(srcApp).existsSync()) {
+      await Process.run('hdiutil', ['detach', mountPoint, '-force']);
+      throw UpdateInstallException('The update image is missing Daccord.app.');
+    }
+    final dst = _installRoot; // …/Daccord.app
+    final pid = _pid;
+    final sh = await _writeHelper('apply.sh', '''
+#!/usr/bin/env bash
+set -u
+while kill -0 $pid 2>/dev/null; do sleep 0.5; done
+rm -rf "$dst.old"
+if mv "$dst" "$dst.old" 2>/dev/null; then
+  if cp -R "$srcApp" "$dst" 2>/dev/null && [ -d "$dst" ]; then
+    xattr -cr "$dst" 2>/dev/null
+    rm -rf "$dst.old"
+  else
+    rm -rf "$dst"; mv "$dst.old" "$dst"
+  fi
+fi
+hdiutil detach "$mountPoint" -force >/dev/null 2>&1 || true
+open "$dst"
+rm -f "\$0"
+''');
+    await Process.start('bash', [
+      sh.path,
+    ], mode: ProcessStartMode.detached);
+  }
+}

--- a/lib/features/updates/services/update_installer_stub.dart
+++ b/lib/features/updates/services/update_installer_stub.dart
@@ -1,0 +1,36 @@
+/// Web/no-io stub of the self-update installer. The web build updates via the
+/// service worker (see `web_update.dart`), so in-place install is unsupported
+/// here; these methods exist only to satisfy the shared API in
+/// `update_installer.dart` and are never reached (the UI gates on
+/// [UpdateInstaller.isSupported]).
+library;
+
+class UpdateInstallException implements Exception {
+  UpdateInstallException(this.message);
+  final String message;
+  @override
+  String toString() => 'UpdateInstallException: $message';
+}
+
+class UpdateInstaller {
+  UpdateInstaller();
+
+  /// No in-place install path off a native platform.
+  static bool get isSupported => false;
+
+  Future<String> download(
+    String url, {
+    String? fileName,
+    void Function(double progress)? onProgress,
+  }) =>
+      throw UpdateInstallException('Self-update is not supported here.');
+
+  Future<void> verify(String path, String expectedHex) =>
+      throw UpdateInstallException('Self-update is not supported here.');
+
+  Future<void> install(
+    String path, {
+    required Future<void> Function() onReadyToQuit,
+  }) =>
+      throw UpdateInstallException('Self-update is not supported here.');
+}

--- a/lib/features/updates/services/web_update.dart
+++ b/lib/features/updates/services/web_update.dart
@@ -1,0 +1,17 @@
+/// Web service-worker update bridge. Detects when a newer build has been
+/// deployed (a new `flutter_service_worker.js` installed in the background) and
+/// applies it by skipping the waiting worker and reloading. Backed by the hooks
+/// defined in `web/index.html`; a no-op on every non-web platform.
+///
+/// The platform split is via conditional import so the rest of the app can call
+/// these unconditionally.
+library;
+
+import 'web_update_stub.dart'
+    if (dart.library.js_interop) 'web_update_web.dart' as impl;
+
+/// Whether a freshly-deployed build is waiting to be loaded (web only).
+bool webUpdateAvailable() => impl.webUpdateAvailable();
+
+/// Activates the waiting build and reloads the page (web only).
+void applyWebUpdate() => impl.applyWebUpdate();

--- a/lib/features/updates/services/web_update_stub.dart
+++ b/lib/features/updates/services/web_update_stub.dart
@@ -1,0 +1,7 @@
+/// Non-web implementation of the web service-worker update bridge: there is no
+/// service worker off the web, so nothing is ever available and apply is a no-op.
+library;
+
+bool webUpdateAvailable() => false;
+
+void applyWebUpdate() {}

--- a/lib/features/updates/services/web_update_web.dart
+++ b/lib/features/updates/services/web_update_web.dart
@@ -1,0 +1,17 @@
+/// Web implementation of the service-worker update bridge. Reads the flags set
+/// by `web/index.html`: `daccordUpdateAvailable` flips to true once a new
+/// service worker has installed in the background, and `daccordApplyUpdate()`
+/// activates it and reloads.
+library;
+
+import 'dart:js_interop';
+
+@JS('daccordUpdateAvailable')
+external JSBoolean? get _available;
+
+@JS('daccordApplyUpdate')
+external JSFunction? get _apply;
+
+bool webUpdateAvailable() => _available?.toDart ?? false;
+
+void applyWebUpdate() => _apply?.callAsFunction();

--- a/lib/features/updates/views/updates_page.dart
+++ b/lib/features/updates/views/updates_page.dart
@@ -135,6 +135,25 @@ class UpdatesScreen extends ConsumerWidget {
                 children: [
                   Builder(
                     builder: (context) {
+                      // Where the platform supports it, download + install in
+                      // place (desktop binary swap / Android APK install);
+                      // otherwise fall back to a plain download link.
+                      if (!kIsWeb && notifier.canInstallInPlace) {
+                        return FilledButton.icon(
+                          onPressed: update.installing
+                              ? null
+                              : () => notifier.installUpdate(),
+                          icon: update.installing
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.download),
+                          label: Text(_installLabel(update)),
+                        );
+                      }
                       // Prefer the matching platform asset (one-click download
                       // of the right file); fall back to the release page.
                       final assetUrl = notifier.platformAssetUrl();
@@ -154,15 +173,32 @@ class UpdatesScreen extends ConsumerWidget {
                     },
                   ),
                   TextButton(
-                    onPressed: () {
-                      notifier.skipCurrent();
-                      Navigator.of(context).maybePop();
-                    },
+                    onPressed: update.installing
+                        ? null
+                        : () {
+                            notifier.skipCurrent();
+                            Navigator.of(context).maybePop();
+                          },
                     child: const Text('Skip this version'),
                   ),
                 ],
               ),
             ),
+            if (update.phase == UpdatePhase.downloading && update.progress > 0)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: LinearProgressIndicator(value: update.progress),
+              ),
+            if (update.installError != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(
+                  update.installError!,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall!.copyWith(color: colors.red),
+                ),
+              ),
             if (kIsWeb)
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
@@ -177,5 +213,22 @@ class UpdatesScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+}
+
+/// Button label reflecting the current install phase.
+String _installLabel(UpdateState update) {
+  switch (update.phase) {
+    case UpdatePhase.downloading:
+      final pct = (update.progress * 100).round();
+      return update.progress > 0 ? 'Downloading… $pct%' : 'Downloading…';
+    case UpdatePhase.verifying:
+      return 'Verifying…';
+    case UpdatePhase.installing:
+      return 'Installing…';
+    case UpdatePhase.failed:
+      return 'Retry update';
+    case UpdatePhase.idle:
+      return 'Download & install';
   }
 }

--- a/lib/features/updates/views/web_update_prompt.dart
+++ b/lib/features/updates/views/web_update_prompt.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:bonfire/features/updates/services/web_update.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+
+/// A slim banner shown on web when a newer build has been deployed and the
+/// active tab is still running the old one. Polls the service-worker bridge
+/// (set up in `web/index.html`) and offers a one-tap reload into the new build —
+/// replacing the old "refresh the page manually" guidance (#91). Renders nothing
+/// off the web or until an update is detected.
+class WebUpdatePrompt extends StatefulWidget {
+  const WebUpdatePrompt({super.key});
+
+  @override
+  State<WebUpdatePrompt> createState() => _WebUpdatePromptState();
+}
+
+class _WebUpdatePromptState extends State<WebUpdatePrompt> {
+  Timer? _poll;
+  bool _available = false;
+  bool _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (kIsWeb) {
+      _poll = Timer.periodic(const Duration(seconds: 5), (_) => _check());
+    }
+  }
+
+  void _check() {
+    final available = webUpdateAvailable();
+    if (available != _available && mounted) {
+      setState(() => _available = available);
+    }
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kIsWeb || !_available || _dismissed) return const SizedBox.shrink();
+    final colors = BonfireThemeExtension.of(context);
+    return Material(
+      color: colors.primary,
+      child: InkWell(
+        onTap: applyWebUpdate,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Row(
+            children: [
+              const Icon(Icons.refresh, size: 16, color: Colors.white),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'A new version is available — reload to update.',
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: Colors.white, fontSize: 13),
+                ),
+              ),
+              TextButton(
+                onPressed: applyWebUpdate,
+                child: const Text(
+                  'Reload',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+              InkWell(
+                onTap: () => setState(() => _dismissed = true),
+                child: const Padding(
+                  padding: EdgeInsets.all(4),
+                  child: Icon(Icons.close, size: 16, color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,10 @@ dependencies:
   webview_flutter: ^4.10.0
   dart_mappable: ^4.6.1
   pasteboard: ^0.5.0
+  # Self-update: extract downloaded desktop bundles (zip / tar.gz) before the
+  # in-place binary swap. Pure Dart, used only by features/updates. Pinned to the
+  # already-resolved transitive version to avoid a version-solve conflict.
+  archive: ^3.6.1
 
 dependency_overrides:
   http: ^1.2.1

--- a/test/features/notifications/notification_gate_test.dart
+++ b/test/features/notifications/notification_gate_test.dart
@@ -11,6 +11,7 @@ void main() {
     bool isVisibleChannel = false,
     bool mentionsMe = false,
     bool mentionEveryone = false,
+    bool spaceMuted = false,
     String? channelLevel,
   }) =>
       MessageNotificationGate.shouldNotify(
@@ -20,6 +21,7 @@ void main() {
         isVisibleChannel: isVisibleChannel,
         mentionsMe: mentionsMe,
         mentionEveryone: mentionEveryone,
+        spaceMuted: spaceMuted,
         channelLevel: channelLevel,
       );
 
@@ -89,6 +91,12 @@ void main() {
           notify(notificationsEnabled: false, mentionEveryone: true),
           isFalse,
         );
+      });
+
+      test('a muted space suppresses any notification, even mentions', () {
+        expect(notify(spaceMuted: true, mentionsMe: true), isFalse);
+        expect(notify(spaceMuted: true, mentionEveryone: true), isFalse);
+        expect(notify(spaceMuted: true, channelLevel: 'all'), isFalse);
       });
     });
   });

--- a/test/features/settings/accord_settings_test.dart
+++ b/test/features/settings/accord_settings_test.dart
@@ -14,6 +14,8 @@ void main() {
         sfxVolume: 0.42,
         recentEmoji: ['😀', 'party:123'],
         masterServerUrl: 'https://master.example.com',
+        mutedSpaces: ['space-1', 'space-2'],
+        hiddenSpaces: ['space-3'],
       );
 
       final restored = AccordSettings.fromJson(settings.toJson());
@@ -26,6 +28,10 @@ void main() {
       expect(restored.sfxVolume, 0.42);
       expect(restored.recentEmoji, ['😀', 'party:123']);
       expect(restored.masterServerUrl, 'https://master.example.com');
+      expect(restored.mutedSpaces, ['space-1', 'space-2']);
+      expect(restored.hiddenSpaces, ['space-3']);
+      expect(restored.isSpaceMuted('space-1'), isTrue);
+      expect(restored.isSpaceHidden('space-3'), isTrue);
     });
 
     test('a null accentColor round-trips as null', () {

--- a/web/index.html
+++ b/web/index.html
@@ -169,6 +169,58 @@
     <div class="loading-text">Loading Daccord</div>
   </div>
 
+  <script>
+    // Service-worker update bridge (#91). Surfaces a newer deployed build to the
+    // running tab so the app can offer a one-tap reload instead of relying on a
+    // manual refresh. Read by lib/features/updates/services/web_update_web.dart.
+    (function () {
+      window.daccordUpdateAvailable = false;
+
+      window.daccordApplyUpdate = function () {
+        if (!('serviceWorker' in navigator)) {
+          window.location.reload();
+          return;
+        }
+        navigator.serviceWorker.getRegistration().then(function (reg) {
+          // Best-effort: ask a waiting worker to take over immediately. The
+          // default Flutter worker may ignore this, in which case the reload
+          // (and eventually closing every tab) still activates the new build.
+          if (reg && reg.waiting) {
+            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          }
+          window.location.reload();
+        }).catch(function () { window.location.reload(); });
+      };
+
+      if ('serviceWorker' in navigator) {
+        var markAvailable = function () {
+          window.daccordUpdateAvailable = true;
+        };
+        var watch = function (reg) {
+          if (!reg) return;
+          if (reg.waiting && navigator.serviceWorker.controller) markAvailable();
+          reg.addEventListener('updatefound', function () {
+            var installing = reg.installing;
+            if (!installing) return;
+            installing.addEventListener('statechange', function () {
+              if (installing.state === 'installed' &&
+                  navigator.serviceWorker.controller) {
+                markAvailable();
+              }
+            });
+          });
+        };
+        navigator.serviceWorker.ready.then(watch).catch(function () {});
+        // Poll for a new deploy while the tab stays open (every 30 minutes).
+        setInterval(function () {
+          navigator.serviceWorker.getRegistration().then(function (reg) {
+            if (reg) reg.update().catch(function () {});
+          }).catch(function () {});
+        }, 1800000);
+      }
+    })();
+  </script>
+
   <script src="flutter_bootstrap.js" async></script>
 </body>
 


### PR DESCRIPTION
Resolves the space context-menu parity items and the desktop/Android/web self-update work in one PR. (Per request, #89 iOS and #90 signing are out of scope.)

## Space context menu (`accord_home_rail.dart`)
- **#82 Mute server** — per-space notification suppression. New `mutedSpaces` in `AccordSettings`; gated in both the notification gate (`spaceMuted`) and the message-SFX path. Mute/Unmute tile in the menu. Muted spaces still show unread badges, like Discord.
- **#83 Copy server link** — one-tap tile (gated on `createInvites`) that reuses an existing invite or mints a default 7-day one, then copies `<baseUrl>/invite/<code>`.
- **#84 Leave & delete data** — destructive tile next to Leave server, owner-guarded, with confirmation, calling `leaveMe(..., deleteData: true)` (mirrors Privacy & Data).
- **#85 Remove server (hide without leaving)** — client-side `hiddenSpaces`; hidden spaces are filtered from the rail and restored via a "N hidden" affordance + sheet. Resolves the open question: it hides locally, it is **not** a leave.

## Self-update
- **#87 Desktop in-place swap** — `UpdateInstaller` downloads the platform asset (progress), verifies SHA-256, extracts the **whole bundle tree** (fixes the Godot flat-copy bug), and a detached per-OS helper renames→swaps→relaunches with rollback (Windows `.zip`, Linux `.tar.gz`, macOS `.dmg` w/ `xattr -cr`).
- **#88 Android** — downloads the `.apk` and launches the system installer via a `FileProvider` content URI through a method channel (`MainActivity.kt`); adds `REQUEST_INSTALL_PACKAGES`, the provider + `provider_paths.xml`, and routes the user to grant "install unknown apps" when needed.
- **#91 Web** — `web/index.html` watches the service worker for a newly-deployed build and exposes a bridge; an in-app "reload to update" banner replaces the manual-refresh guidance.
- `update_controller` orchestrates phases (download → verify → install) and progress; the Updates page shows a progress bar, live button label, and errors. The installer is split into io / stub via conditional export so the **web build still compiles** (no `dart:io` on web).

## #86 Migration (code parts)
- `docs/MIGRATION.md` documents the hard-cutover plan and the artifact/updater contract.
- `release.yml` now generates `SHA256SUMS.txt`, which also backs the self-update integrity check.
- The updater already targets `DaccordProject/daccord` at `0.2.0`. The remaining repo-move/announcement steps are manual ops, tracked in the doc.

## Tests
- Extended the notification-gate test (muted space suppresses even mentions) and the settings round-trip test (`mutedSpaces`/`hiddenSpaces`).

## Validation note
Per the local environment constraint, I did not run the Flutter toolchain locally (the repo's pinned beta SDK requires a newer macOS than this machine). CI (`ci.yml`: build_runner → `flutter analyze` → `flutter test`) is the validation gate. No new codegen is required — no `@riverpod`/serializer signatures changed.

The native swap (desktop) and APK-install (Android) paths are inherently per-platform and untestable in CI; they're structured faithfully to the Godot spec and should get an on-device pass before a release relies on them.

Closes #82
Closes #83
Closes #84
Closes #85
Closes #87
Closes #88
Closes #91
Addresses #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)