### PR TITLE
Fix welcome screen layout overflow; rebrand web loader

### DIFF
--- a/lib/features/authentication/views/welcome_view.dart
+++ b/lib/features/authentication/views/welcome_view.dart
@@ -101,14 +101,16 @@ class WelcomeView extends StatelessWidget {
                   ],
                 );
               }
-              return Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (var i = 0; i < cards.length; i++) ...[
-                    if (i > 0) const SizedBox(width: 10),
-                    Expanded(child: cards[i]),
+              return IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (var i = 0; i < cards.length; i++) ...[
+                      if (i > 0) const SizedBox(width: 10),
+                      Expanded(child: cards[i]),
+                    ],
                   ],
-                ],
+                ),
               );
             },
           ),

--- a/web/index.html
+++ b/web/index.html
@@ -22,8 +22,10 @@
       margin: 0;
       padding: 0;
       font-family: 'Public Sans', sans-serif;
-      background-color: #14161A;
-      color: #ffffff;
+      /* Match the app's dark preset (lib/theme/app_theme.dart): background
+         #27292C, accent #5764F1, high-emphasis text #D5D9DF, muted #939BA3. */
+      background-color: #27292C;
+      color: #D5D9DF;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -39,7 +41,7 @@
     .welcome-text {
       font-size: 28px;
       margin-bottom: 10px;
-      opacity: 0.9;
+      color: #939BA3;
       font-weight: 300;
       letter-spacing: 2px;
     }
@@ -48,20 +50,23 @@
       font-size: 72px;
       font-weight: 600;
       margin-bottom: 20px;
-      background: linear-gradient(45deg, #ff6b6b, #feca57, #ff9ff3);
+      /* Accent-family gradient (#5764F1 ± a tint) instead of Bonfire's fire
+         palette, so it shimmers but stays on Daccord brand. */
+      background: linear-gradient(45deg, #5764F1, #8A93F6, #5764F1);
+      background-size: 200% auto;
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
-      animation: fireGradient 3s ease infinite;
+      animation: accentShimmer 3s ease infinite;
     }
 
     .loading-text {
       font-size: 18px;
       margin-top: 30px;
-      opacity: 0.7;
+      color: #939BA3;
       font-weight: 300;
     }
 
-    @keyframes fireGradient {
+    @keyframes accentShimmer {
       0% {
         background-position: 0% 50%;
       }
@@ -87,20 +92,20 @@
       width: 100%;
       height: 100%;
       border: 4px solid transparent;
-      border-top-color: #ff6b6b;
+      border-top-color: #5764F1;
       border-radius: 50%;
       animation: spinnerOne 1.2s linear infinite;
     }
 
     .complex-loader div:nth-child(2) {
       border: 4px solid transparent;
-      border-bottom-color: #feca57;
+      border-bottom-color: #8A93F6;
       animation: spinnerTwo 1.2s linear infinite;
     }
 
     .complex-loader div:nth-child(3) {
       border: 4px solid transparent;
-      border-left-color: #ff9ff3;
+      border-left-color: #4049C0;
       animation: spinnerThree 1.2s linear infinite;
     }
 


### PR DESCRIPTION
## What changed

- **Fix infinite-height layout crash on the welcome screen.** The wide-layout `Row` in `welcome_view.dart` used `CrossAxisAlignment.stretch` while nested inside a `SingleChildScrollView` (vertically unbounded). `stretch` therefore tried to size the row to infinite height, throwing `BoxConstraints forces an infinite height` on first layout, followed by a cascade of "render box with no size" / "cannot hit test" errors. Wrapping the `Row` in `IntrinsicHeight` bounds it to the tallest card's height, so the feature cards still render at equal heights without the bad constraint.
- **Rebrand the web loading screen** (`web/index.html`) from Bonfire's fire palette to Daccord's accent colors (`#5764F1` family), matching the app's dark theme.

## Why

The welcome/onboarding screen — the first thing a user sees on web (and any layout wider than 420px) — threw a continuous stream of rendering exceptions on load. The `IntrinsicHeight` wrap is the minimal fix that preserves the intended equal-height card row.

## Testing

- Ran the web build (`flutter run -d chrome`) before and after.
- **Before:** continuous `EXCEPTION CAUGHT BY RENDERING LIBRARY` / infinite-height assertions on load.
- **After:** 0 layout exceptions; welcome screen renders cleanly and serves at `localhost:8088`.

## Reviewer notes

- `pubspec.lock` is intentionally **not** included. Local verification ran on stable Flutter 3.38.1 (the repo pins `beta` via `.fvmrc`, whose Dart SDK requires macOS 14; the test machine is on 13.0), which downgraded several locked packages. That lockfile churn was reverted so it doesn't leak into the repo — `pubspec.lock` is unchanged from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)