### PR TITLE
fix(theme): make all text readable on dark surfaces

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -125,50 +125,35 @@ TextTheme _textTheme(BonfireThemeExtension palette) {
   final family = GoogleFonts.publicSans().fontFamily!;
   final high = palette.dirtyWhite;
   final medium = palette.gray;
+  // Every slot is defined with an explicit colour. ThemeData.copyWith replaces
+  // the textTheme wholesale (it does NOT merge with the base typography), so any
+  // slot left undefined here — or defined without a colour — resolves to the
+  // framework's near-black default and becomes unreadable on the dark surfaces
+  // (e.g. the "Daccord" welcome title, which uses headlineSmall). Metrics are
+  // kept tight (no `height`) to match the original layout and avoid overflow.
+  TextStyle s(double size, Color color,
+          [FontWeight weight = FontWeight.w500]) =>
+      TextStyle(
+          fontSize: size,
+          fontFamily: family,
+          fontWeight: weight,
+          color: color);
   return TextTheme(
-    displayLarge:
-        TextStyle(fontSize: 36, fontFamily: family, fontWeight: FontWeight.w500),
-    displayMedium:
-        TextStyle(fontSize: 20, fontFamily: family, fontWeight: FontWeight.w500),
-    displaySmall:
-        TextStyle(fontSize: 15, fontFamily: family, fontWeight: FontWeight.w500),
-    titleLarge: TextStyle(
-        fontSize: 36,
-        fontFamily: family,
-        fontWeight: FontWeight.w500,
-        color: high),
-    titleMedium: TextStyle(
-        fontSize: 20,
-        fontFamily: family,
-        fontWeight: FontWeight.w500,
-        color: high),
-    titleSmall: TextStyle(
-        fontSize: 15,
-        fontFamily: family,
-        fontWeight: FontWeight.w500,
-        color: high),
-    headlineLarge:
-        TextStyle(fontSize: 18, fontWeight: FontWeight.w500, fontFamily: family),
-    labelLarge: TextStyle(
-        fontSize: 15,
-        fontWeight: FontWeight.w500,
-        fontFamily: family,
-        color: medium),
-    labelMedium: TextStyle(
-        fontSize: 12,
-        fontFamily: family,
-        fontWeight: FontWeight.w500,
-        color: medium),
-    bodyLarge: TextStyle(
-        fontSize: 15,
-        fontFamily: family,
-        color: high,
-        fontWeight: FontWeight.w500),
-    bodyMedium: TextStyle(
-        fontSize: 14,
-        fontFamily: family,
-        color: medium,
-        fontWeight: FontWeight.w500),
+    displayLarge: s(36, high),
+    displayMedium: s(20, high),
+    displaySmall: s(15, high),
+    titleLarge: s(36, high),
+    titleMedium: s(20, high),
+    titleSmall: s(15, high),
+    headlineLarge: s(18, high),
+    headlineMedium: s(16, high),
+    headlineSmall: s(24, high),
+    labelLarge: s(15, medium),
+    labelMedium: s(12, medium),
+    labelSmall: s(11, medium),
+    bodyLarge: s(15, high),
+    bodyMedium: s(14, medium),
+    bodySmall: s(12, medium),
   );
 }
 


### PR DESCRIPTION
## What

Rewrites `_textTheme` in `lib/theme/app_theme.dart` so **every** `TextTheme` slot is defined with an explicit color.

## Why

`buildAppTheme` applies the custom text styles via `base.copyWith(textTheme: _textTheme(palette))`. `ThemeData.copyWith` **replaces** the text theme wholesale — it does *not* merge with the base typography (confirmed in the Flutter SDK: `copyWith` does `textTheme ?? this.textTheme`, whereas the merge only happens in the main `ThemeData(...)` constructor).

As a result, any text style that `_textTheme` left:
- **undefined** — `headlineSmall`, `headlineMedium`, `bodySmall`, `labelSmall`, or
- **defined without a `color`** — `displayLarge` / `displayMedium` / `displaySmall`, `headlineLarge`

…fell through to the framework's near-black default and was effectively invisible on the app's dark surfaces. The most visible victim was the **"Daccord"** welcome title, which uses `headlineSmall`.

## Change

- All 15 text styles are now defined with an explicit color: high-emphasis (`dirtyWhite`) for headings/body, muted (`gray`) for labels.
- Metrics are kept tight (no inherited `height`) to match the original layout — an earlier attempt that seeded from the platform `TextTheme` via `.apply()` pulled in Material's taller default line-heights and caused the welcome feature cards to overflow ("BOTTOM OVERFLOWED BY 16 PIXELS"). This version avoids that.

## Notes for reviewer

- Scope is intentionally limited to `lib/theme/app_theme.dart`. Regenerated `*.g.dart` files and a downgraded `pubspec.lock` in the working tree were **not** included — they were byproducts of building under the stable Flutter SDK (the repo pins `beta` via `.fvmrc`, whose Dart VM requires macOS 14 and can't run on the dev machine here).
- Visual verification on the Chrome (`-d chrome`) build is still recommended: confirm the "Daccord" title is light/readable and the welcome feature cards show no overflow stripes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)