### PR TITLE
fix(updates): enable macOS self-update by dropping the App Sandbox

### DIFF
--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
-								enabled = 1;
+								enabled = 0;
 							};
 						};
 					};

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -2,8 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<!-- App Sandbox is intentionally OFF here too, so the in-place self-updater
+	     can be exercised in local/debug builds. See Release.entitlements for the
+	     full rationale. -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -28,6 +28,10 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Daccord needs camera access for video calls and screen sharing.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Daccord needs microphone access for voice and video calls.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<!-- App Sandbox is intentionally OFF. This app ships outside the Mac App
+	     Store (DMG via GitHub Releases) and self-updates in place; the sandbox
+	     forbids spawning the swap helper (hdiutil/bash) and writing over
+	     /Applications/Daccord.app, which breaks the updater. With the sandbox
+	     off, camera/mic are governed by TCC + the NS*UsageDescription strings in
+	     Info.plist rather than the device.* entitlements below (kept harmless). -->
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>


### PR DESCRIPTION
## What

Makes the in-place self-updater actually work on macOS by removing the **App Sandbox** from the macOS build, and adds the camera/mic usage strings that become required once the sandbox is gone.

## Why

On macOS, "Download & install" downloaded and verified the DMG, then silently did nothing — no swap, no relaunch. The updater code was fully wired (installer, `.dmg` asset matching, release DMG all present), but the app was built **sandboxed**.

A sandboxed app fundamentally can't do what `_installMacOs` needs:
- spawn `hdiutil` / `bash` / `chmod` / `open` via `Process` (arbitrary exec is denied), nor
- write outside its container — so swapping `/Applications/Daccord.app` is denied.

So the apply step died at `hdiutil attach`; Windows/Linux work because those builds aren't sandboxed. The sandbox is only *required* for Mac App Store distribution — this app ships as a DMG via GitHub Releases, so dropping it is the right call (the same posture Sparkle-based self-updating Mac apps take).

## Changes

- **`Release.entitlements` / `DebugProfile.entitlements`** — remove `com.apple.security.app-sandbox`. Debug too, so the updater can be exercised in local builds.
- **`Info.plist`** — add `NSCameraUsageDescription` + `NSMicrophoneUsageDescription`. With the sandbox off, camera/mic are governed by TCC instead of the `device.*` entitlements; **without these strings the app would crash on device access, breaking voice/video** (a hard project requirement).
- **`project.pbxproj`** — flip the Xcode `com.apple.Sandbox` capability flag to `0` so the UI stays in sync and won't silently re-add the entitlement.

## Reviewer notes

- **Verified statically:** `plutil -lint` passes on all three plists; the `app-sandbox` key is gone from both entitlement files; both usage strings are present; no other sandbox injection exists in the macos tree/Podfile; the Release config's `CODE_SIGN_ENTITLEMENTS` points at the edited `Release.entitlements`. Since CI builds unsigned, `codesign` embeds that file verbatim, so the produced bundle will not be sandboxed.
- **Not verifiable locally:** the build couldn't run on the dev machine (macOS 13 < the Flutter beta's required macOS 14). Two things to confirm on the CI `macos-15` runner or a macOS 14+ Mac:
  1. `codesign -d --entitlements - build/macos/Build/Products/Release/Daccord.app` shows **no** `app-sandbox` and the usage strings.
  2. The actual swap (needs two releases — update from a build carrying this fix to a newer one).
- **Rollout:** takes effect from the **next tagged release forward**. The shipped v0.2.1 DMG is still sandboxed and can't self-apply regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)