### PR TITLE
feat: remember last window size & position on desktop

### DIFF
--- a/lib/features/authentication/utils/hive.dart
+++ b/lib/features/authentication/utils/hive.dart
@@ -19,6 +19,9 @@ Future<void> setupHive() async {
   await Hive.openBox("last-location");
   await Hive.openBox("last-guild-channels");
   await Hive.openBox("added-accounts");
+  // Device-global desktop window geometry (size/position/maximized), restored
+  // before the first frame by `setupDesktopWindow`.
+  await Hive.openBox("window-state");
   // The active local device profile owns the `accord-session` (persisted
   // server + token + user for session restore) and `accord-settings` (client
   // preferences) boxes — bootstrap opens them from the active profile's

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:bonfire/features/server/views/add_server_dialog.dart';
 import 'package:bonfire/features/developer/controllers/mcp_server_controller.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/router/controller.dart';
+import 'package:bonfire/shared/utils/desktop_window.dart';
 import 'package:bonfire/theme/app_theme.dart';
 
 import 'package:flutter/foundation.dart';
@@ -72,6 +73,15 @@ void main() async {
     await setupHive();
   } catch (e, st) {
     debugPrint('setupHive failed during startup: $e\n$st');
+  }
+
+  // Restore the last desktop window size/position before the first frame
+  // (no-op on web/mobile). Guarded so a window-manager failure can't block
+  // startup.
+  try {
+    await setupDesktopWindow();
+  } catch (e, st) {
+    debugPrint('setupDesktopWindow failed during startup: $e\n$st');
   }
 
   runApp(

--- a/lib/shared/utils/desktop_window.dart
+++ b/lib/shared/utils/desktop_window.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:universal_platform/universal_platform.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// Persists and restores the desktop window's last size, position, and
+/// maximized state across launches. No-op on web and mobile (where the OS owns
+/// window geometry). Backed by the `window-state` Hive box opened in
+/// `setupHive`.
+
+const String windowStateBoxName = 'window-state';
+const String _key = 'bounds';
+
+/// Default window size used on first launch (matches the Linux runner default).
+const Size _defaultSize = Size(1280, 720);
+
+bool get _isDesktop =>
+    !UniversalPlatform.isWeb &&
+    (UniversalPlatform.isWindows ||
+        UniversalPlatform.isLinux ||
+        UniversalPlatform.isMacOS);
+
+/// Restores the saved window geometry and starts persisting future changes.
+/// Call once during startup, after `setupHive()` (so the box is open) and
+/// before `runApp()`.
+Future<void> setupDesktopWindow() async {
+  if (!_isDesktop) return;
+
+  await windowManager.ensureInitialized();
+
+  final box = Hive.box(windowStateBoxName);
+  final raw = box.get(_key);
+
+  Size size = _defaultSize;
+  Offset? position;
+  bool maximized = false;
+  if (raw is Map) {
+    final w = (raw['width'] as num?)?.toDouble();
+    final h = (raw['height'] as num?)?.toDouble();
+    if (w != null && h != null && w > 0 && h > 0) size = Size(w, h);
+    final x = (raw['x'] as num?)?.toDouble();
+    final y = (raw['y'] as num?)?.toDouble();
+    if (x != null && y != null) position = Offset(x, y);
+    maximized = raw['maximized'] == true;
+  }
+
+  // Center on first launch (no saved position); otherwise restore the exact
+  // spot. waitUntilReadyToShow avoids a flash at the default geometry.
+  final options = WindowOptions(size: size, center: position == null);
+  await windowManager.waitUntilReadyToShow(options, () async {
+    if (position != null) await windowManager.setPosition(position);
+    if (maximized) await windowManager.maximize();
+    await windowManager.show();
+    await windowManager.focus();
+  });
+
+  windowManager.addListener(_WindowStatePersister(box));
+}
+
+/// Saves window geometry on move/resize/(un)maximize, debounced so a drag
+/// doesn't write to Hive on every frame. While maximized, only the flag is
+/// updated — the last normal bounds are preserved for un-maximize restore.
+class _WindowStatePersister extends WindowListener {
+  _WindowStatePersister(this._box);
+
+  final Box _box;
+  Timer? _debounce;
+
+  void _scheduleSave() {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), _save);
+  }
+
+  Future<void> _save() async {
+    try {
+      final maximized = await windowManager.isMaximized();
+      final record = <String, dynamic>{
+        ...?(_box.get(_key) as Map?)?.cast<String, dynamic>(),
+        'maximized': maximized,
+      };
+      if (!maximized) {
+        final bounds = await windowManager.getBounds();
+        record['x'] = bounds.left;
+        record['y'] = bounds.top;
+        record['width'] = bounds.width;
+        record['height'] = bounds.height;
+      }
+      await _box.put(_key, record);
+    } catch (_) {
+      // Geometry is best-effort; never let a persistence hiccup surface.
+    }
+  }
+
+  @override
+  void onWindowResized() => _scheduleSave();
+
+  @override
+  void onWindowMoved() => _scheduleSave();
+
+  @override
+  void onWindowMaximize() => _scheduleSave();
+
+  @override
+  void onWindowUnmaximize() => _scheduleSave();
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -15,8 +15,10 @@
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <webcrypto/webcrypto_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
@@ -46,10 +48,16 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) pasteboard_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PasteboardPlugin");
   pasteboard_plugin_register_with_registrar(pasteboard_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
   g_autoptr(FlPluginRegistrar) webcrypto_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WebcryptoPlugin");
   webcrypto_plugin_register_with_registrar(webcrypto_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -12,8 +12,10 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_linux
   media_kit_video
   pasteboard
+  screen_retriever_linux
   url_launcher_linux
   webcrypto
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -20,12 +20,14 @@ import media_kit_video
 import package_info_plus
 import pasteboard
 import path_provider_foundation
+import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
 import url_launcher_macos
 import wakelock_plus
 import webcrypto
 import webview_flutter_wkwebview
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
@@ -43,10 +45,12 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WebcryptoPlugin.register(with: registry.registrar(forPlugin: "WebcryptoPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,7 +91,7 @@ packages:
     source: hosted
     version: "1.0.4"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
@@ -254,10 +254,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -986,18 +986,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   media_kit:
     dependency: "direct main"
     description:
@@ -1069,10 +1069,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1441,6 +1441,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sdp_transform:
     dependency: "direct main"
     description:
@@ -1698,26 +1738,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   thumbhash:
     dependency: transitive
     description:
@@ -2040,6 +2080,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,8 @@ dependencies:
   loading_animation_widget: ^1.2.1
   hive_ce: ^2.5.0
   universal_io: ^2.2.2
+  # Desktop window control — restore/persist last window size & position.
+  window_manager: ^0.4.3
 
   flutter_thumbhash: ^0.1.0+1
   flutter_cache_manager: ^3.4.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -17,8 +17,10 @@
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <webcrypto/webcrypto_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
@@ -43,8 +45,12 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PasteboardPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WebcryptoPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WebcryptoPlugin"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -14,8 +14,10 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   pasteboard
   permission_handler_windows
+  screen_retriever_windows
   url_launcher_windows
   webcrypto
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## What

Desktop builds now remember the window's last **size, position, and maximized state** across launches. Previously every launch opened at a fixed default size and forgot where the window had been placed or resized.

## How

- Added the [`window_manager`](https://pub.dev/packages/window_manager) package — there was no window-management library in the project before.
- New `lib/shared/utils/desktop_window.dart` with `setupDesktopWindow()`:
  - On launch, restores saved geometry via `waitUntilReadyToShow` (centers on first run, no flash at the default size).
  - Installs a `WindowListener` that persists geometry on move/resize/(un)maximize, **debounced 400ms** so a drag doesn't write to Hive on every frame.
  - While maximized, only the flag is stored and the last *normal* bounds are preserved, so un-maximize restores the prior size/position.
  - No-op on web/mobile (the OS owns geometry there).
- Persisted to a device-global `window-state` Hive box, opened in `setupHive`.
- Wired `setupDesktopWindow()` into `main()` after Hive is ready and before `runApp()`, guarded with try/catch like the rest of startup so a window-manager failure can't block launch.
- Regenerated native plugin registrants (Linux/macOS/Windows) for the new plugin.

## Notes for reviewers

- Works on Windows/Linux/macOS without native runner changes. On macOS, geometry persistence relies on the App Sandbox already being dropped (#97), which it is.
- **Verification:** `flutter analyze` passes clean on the changed files. I could not run the app live — the project pins Flutter `beta`, whose Dart VM requires macOS 14 while my machine is on macOS 13; I validated with the installed stable `3.38.1` toolchain (`pub get` + `analyze`). A live launch/resize test on a desktop target is the one thing left to confirm by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)