### PR TITLE
fix(updates): select installable asset by priority; show version in About

### DIFF
--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:bonfire/features/settings/views/settings_backup.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/user/views/accord_profile_edit.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -295,6 +296,7 @@ class AccordSettingsScreen extends ConsumerWidget {
           const ListTile(
             title: Text('Daccord'),
             subtitle: Text('A native multi-platform Daccord client (GPLv3).'),
+            trailing: Text('v$kAppVersion'),
           ),
           const Divider(height: 24),
           ListTile(

--- a/lib/features/updates/controllers/update_controller.dart
+++ b/lib/features/updates/controllers/update_controller.dart
@@ -214,46 +214,61 @@ class UpdateController extends _$UpdateController {
         .setSkippedUpdateVersion(version);
   }
 
-  /// The download URL of the release asset matching the current platform, or
-  /// null when none is found (the caller then falls back to the release page).
-  /// Always null on web (no downloadable binary applies).
-  String? platformAssetUrl() {
-    final assets = state.latest?.assets ?? const [];
-    if (assets.isEmpty || UniversalPlatform.isWeb) return null;
-    bool hasExt(AppReleaseAsset a, List<String> exts) {
-      final n = a.name.toLowerCase();
-      return exts.any(n.endsWith);
-    }
+  /// File extensions the in-place installer can actually apply for the current
+  /// platform, in priority order. Kept in lockstep with [UpdateInstaller]: it
+  /// extracts a `.tar.gz`/`.zip` bundle on Linux/Windows, mounts a `.dmg` on
+  /// macOS, and hands a `.apk` to the system installer on Android. Package
+  /// formats the swap helper can't apply (`.deb`/`.rpm`/`.appimage`, setup
+  /// `.exe`/`.msi`) are deliberately excluded — they're download-only.
+  List<String> get _installableExts {
+    if (UniversalPlatform.isAndroid) return const ['.apk'];
+    if (UniversalPlatform.isWindows) return const ['.zip'];
+    if (UniversalPlatform.isMacOS) return const ['.dmg'];
+    if (UniversalPlatform.isLinux) return const ['.tar.gz'];
+    return const [];
+  }
 
-    List<String> exts;
-    if (UniversalPlatform.isAndroid) {
-      exts = const ['.apk'];
-    } else if (UniversalPlatform.isWindows) {
-      exts = const ['.exe', '.msi', '.zip'];
-    } else if (UniversalPlatform.isMacOS) {
-      exts = const ['.dmg', '.pkg', '.zip'];
-    } else if (UniversalPlatform.isLinux) {
-      exts = const ['.appimage', '.tar.gz', '.deb', '.rpm'];
-    } else if (UniversalPlatform.isIOS) {
-      return null; // iOS updates come from the App Store.
-    } else {
-      return null;
+  /// Extensions worth offering as a direct download for the platform, in
+  /// priority order. A superset of [_installableExts] that also includes
+  /// package formats a user can install manually but the swap helper can't
+  /// apply in place.
+  List<String> get _downloadExts {
+    if (UniversalPlatform.isAndroid) return const ['.apk'];
+    if (UniversalPlatform.isWindows) return const ['.zip', '.exe', '.msi'];
+    if (UniversalPlatform.isMacOS) return const ['.dmg', '.pkg', '.zip'];
+    if (UniversalPlatform.isLinux) {
+      return const ['.tar.gz', '.deb', '.rpm', '.appimage'];
     }
-    for (final a in assets) {
-      if (hasExt(a, exts)) return a.url;
+    return const [];
+  }
+
+  /// First release asset whose name ends with one of [exts], honouring [exts]
+  /// as a priority list (GitHub returns assets in upload/alphabetical order, so
+  /// iterating assets first would ignore our preference — e.g. picking the
+  /// unextractable `.deb` over the `.tar.gz`). Returns null when none match.
+  AppReleaseAsset? _assetForExts(List<String> exts) {
+    final assets = state.latest?.assets ?? const [];
+    if (assets.isEmpty) return null;
+    for (final ext in exts) {
+      final match = assets.firstWhereOrNull(
+        (a) => a.name.toLowerCase().endsWith(ext),
+      );
+      if (match != null) return match;
     }
     return null;
   }
 
-  /// The release asset matching the current platform (the object behind
-  /// [platformAssetUrl]), or null when none applies.
-  AppReleaseAsset? platformAsset() {
-    final url = platformAssetUrl();
-    if (url == null) return null;
-    return (state.latest?.assets ?? const []).firstWhereOrNull(
-      (a) => a.url == url,
-    );
+  /// The download URL of the best release asset for the current platform, or
+  /// null when none is found (the caller then falls back to the release page).
+  /// Always null on web/iOS (no self-served binary applies).
+  String? platformAssetUrl() {
+    if (UniversalPlatform.isWeb || UniversalPlatform.isIOS) return null;
+    return _assetForExts(_downloadExts)?.url;
   }
+
+  /// The release asset the in-place installer can apply for the current
+  /// platform, or null when none applies (the UI then offers a plain download).
+  AppReleaseAsset? platformAsset() => _assetForExts(_installableExts);
 
   /// Whether the running platform supports an in-place download-and-install
   /// (desktop binary swap or Android APK install), and a matching asset exists.

--- a/lib/shared/app_info.dart
+++ b/lib/shared/app_info.dart
@@ -5,7 +5,7 @@ library;
 /// The current app version, kept in sync with `pubspec.yaml` `version:`
 /// (the `+build` suffix is omitted). Used as the baseline the update checker
 /// compares GitHub releases against.
-const String kAppVersion = '0.2.0';
+const String kAppVersion = '0.2.1';
 
 /// `owner/repo` whose GitHub Releases drive the in-app update checker. This is
 /// the Flutter client's own repository (the reference client checks its own


### PR DESCRIPTION
## Summary

Fixes the self-updater failing with **"Unsupported archive: daccord-linux-x86_64.deb"** on Linux (and the same latent bug on Windows), plus surfaces the app version in Settings.

### Root cause
`platformAssetUrl()` iterated over the release's **assets** and returned the first one matching *any* listed extension. The `exts` list encoded an intended priority, but iterating assets ignored it. For v0.2.1 — which ships both `daccord-linux-x86_64.tar.gz` **and** `daccord-linux-x86_64.deb` — the alphabetically-first `.deb` won. The in-place installer only extracts `.tar.gz`/`.zip`, so it threw "Unsupported archive". Windows had the identical problem: it would have selected `daccord-windows-x86_64-setup.exe` over the `.zip` and failed the same way.

### Fix
Split asset selection into two priority-ordered lists in `update_controller.dart`:

- **`_installableExts`** — only formats the in-place swap helper can actually apply: Linux `.tar.gz`, Windows `.zip`, macOS `.dmg`, Android `.apk`. Drives the one-click "Download & install" button.
- **`_downloadExts`** — superset including `.deb`/`.rpm`/`.appimage` (Linux) and setup `.exe`/`.msi` (Windows) as manual-download fallbacks.

Selection now iterates **extensions** (preference) rather than assets, so:
- A release bundling multiple formats installs the right one.
- A package-only release falls back to a manual "Download" link instead of failing mid-install.

### Also
- Bump `kAppVersion` `0.2.0` → `0.2.1` to match `pubspec.yaml` (it was stale).
- Show `v<version>` in **Settings → About**.

## Reviewer notes
- Windows in-place install targets the portable `.zip`. The Inno installer (`dist/installer.iss`) uses `PrivilegesRequired=lowest` + `{autopf}`, so the default install dir is user-writable `%LOCALAPPDATA%\Programs\Daccord` — the `move`-based swap works without elevation. (Only a user who manually elevates into `C:\Program Files` hits the same inherent limitation as macOS copying into `/Applications`.)
- `pubspec.lock` was intentionally left out — local `pub get` produced unrelated transitive bumps.

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean on changed files
- [x] `flutter test` (settings + notifications) pass
- [ ] Manually trigger an update check on Linux against v0.2.1 and confirm it downloads the `.tar.gz` and installs in place
- [ ] Confirm Settings → About shows `v0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)