### PR TITLE
Top-of-rail DM button + member context menu & quick DM

### DIFF
--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -7,9 +7,11 @@ import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:bonfire/features/member/views/accord_member_popout.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// The right-hand member roster for the Accord home view. Groups the space's
@@ -172,7 +174,7 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-class _MemberRow extends StatelessWidget {
+class _MemberRow extends ConsumerWidget {
   const _MemberRow({
     required this.member,
     required this.roles,
@@ -188,7 +190,7 @@ class _MemberRow extends StatelessWidget {
   final String status;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
     final name = accordMemberName(member);
@@ -211,6 +213,20 @@ class _MemberRow extends StatelessWidget {
             context,
             spaceId: spaceId,
             userId: member.userId,
+          ),
+          onSecondaryTapUp: (d) => _showMemberContextMenu(
+            context,
+            ref,
+            member,
+            spaceId,
+            d.globalPosition,
+          ),
+          onLongPress: () => _showMemberContextMenu(
+            context,
+            ref,
+            member,
+            spaceId,
+            null,
           ),
           child: Opacity(
             opacity: dimmed ? 0.5 : 1,
@@ -243,4 +259,68 @@ class _MemberRow extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Quick-utility right-click / long-press menu for a roster member: view their
+/// profile, start a DM, or copy their id/username. Moderation lives in the
+/// profile popout reached by tapping the row. [globalPos] is the pointer
+/// location for a right-click; it's null for a long-press, where the menu
+/// anchors to the overlay centre instead.
+Future<void> _showMemberContextMenu(
+  BuildContext context,
+  WidgetRef ref,
+  AccordMember member,
+  String spaceId,
+  Offset? globalPos,
+) async {
+  final overlay = Overlay.of(context).context.findRenderObject() as RenderBox?;
+  if (overlay == null) return;
+  final anchor = globalPos ?? overlay.size.center(Offset.zero);
+  final currentUserId = ref.read(
+    accordAuthProvider.select(
+      (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
+    ),
+  );
+  final isSelf = currentUserId != null && currentUserId == member.userId;
+  final username = member.user?.username;
+  final selected = await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromRect(
+      anchor & const Size(40, 40),
+      Offset.zero & overlay.size,
+    ),
+    items: [
+      const PopupMenuItem(value: 'profile', child: Text('View Profile')),
+      if (!isSelf)
+        const PopupMenuItem(value: 'dm', child: Text('Direct Message')),
+      const PopupMenuDivider(),
+      const PopupMenuItem(value: 'copyId', child: Text('Copy User ID')),
+      if (username != null && username.isNotEmpty)
+        const PopupMenuItem(value: 'copyName', child: Text('Copy Username')),
+    ],
+  );
+  if (selected == null || !context.mounted) return;
+  switch (selected) {
+    case 'profile':
+      await showAccordMemberPopout(
+        context,
+        spaceId: spaceId,
+        userId: member.userId,
+      );
+    case 'dm':
+      await openAccordDirectMessage(context, ref, member.userId);
+    case 'copyId':
+      await Clipboard.setData(ClipboardData(text: member.userId));
+      if (context.mounted) _toast(context, 'User ID copied');
+    case 'copyName':
+      await Clipboard.setData(ClipboardData(text: username!));
+      if (context.mounted) _toast(context, 'Username copied');
+  }
+}
+
+void _toast(BuildContext context, String message) {
+  if (!context.mounted) return;
+  ScaffoldMessenger.maybeOf(
+    context,
+  )?.showSnackBar(SnackBar(content: Text(message)));
 }

--- a/lib/features/member/views/accord_member_popout.dart
+++ b/lib/features/member/views/accord_member_popout.dart
@@ -9,6 +9,7 @@ import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:bonfire/features/spaces/controllers/role_preview.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -509,6 +510,23 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
               ],
               if (!isSelf) ...[
                 const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: _busy
+                        ? null
+                        : () => openAccordDirectMessage(
+                            context,
+                            ref,
+                            widget.userId,
+                          ),
+                    style: TextButton.styleFrom(
+                      foregroundColor: colors.primary,
+                    ),
+                    icon: const Icon(Icons.chat_bubble_outline, size: 18),
+                    label: const Text('Direct Message'),
+                  ),
+                ),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: TextButton.icon(

--- a/lib/features/spaces/views/accord_home_rail.dart
+++ b/lib/features/spaces/views/accord_home_rail.dart
@@ -83,7 +83,18 @@ class _SpaceRail extends ConsumerWidget {
     final globalOrder = _orderedIds(byId.values.toList(), settings.spaceOrder);
     final units = _buildUnits(globalOrder, byId, settings.spaceFolders);
 
-    final railItems = <Widget>[];
+    final railItems = <Widget>[
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: _DirectMessagesButton(
+          onTap: () => showAccordDirectMessages(context),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+        child: Divider(color: colors.darkGray, height: 2, thickness: 2),
+      ),
+    ];
     for (final unit in units) {
       if (unit.isFolder) {
         railItems.add(
@@ -153,15 +164,6 @@ class _SpaceRail extends ConsumerWidget {
             child: ListView(
               padding: const EdgeInsets.symmetric(vertical: 8),
               children: railItems,
-            ),
-          ),
-          IconButton(
-            tooltip: 'Direct messages',
-            onPressed: () => showAccordDirectMessages(context),
-            icon: Icon(
-              Icons.chat_bubble_outline,
-              size: 20,
-              color: colors.dirtyWhite,
             ),
           ),
           IconButton(
@@ -1051,6 +1053,42 @@ class _SpaceIcon extends ConsumerWidget {
                   ),
                 ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The Direct Messages affordance pinned at the top of the rail, styled as a
+/// space-icon tile (Discord-style "home" button) rather than a small footer
+/// icon. Opens the DM/friends modal.
+class _DirectMessagesButton extends StatelessWidget {
+  const _DirectMessagesButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Center(
+      child: Tooltip(
+        message: 'Direct messages',
+        child: GestureDetector(
+          onTap: onTap,
+          child: Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: colors.darkGray,
+              borderRadius: BorderRadius.circular(24),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              Icons.chat_bubble_outline,
+              size: 22,
+              color: colors.dirtyWhite,
+            ),
           ),
         ),
       ),

--- a/lib/features/user/views/accord_direct_messages.dart
+++ b/lib/features/user/views/accord_direct_messages.dart
@@ -53,16 +53,49 @@ String _channelTitle(AccordChannel channel, String? selfId) {
 
 /// Opens the direct-messages & friends panel: a tabbed dialog with the user's DM
 /// conversations and their friends list (with requests). The Accord analogue of
-/// the reference client's `dm_list` + `friends_list`.
-Future<void> showAccordDirectMessages(BuildContext context) {
+/// the reference client's `dm_list` + `friends_list`. Pass [initialChannel] to
+/// open straight into a conversation.
+Future<void> showAccordDirectMessages(
+  BuildContext context, {
+  AccordChannel? initialChannel,
+}) {
   return showDialog<void>(
     context: context,
-    builder: (_) => const _DirectMessagesDialog(),
+    builder: (_) => _DirectMessagesDialog(initialChannel: initialChannel),
   );
 }
 
+/// Opens (creating if needed) the 1:1 direct message with [userId] and shows the
+/// DM dialog focused on that conversation. Accord's `createDm` is idempotent for
+/// a single recipient — it returns the existing DM when one already exists.
+Future<void> openAccordDirectMessage(
+  BuildContext context,
+  WidgetRef ref,
+  String userId,
+) async {
+  final client = ref.read(
+    accordAuthProvider.select((s) => s is AccordAuthLoggedIn ? s.client : null),
+  );
+  if (client == null) return;
+  final result = await client.users.createDm({
+    'recipients': [userId],
+  });
+  if (!context.mounted) return;
+  final data = result.data;
+  if (result.ok && data is AccordChannel) {
+    ref.read(dmChannelsControllerProvider.notifier).upsert(data);
+    await showAccordDirectMessages(context, initialChannel: data);
+  } else {
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      const SnackBar(content: Text('Failed to open direct message')),
+    );
+  }
+}
+
 class _DirectMessagesDialog extends ConsumerStatefulWidget {
-  const _DirectMessagesDialog();
+  const _DirectMessagesDialog({this.initialChannel});
+
+  final AccordChannel? initialChannel;
 
   @override
   ConsumerState<_DirectMessagesDialog> createState() =>
@@ -72,7 +105,7 @@ class _DirectMessagesDialog extends ConsumerStatefulWidget {
 class _DirectMessagesDialogState extends ConsumerState<_DirectMessagesDialog>
     with SingleTickerProviderStateMixin {
   late final TabController _tabs = TabController(length: 2, vsync: this);
-  AccordChannel? _openChannel;
+  late AccordChannel? _openChannel = widget.initialChannel;
 
   @override
   void dispose() {


### PR DESCRIPTION
## Summary

- **Direct Messages moved to the top of the left rail**, restyled from a small 20px footer icon to a 48px speech-bubble tile that matches the space (server) icons — Discord-style — with a divider separating it from the space list.
- **Member roster context menu** (right-click / long-press) with quick utilities: **View Profile**, **Direct Message** (hidden for yourself), **Copy User ID**, **Copy Username**. Moderation deliberately stays in the tap-to-open profile popout; the menu uses the app's existing `showMenu` pattern.
- **Direct Message action added to the member popout** (modal) as well, for non-self users.
- New `openAccordDirectMessage(context, ref, userId)` helper creates-or-opens the 1:1 DM via the idempotent `users.createDm({recipients:[id]})` and opens the DM dialog straight into that conversation. `showAccordDirectMessages` gained an optional `initialChannel` to support this.

## Why

The DM entry point was a hard-to-spot icon at the bottom of the rail, and members had no right-click affordance. This brings both in line with the reference client / Discord conventions and makes starting a DM a one-click action from a member's row or profile.

## Reviewer notes

- "Mention in composer" was intentionally **left out** of the quick menu: the message composer (`_Composer`) is private with a self-owned controller and no external injection hook, so wiring it would require new cross-cutting plumbing. Easy follow-up if wanted.
- DM open relies on `users.createDm` being idempotent for a single recipient (returns the existing channel). When opened from the popout, the DM dialog stacks over it rather than replacing it.
- `flutter analyze --no-fatal-infos` is clean on all four changed files. Not smoke-tested in a running app — worth a manual check of right-click → Direct Message and the popout's new button.

## Test plan

- [ ] DM tile appears at the top of the rail, sized like a space icon, opens the DM panel.
- [ ] Right-click (and long-press) a member row → menu shows; each item works; copy items toast.
- [ ] "Direct Message" from both the context menu and the popout opens the correct 1:1 conversation (existing or freshly created).
- [ ] "Direct Message" is hidden when targeting yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)