### PR TITLE
fix(reactions): show reactors list and render emoji glyph

### DIFF
--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -1,6 +1,7 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -304,7 +305,9 @@ class AccordMessagesController extends _$AccordMessagesController {
       (r) => _emojiName(r) == emojiName,
     );
     final adding = !(existing?.includesMe ?? false);
-    final token = emojiId == null ? emojiName : '$emojiName:$emojiId';
+    final token = emojiId == null
+        ? resolveEmojiGlyph(emojiName)
+        : '$emojiName:$emojiId';
 
     applyReaction(
       messageId,
@@ -340,7 +343,9 @@ class AccordMessagesController extends _$AccordMessagesController {
     String? emojiId,
     int limit = 100,
   }) async {
-    final token = emojiId == null ? emojiName : '$emojiName:$emojiId';
+    final token = emojiId == null
+        ? resolveEmojiGlyph(emojiName)
+        : '$emojiName:$emojiId';
     final result = await client.reactions.listUsers(
       channelId,
       messageId,
@@ -352,7 +357,21 @@ class AccordMessagesController extends _$AccordMessagesController {
       return const [];
     }
     final data = result.data;
-    return data is List ? data.whereType<AccordUser>().toList() : const [];
+    if (data is! List) return const [];
+    // The endpoint returns bare user-id strings, not user objects — resolve each
+    // to an AccordUser, falling back to an id-only stub if the fetch fails so the
+    // reactor still appears (and the list matches the badge count).
+    final ids = [
+      for (final item in data)
+        if (item is AccordUser) item.id else item.toString(),
+    ].where((id) => id.isNotEmpty).toList();
+    return Future.wait(
+      ids.map((id) async {
+        final res = await client.users.fetch(id);
+        final user = res.data;
+        return res.ok && user is AccordUser ? user : AccordUser(id: id);
+      }),
+    );
   }
 
   /// Applies a reaction add/remove to [messageId]'s aggregate counts. Used both

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -1028,7 +1028,11 @@ class _ReactorsDialogState extends ConsumerState<_ReactorsDialog> {
     );
     final users = _users;
     return AlertDialog(
-      title: Text('Reacted with :${widget.emojiName}:'),
+      title: Text(
+        widget.emojiId == null
+            ? 'Reacted with ${resolveEmojiGlyph(widget.emojiName)}'
+            : 'Reacted with :${widget.emojiName}:',
+      ),
       content: SizedBox(
         width: 300,
         child: users == null


### PR DESCRIPTION
## Summary

Two bugs in the message reaction UI, found from a screenshot where a `👍` reaction showed `1` on the badge but the reactor dialog said "No one yet." and the header read `Reacted with :thumbsup:`.

- **Empty reactor list (primary fix).** The server's `GET .../reactions/{emoji}` returns `{ "data": [user_id strings] }` — bare ID strings, not user objects. The client ran the response through `deserializeArray(AccordUser.fromJson)` (which only maps `Map` elements) and then `whereType<AccordUser>()`, so every string was discarded → always empty. `reactionUsers` now parses the IDs and resolves each to an `AccordUser` via `client.users.fetch`, with an id-only stub fallback so a failed fetch doesn't drop a reactor (keeping the list consistent with the badge count).
- **Emoji token + header.** For unicode emoji the client sent the shortcode name (`thumbsup`) as the REST token. The server keys reactions by `emoji_name` with no shortcode↔glyph conversion, so a client storing `thumbsup` would create a separate aggregate from a client storing the glyph `👍`. Add/remove/list now send the resolved glyph, and the dialog header renders the glyph instead of the literal `:shortcode:` (custom emoji still show `:name:`).

## Why

Verified against the `accordserver` source: `add`/`remove`/`list` bind the URL-decoded emoji path param directly to the `emoji_name` column, and the list handler returns user-id strings. Sending the glyph is the canonical form (server tests use URL-encoded glyphs) and ensures reactions aggregate across clients.

## Reviewer notes

- Custom emoji (`emojiId != null`) are unchanged: token stays `name:id` and the header stays `:name:`.
- Caveat: a reaction previously **seeded** with the shortcode `thumbsup` won't match a glyph (`👍`) list query, so legacy seeded rows may still show "No one yet." Reactions added through the app store the glyph and round-trip correctly.

## Test plan

- [ ] Add a unicode reaction in-app, open the reactor dialog, confirm your user appears.
- [ ] Confirm the dialog header shows the emoji glyph, not `:thumbsup:`.
- [ ] React with the same emoji from another client and confirm the count aggregates into one badge.
- [ ] Custom (image) emoji reactions still add/list and show `:name:` in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)