### PR TITLE
Restore documentation and add desktop self-hosting guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# daccord Documentation
+
+End-user documentation for the daccord chat client. This content is designed to be pulled by external services (static site generators, help portals, etc.) to produce website documentation.
+
+## Structure
+
+```
+docs/
+  README.md              # This file
+  index.md               # Documentation home page
+  getting-started/       # First-time setup and onboarding
+  messaging/             # Sending, replying, editing, and managing messages
+  navigation/            # Spaces, channels, and the sidebar
+  voice-and-video/       # Voice channels, video, and screen sharing
+  customization/         # Themes, settings, and profiles
+  administration/        # Server and space management for admins
+  troubleshooting/       # Common issues and solutions
+```
+
+## Conventions
+
+- **Audience:** Non-technical end-users. Avoid implementation details, API references, and code.
+- **Tone:** Friendly, concise, and direct. Second person ("you").
+- **Format:** Standard Markdown with YAML front matter for metadata.
+- **Front matter fields:**
+  - `title` -- Page title (used in navigation and `<title>` tags)
+  - `description` -- Short summary for SEO and link previews
+  - `order` -- Sort order within the section (lower numbers first)
+  - `section` -- Parent section slug (matches directory name)
+- **Images:** Place in an `images/` subdirectory next to the markdown file. Use relative paths.
+- **Links:** Use relative markdown links between pages (e.g., `../messaging/sending-messages.md`).
+- **Headings:** Each page starts with an H1 matching the `title`. Use H2 and H3 for subsections. Avoid H4+.

--- a/docs/administration/invites.md
+++ b/docs/administration/invites.md
@@ -1,0 +1,32 @@
+---
+title: Invites
+description: Invite people to your server.
+order: 3
+section: administration
+---
+
+# Invites
+
+Invite links let you share access to your space with others.
+
+## Creating an Invite
+
+1. Open space settings or use the invite option from the space context menu.
+2. Go to the **Invites** section.
+3. Click **Create Invite**.
+4. Configure the invite options:
+   - **Expires after** — how long the link is valid: 30 minutes, 1 hour, 6 hours, 12 hours, 1 day, 7 days, or Never. Defaults to 1 day.
+   - **Max uses** — maximum number of times the link can be used (0 = unlimited).
+   - **Temporary membership** — when checked, members who join via this invite are removed from the space when they disconnect unless they are assigned a role before leaving.
+5. Click **Create** to generate the link and copy it to share.
+
+## Joining via Invite
+
+When someone receives an invite link:
+
+- If it's a `daccord://` link, clicking it opens daccord and starts the connection process automatically.
+- If it's a URL, they can paste it into the Add Server dialog. The invite code is extracted and accepted during connection.
+
+## Managing Invites
+
+From the Invites section in space settings, admins can view all active invites and revoke any that are no longer needed.

--- a/docs/administration/managing-your-space.md
+++ b/docs/administration/managing-your-space.md
@@ -1,0 +1,64 @@
+---
+title: Managing Your Space
+description: Configure channels, roles, and settings for your space.
+order: 1
+section: administration
+---
+
+# Managing Your Space
+
+If you have admin permissions, you can manage your space's channels, roles, and settings.
+
+## Accessing Space Settings
+
+Right-click a space icon in the space bar and select **Space Settings** (or the equivalent admin option) to open the management panel.
+
+## Channels
+
+### Creating a Channel
+
+1. In space settings, go to the Channels section.
+2. Click **Create Channel**.
+3. Choose a channel type (text, voice, announcement, or forum).
+4. Enter a name and optionally assign it to a category.
+5. Click **Create**.
+
+### Editing a Channel
+
+Click on a channel in the settings list to edit its name, topic, or other properties.
+
+### Deleting a Channel
+
+Select a channel and click **Delete**. This permanently removes the channel and all its messages.
+
+### Categories
+
+Channels can be organized into categories. Create, rename, or delete categories from the Channels section.
+
+## Roles
+
+Roles control what members can do in your space.
+
+### Creating a Role
+
+1. Go to the Roles section in space settings.
+2. Click **Create Role**.
+3. Set a name and color.
+4. Toggle individual permissions on or off.
+5. Save the role.
+
+### Assigning Roles
+
+Right-click a member in the member list and select a role to assign or remove.
+
+### Channel Permissions
+
+You can set per-channel permission overrides for specific roles:
+
+1. Open the channel's settings.
+2. Go to Permissions.
+3. Add a role and set permissions to **Allow**, **Inherit**, or **Deny** for each permission.
+
+## Invites
+
+See [Invites](invites.md) for details on inviting people to your server.

--- a/docs/administration/moderation.md
+++ b/docs/administration/moderation.md
@@ -1,0 +1,46 @@
+---
+title: Moderation
+description: Keep your community safe with moderation tools.
+order: 2
+section: administration
+---
+
+# Moderation
+
+daccord provides tools for space admins and moderators to manage members and content.
+
+## Member Actions
+
+Right-click a member in the member list to access moderation actions:
+
+- **Kick** -- Remove a member from the space. They can rejoin with a new invite.
+- **Ban** -- Permanently remove a member and prevent them from rejoining.
+- **Timeout** -- Temporarily restrict a member's ability to send messages.
+- **Mute** -- Prevent a member from speaking in voice channels.
+- **Deafen** -- Prevent a member from hearing audio in voice channels.
+
+These actions require the appropriate permissions for your role.
+
+## Managing Bans
+
+1. Open space settings.
+2. Go to the **Bans** section.
+3. View the list of banned users.
+4. Select a user and click **Unban** to allow them to rejoin.
+
+You can unban multiple users at once using bulk selection.
+
+## Deleting Messages
+
+Admins and moderators can delete any message in channels they have permission to moderate. Right-click the message and select **Delete**.
+
+## Audit Log
+
+The audit log records all administrative actions taken in your space:
+
+1. Open space settings.
+2. Go to **Audit Log**.
+3. Browse actions by type (kicks, bans, channel changes, role changes, etc.).
+4. Use the filter and search to find specific events.
+
+Each entry shows who performed the action, what was affected, and when it happened.

--- a/docs/customization/profiles.md
+++ b/docs/customization/profiles.md
@@ -1,0 +1,34 @@
+---
+title: Profiles
+description: Use multiple profiles to keep different server sets and settings separate.
+order: 3
+section: customization
+---
+
+# Profiles
+
+Profiles let you maintain separate configurations -- each with its own servers, settings, and preferences. This is useful if you use daccord for different purposes (e.g., work and personal).
+
+## Switching Profiles
+
+1. Open **App Settings**.
+2. Go to **Profiles**.
+3. Select a profile from the list to switch to it.
+
+You can also launch daccord with a specific profile from the command line using `--profile <name>`.
+
+## Creating a Profile
+
+1. In the Profiles settings page, click **Create Profile**.
+2. Enter a name for the new profile.
+3. Optionally set a password to protect it.
+
+Each profile has its own server connections, theme, and preferences. Switching profiles reloads the app with that profile's configuration.
+
+## Password-Protected Profiles
+
+You can add a password to any profile. When switching to a password-protected profile, you'll be prompted to enter the password first. This keeps your conversations private on shared devices.
+
+## Deleting a Profile
+
+Select a profile and click **Delete** to remove it. This deletes all configuration associated with that profile, including saved server connections.

--- a/docs/customization/themes.md
+++ b/docs/customization/themes.md
@@ -1,0 +1,41 @@
+---
+title: Themes and Appearance
+description: Customize the look and feel of daccord.
+order: 1
+section: customization
+---
+
+# Themes and Appearance
+
+daccord comes with several built-in themes and supports full color customization.
+
+## Changing the Theme
+
+1. Open **App Settings** (click the gear icon in the user bar, or open the user bar menu and select "App Settings").
+2. Go to **Appearance**.
+3. Select a theme from the dropdown: **Dark**, **Light**, **Nord**, **Monokai**, or **Solarized**.
+4. The theme applies instantly.
+
+## Custom Colors
+
+To create your own theme:
+
+1. Select **Custom** from the theme dropdown.
+2. Use the color pickers to adjust individual colors: Accent, Text, Muted Text, Error, Success, Panel Background, Navigation Background, and Input Background.
+3. Changes apply in real time.
+
+## Sharing Themes
+
+You can share your custom theme with others:
+
+1. Click **Copy Theme** to copy your theme as a shareable string.
+2. Send the string in a chat message or any other way.
+3. The recipient can apply it by:
+   - Going to Appearance settings and clicking **Paste Theme**
+   - Pasting the theme string in chat -- daccord detects it and shows an **Apply Theme** button inline
+
+## Other Appearance Settings
+
+- **Reduce motion** -- Disables animations throughout the app for a calmer experience
+- **UI Scale** -- Adjust the interface size from 50% to 200%
+- **Emoji skin tone** -- Set your preferred default skin tone

--- a/docs/customization/user-settings.md
+++ b/docs/customization/user-settings.md
@@ -1,0 +1,52 @@
+---
+title: User Settings
+description: Manage your account, preferences, and security settings.
+order: 2
+section: customization
+---
+
+# User Settings
+
+Open the settings panel by clicking the **gear icon** in the user bar at the bottom of the sidebar, or from the user bar menu.
+
+## Settings Pages
+
+### My Account
+
+View and manage your account details, including your username and display name.
+
+### Profile
+
+Edit your display name and other profile information visible to others.
+
+### Voice & Video
+
+Configure your microphone, speaker, and camera devices. Adjust input sensitivity and other audio preferences.
+
+### Sound
+
+Control notification and UI sound effects. Toggle sounds for messages, mentions, voice join/leave, and other events.
+
+### Notifications
+
+Configure how and when you receive notifications for messages and mentions. You can also set an **idle timeout** here — after a period of inactivity (1, 5, 10, or 30 minutes), your status switches to idle automatically. Set it to Disabled to keep your status unchanged.
+
+### Appearance
+
+Change themes, UI scale, animations, and emoji preferences. See [Themes and Appearance](themes.md) for details.
+
+### Change Password
+
+Update your account password.
+
+### Two-Factor Authentication
+
+Enable or disable two-factor authentication for added account security. When enabled, you'll need a code from your authenticator app when signing in. Backup codes are provided for recovery.
+
+### Connections
+
+Link external accounts or services to your profile. Connected accounts may be visible to other users on your profile.
+
+### Delete Account
+
+Permanently delete your account from the server.

--- a/docs/getting-started/adding-a-server.md
+++ b/docs/getting-started/adding-a-server.md
@@ -1,0 +1,44 @@
+---
+title: Adding a Server
+description: Connect to a daccord server to start chatting.
+order: 2
+section: getting-started
+---
+
+# Adding a Server
+
+To use daccord, you need to connect to at least one server. A server is a community hosted by someone running accordserver.
+
+## How to Add a Server
+
+1. Click the **+** button at the bottom of the space bar (the icon strip on the left side of the window).
+2. The Add Server dialog opens.
+3. Enter the server URL you were given. This is usually something like `chat.example.com`.
+4. Click **Connect**.
+
+## Server URL Format
+
+The simplest URL is just a hostname like `chat.example.com`. You can also include:
+
+- A port number: `chat.example.com:8443`
+- A specific space: `chat.example.com#my-space` (defaults to "general" if omitted)
+- A protocol: `https://chat.example.com` (HTTPS is used by default)
+- A pre-filled token: `chat.example.com?token=yourtoken` (logs you in automatically)
+- An invite code: `chat.example.com?invite=yourcode` (joins the space using the invite)
+
+If you received an invite link starting with `daccord://`, clicking it will open daccord and fill in the server details automatically.
+
+## What Happens Next
+
+- If the URL includes a `?token=` parameter, you'll be connected and signed in immediately.
+- If it includes a `?invite=` parameter, the invite is accepted during connection.
+- If neither is present, an authentication dialog appears where you can [sign in or create an account](creating-an-account.md).
+- Once connected, the server's space icon appears in the space bar and you can start browsing channels.
+
+## Multiple Servers
+
+You can connect to as many servers as you like. Each one appears as a separate icon in the space bar. Click an icon to switch between servers.
+
+## Removing a Server
+
+Right-click a space icon in the space bar and select **Remove Server** to disconnect from that server.

--- a/docs/getting-started/creating-an-account.md
+++ b/docs/getting-started/creating-an-account.md
@@ -1,0 +1,37 @@
+---
+title: Creating an Account
+description: Register a new account or sign in to an existing one.
+order: 3
+section: getting-started
+---
+
+# Creating an Account
+
+When you connect to a server for the first time, you'll need to sign in or create a new account.
+
+## Signing In
+
+If you already have an account on the server:
+
+1. Enter your **username** and **password**.
+2. Click **Sign In**.
+
+Your credentials are saved so you'll be signed in automatically on future launches.
+
+## Registering
+
+If you're new to the server:
+
+1. Toggle to **Register** mode in the auth dialog.
+2. Enter a **username** -- this is your unique identifier on the server.
+3. Choose a **password**, or click the generate button to create a strong one. Use the eye icon to reveal the password.
+4. Optionally set a **display name** -- this is what others will see. If you leave it blank, your username is used.
+5. Click **Register**.
+
+## After Signing In
+
+Once authenticated, daccord connects to the server and loads your spaces and channels. Your session is saved -- you won't need to sign in again unless your session expires or you remove the server.
+
+## Signing In on Another Device
+
+Your account lives on the server, not on your device. You can sign in to the same account from multiple devices. Each device maintains its own session.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,58 @@
+---
+title: Installing daccord
+description: Download and install daccord on Linux, Windows, macOS, or Android.
+order: 1
+section: getting-started
+---
+
+# Installing daccord
+
+daccord is available for Linux, Windows, macOS, Android, and the web.
+
+## Download
+
+Download the latest release from the [GitHub Releases page](https://github.com/DaccordProject/daccord/releases).
+
+Choose the right file for your platform:
+
+| Platform | File |
+|----------|------|
+| Linux (x86_64) | `daccord-linux-x86_64.zip` |
+| Linux (ARM64) | `daccord-linux-arm64.zip` |
+| Windows (installer) | `daccord-windows-x86_64-setup.exe` |
+| Windows (portable) | `daccord-windows-x86_64.zip` |
+| macOS | `daccord-macos.dmg` |
+| Android | `daccord-android.apk` |
+| Web | `daccord-web.zip` |
+
+## Linux
+
+1. Extract the downloaded archive.
+2. Run the `daccord` executable.
+3. On some distributions you may need to mark it as executable first: right-click the file, open Properties, and enable "Allow executing file as program".
+
+## Windows
+
+**Installer:** Download and run `daccord-windows-x86_64-setup.exe`. It installs daccord to Program Files, adds a Start Menu shortcut, and registers the `daccord://` URL scheme so invite links open automatically. A per-user install (no admin rights required) is also supported.
+
+**Portable:** Download and extract `daccord-windows-x86_64.zip`, then double-click `daccord.exe` to launch without installing.
+
+## macOS
+
+1. Open the downloaded `.dmg` file.
+2. Drag daccord to your Applications folder.
+3. Launch from Applications. On first launch, you may need to right-click and choose "Open" to bypass Gatekeeper.
+
+## Android
+
+1. Download the `.apk` file to your device.
+2. Open it and follow the installation prompts. You may need to allow installation from unknown sources in your device settings.
+3. Launch daccord from your app drawer.
+
+## Web
+
+The web build runs entirely in your browser with no installation required. Extract `daccord-web.zip` and open it from a web server, or visit a hosted instance if your server operator provides one. Voice and video are supported via the web audio stack. Note that some features (such as automatic updates and file system access) are not available in the web build.
+
+## Updates
+
+daccord checks for updates automatically on startup. When a new version is available, a banner appears at the top of the window. Click it to download and install the update. You can also check manually from the user menu.

--- a/docs/getting-started/your-first-message.md
+++ b/docs/getting-started/your-first-message.md
@@ -1,0 +1,39 @@
+---
+title: Your First Message
+description: Send your first message in daccord.
+order: 4
+section: getting-started
+---
+
+# Your First Message
+
+Once you're connected to a server, you're ready to start chatting.
+
+## Sending a Message
+
+1. Click a **text channel** in the channel list on the left.
+2. The message area loads on the right.
+3. Type your message in the **composer** at the bottom.
+4. Press **Enter** to send.
+
+To insert a new line without sending, press **Shift+Enter**.
+
+## Reading Messages
+
+Messages appear in the message area in chronological order. Each message shows the sender's avatar, display name, and timestamp. When the same person sends multiple messages in a row, follow-up messages are displayed in a compact format without repeating the avatar and name.
+
+## Replying
+
+To reply to a specific message:
+
+1. Hover over the message and click the **Reply** button, or right-click the message and select **Reply**.
+2. A reply bar appears above the composer showing who you're replying to.
+3. Type your reply and press **Enter**.
+
+The reply appears in chat with a reference to the original message.
+
+## Next Steps
+
+- [Learn about editing and deleting messages](../messaging/sending-messages.md)
+- [Send a direct message](../messaging/direct-messages.md)
+- [Navigate spaces and channels](../navigation/spaces-and-channels.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,54 @@
+---
+title: daccord Documentation
+description: Learn how to use daccord, a cross-platform chat client for communities.
+order: 0
+---
+
+# daccord Documentation
+
+Welcome to the daccord documentation. daccord is a chat client for communities -- connect to servers, join spaces, and communicate through text, voice, and video.
+
+## Getting Started
+
+New to daccord? Start here.
+
+- [Installing daccord](getting-started/installation.md) -- Download and install on your platform
+- [Adding a Server](getting-started/adding-a-server.md) -- Connect to your first server
+- [Creating an Account](getting-started/creating-an-account.md) -- Register and sign in
+- [Your First Message](getting-started/your-first-message.md) -- Send and receive messages
+
+## Using daccord
+
+- [Navigating Spaces and Channels](navigation/spaces-and-channels.md) -- Find your way around
+- [Sending Messages](messaging/sending-messages.md) -- Text, replies, edits, and more
+- [Direct Messages](messaging/direct-messages.md) -- Private conversations
+- [Reactions and Emoji](messaging/reactions-and-emoji.md) -- React to messages
+- [File Sharing](messaging/file-sharing.md) -- Share images and files
+- [Voice and Video](voice-and-video/voice-channels.md) -- Join voice calls
+
+## Personalizing Your Experience
+
+- [Themes and Appearance](customization/themes.md) -- Change colors and layout
+- [User Settings](customization/user-settings.md) -- Manage your account and preferences
+- [Profiles](customization/profiles.md) -- Switch between multiple profiles
+
+## For Admins
+
+- [Managing Your Space](administration/managing-your-space.md) -- Channels, roles, and settings
+- [Moderation](administration/moderation.md) -- Keep your community safe
+- [Invites](administration/invites.md) -- Invite people to your server
+
+## Self-Hosting
+
+- [Self-Hosting Overview](self-hosting/overview.md) -- The two ways to host and how to choose
+- [Running Accord on Your Desktop](self-hosting/desktop-app.md) -- Run a server from your own computer, no setup required
+- [Deploying a Server](self-hosting/deploying-a-server.md) -- Set up an always-on accordserver with Docker or from source
+
+## Plugins
+
+- [daccord Editor](https://github.com/DaccordProject/daccord-editor) -- Create and test Lua-based activity plugins for your server
+
+## Help
+
+- [Troubleshooting](troubleshooting/common-issues.md) -- Solutions to common problems
+- [Keyboard Shortcuts](troubleshooting/keyboard-shortcuts.md) -- Speed up your workflow

--- a/docs/messaging/direct-messages.md
+++ b/docs/messaging/direct-messages.md
@@ -1,0 +1,42 @@
+---
+title: Direct Messages
+description: Send private messages to other users.
+order: 2
+section: messaging
+---
+
+# Direct Messages
+
+Direct messages (DMs) let you have private one-on-one or group conversations outside of space channels.
+
+## Opening Direct Messages
+
+1. Click the **DM** button at the top of the space bar.
+2. The sidebar switches to show your DM conversation list.
+
+The DM panel has two tabs at the top: **Friends** and **Messages**.
+
+- **Friends** — shows your friends list and lets you start new DMs.
+- **Messages** — shows your existing DM conversations.
+
+Each DM shows the other person's avatar, display name, a preview of the last message, and an unread indicator if there are new messages.
+
+## Starting a Conversation
+
+Click on a user's name in a member list or message to start a DM with them. You can also start a DM from the Friends tab.
+
+## Searching DMs
+
+Use the search field at the top of the DM list to filter conversations by name.
+
+## Closing a DM
+
+To remove a conversation from your DM list, hover over it and click the **×** button that appears. This hides the conversation but does not delete the messages.
+
+## Group DMs
+
+Group DMs include more than two people. They display all participants' names separated by commas.
+
+## Sending Messages
+
+Sending messages in a DM works exactly the same as in a channel -- type in the composer and press Enter. Replies, edits, and deletes work the same way too.

--- a/docs/messaging/file-sharing.md
+++ b/docs/messaging/file-sharing.md
@@ -1,0 +1,29 @@
+---
+title: File Sharing
+description: Share images and files in conversations.
+order: 4
+section: messaging
+---
+
+# File Sharing
+
+You can share files and images directly in any text channel or DM.
+
+## Uploading Files
+
+Attach a file to your message using the attachment button in the composer. You can also **drag and drop** files into the message area.
+
+The maximum file size is **25 MB**. Files larger than this will show an error and will not be uploaded.
+
+## Pasting Images
+
+Copy an image to your clipboard and paste it directly into the composer with **Ctrl+V** (or **Cmd+V** on macOS). This works with screenshots and images copied from other apps.
+
+You can also paste large blocks of text -- they'll be attached as a text file rather than sent as an enormous message.
+
+## Viewing Attachments
+
+- **Images** are displayed inline within the message. Click an image to view it at full size.
+- **Audio files** show an inline player with a progress slider so you can listen without downloading.
+- **Video files** show a clickable thumbnail. Click it to play the video.
+- **Other files** appear as a download link with the filename.

--- a/docs/messaging/reactions-and-emoji.md
+++ b/docs/messaging/reactions-and-emoji.md
@@ -1,0 +1,35 @@
+---
+title: Reactions and Emoji
+description: React to messages with emoji.
+order: 3
+section: messaging
+---
+
+# Reactions and Emoji
+
+You can react to any message with emoji to express yourself without sending a full reply.
+
+## Adding a Reaction
+
+1. Hover over a message and click the **React** button in the floating action bar.
+2. The emoji picker opens showing 160 emoji organized into 8 categories.
+3. Use the search field to find a specific emoji.
+4. Click an emoji to add it as a reaction.
+
+You can also right-click a message and select **React** from the context menu.
+
+## Removing a Reaction
+
+Click your own reaction on a message to remove it.
+
+## Reaction Display
+
+Reactions appear as small pills below the message content, showing the emoji and a count of how many people reacted with it. Your own reactions are highlighted.
+
+## Using Emoji in Messages
+
+To insert an emoji into your message text, open the emoji picker from the composer area.
+
+## Skin Tone
+
+You can set your preferred emoji skin tone in **App Settings > Appearance**.

--- a/docs/messaging/sending-messages.md
+++ b/docs/messaging/sending-messages.md
@@ -1,0 +1,62 @@
+---
+title: Sending Messages
+description: Send, reply to, edit, and delete messages.
+order: 1
+section: messaging
+---
+
+# Sending Messages
+
+## Sending
+
+Type your message in the composer at the bottom of the message area and press **Enter** to send. Press **Shift+Enter** to insert a new line without sending.
+
+daccord supports basic Markdown formatting in messages:
+
+- `**bold**` for **bold**
+- `*italic*` for *italic*
+- `` `code` `` for `inline code`
+- ``` ```code block``` ``` for code blocks
+
+## Replying
+
+To reply to a specific message:
+
+1. Hover over the message and click the **Reply** button in the floating action bar, or right-click and select **Reply**.
+2. A reply bar appears above the composer showing "Replying to [name]".
+3. Type your reply and send as usual.
+4. Click the **x** on the reply bar to cancel.
+
+## Editing
+
+You can edit your own messages:
+
+1. Hover over your message and click the **Edit** button, or right-click and select **Edit**.
+2. The message text becomes editable inline.
+3. Press **Enter** to save your changes.
+4. Press **Escape** to cancel and discard changes.
+
+You can also press the **Up arrow** key in an empty composer to quickly edit your last sent message.
+
+Edited messages display an "(edited)" indicator.
+
+## Deleting
+
+To delete your own message:
+
+1. Hover over the message and click the **Delete** button, or right-click and select **Delete**.
+2. Confirm the deletion.
+
+Admins may also be able to delete other users' messages depending on their permissions.
+
+## Drafts
+
+If you switch to a different channel before sending, your unfinished message is automatically saved as a draft. When you return to that channel, the draft is restored so you can continue where you left off.
+
+## Sending While Disconnected
+
+If you lose your connection, you can still type and send messages. They are queued locally and sent automatically once the connection is restored. A "Message queued" notice appears below the composer to let you know.
+
+## Typing Indicator
+
+When you're typing, other users in the channel see a typing indicator below the message list showing your name.

--- a/docs/navigation/spaces-and-channels.md
+++ b/docs/navigation/spaces-and-channels.md
@@ -1,0 +1,54 @@
+---
+title: Navigating Spaces and Channels
+description: Find your way around servers, spaces, channels, and categories.
+order: 1
+section: navigation
+---
+
+# Navigating Spaces and Channels
+
+daccord organizes conversations into **spaces** and **channels**, similar to other chat platforms.
+
+## The Space Bar
+
+The vertical icon strip on the far left is the **space bar**. It shows:
+
+- An icon for each space you belong to across all connected servers
+- A **DM** button at the top for direct messages
+- A **+** button to add new servers
+
+Click a space icon to switch to that space. The currently selected space is highlighted with a pill indicator.
+
+## Space Folders
+
+You can organize your spaces into collapsible folders:
+
+1. Right-click a space icon.
+2. Select **Add to Folder** and choose an existing folder, or create a new one.
+3. Folders appear as collapsible groups in the space bar. Click to expand or collapse.
+
+## Channels
+
+When you select a space, its channels appear in the **channel panel** to the right of the space bar. Channels come in several types:
+
+- **Text channels** -- for written conversations
+- **Voice channels** -- for real-time audio (and optionally video)
+- **Announcement channels** -- for important broadcasts
+- **Forum channels** -- for threaded discussions organized by topic
+
+## Categories
+
+Channels are grouped under **categories** -- collapsible section headers. Click a category name to expand or collapse it and show or hide its channels.
+
+## Tabs
+
+When you open a channel, it appears as a **tab** at the top of the message area. You can have multiple channels open at once:
+
+- Click a tab to switch to that channel.
+- Click the **x** on a tab to close it.
+- At least one tab is always open.
+- The tab bar is hidden when only one channel is open.
+
+## On Small Screens
+
+On narrow windows or mobile devices, the sidebar becomes a **drawer** that slides in from the left. Tap the hamburger menu button to open it, and tap outside to close it.

--- a/docs/self-hosting/deploying-a-server.md
+++ b/docs/self-hosting/deploying-a-server.md
@@ -1,0 +1,147 @@
+---
+title: Deploying a Server
+description: Set up and run your own always-on accordserver instance with Docker or from source.
+order: 3
+section: self-hosting
+---
+
+# Deploying a Server
+
+daccord connects to servers running [accordserver](https://github.com/DaccordProject/accordserver). You can host your own server to keep full control of your community's data.
+
+This guide covers running an always-on server with Docker (or from source) on a Linux machine or VPS — the right choice for a public or 24/7 community. If you just want to host for friends from your own computer, the [Accord desktop app](desktop-app.md) is far simpler. See the [Self-Hosting Overview](overview.md) to compare the two.
+
+## Requirements
+
+- A Linux machine or VPS (1 GB RAM minimum)
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose (recommended), or Rust 1.88+ to build from source
+- A domain name with DNS pointed at your server (for HTTPS)
+
+## Quick Start with Docker Compose
+
+This is the simplest way to get a server running. It includes accordserver, a LiveKit voice server, and a Caddy reverse proxy for automatic HTTPS.
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/DaccordProject/accordserver.git
+   cd accordserver
+   ```
+
+2. Create a `.env` file with your configuration:
+
+   ```bash
+   # Required -- replace with your actual domains
+   LIVEKIT_EXTERNAL_URL=wss://livekit.example.com
+   LIVEKIT_INTERNAL_URL=http://livekit:7880
+   LIVEKIT_API_KEY=your-api-key
+   LIVEKIT_API_SECRET=your-api-secret
+   ```
+
+3. Start the stack:
+
+   ```bash
+   docker compose up -d
+   ```
+
+The server listens on port **39099** by default. Caddy handles HTTPS termination automatically if your DNS is configured.
+
+## Using PostgreSQL (Recommended for Production)
+
+For production deployments, use the PostgreSQL compose file instead of the default SQLite backend:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+```
+
+This adds a PostgreSQL 17 database with persistent storage. Set the database connection in your `.env`:
+
+```bash
+DATABASE_URL=postgres://accord:your-password@postgres/accord
+```
+
+The server automatically creates the database and runs migrations on first startup.
+
+**Note:** Special characters in the PostgreSQL password must be URL-encoded (e.g., `!` becomes `%21`, `@` becomes `%40`).
+
+## Configuration Reference
+
+All configuration is done through environment variables.
+
+### Core
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `39099` | HTTP listen port |
+| `DATABASE_URL` | `sqlite:data/accord.db?mode=rwc` | Database connection string |
+| `ACCORD_STORAGE_PATH` | `./data/cdn` | Path for uploaded files and plugin bundles |
+| `RUST_LOG` | `accordserver=debug,tower_http=debug` | Log level filter |
+
+### Voice and Video (LiveKit)
+
+| Variable | Description |
+|----------|-------------|
+| `LIVEKIT_INTERNAL_URL` | Internal LiveKit URL (e.g., `http://livekit:7880`) |
+| `LIVEKIT_EXTERNAL_URL` | Public LiveKit URL that clients connect to (e.g., `wss://livekit.example.com`) |
+| `LIVEKIT_API_KEY` | LiveKit API key |
+| `LIVEKIT_API_SECRET` | LiveKit API secret |
+
+Voice and video features require all four LiveKit variables to be set. Without them, voice channels will not work.
+
+### Security
+
+| Variable | Description |
+|----------|-------------|
+| `TOTP_ENCRYPTION_KEY` | Encryption key for two-factor authentication secrets |
+| `MCP_API_KEY` | API key for the MCP management endpoint |
+
+### Master Server (Optional)
+
+Register your server with the daccord master server so users can discover it in the public server list.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MASTER_SERVER_PUBLIC_URL` | *(none)* | Your server's public URL (required to enable) |
+| `MASTER_SERVER_URL` | `https://master.daccord.gg` | Master server endpoint |
+| `MASTER_SERVER_NAME` | `Accord Server` | Display name in the server list |
+| `MASTER_HEARTBEAT_INTERVAL` | `60` | Heartbeat interval in seconds |
+
+## Building from Source
+
+If you prefer not to use Docker:
+
+```bash
+git clone https://github.com/DaccordProject/accordserver.git
+cd accordserver
+cargo build --release
+./target/release/accordserver
+```
+
+The server creates its SQLite database and data directory automatically on first run.
+
+## Ports
+
+Make sure the following ports are accessible:
+
+| Port | Service |
+|------|---------|
+| 39099 | accordserver (HTTP + WebSocket) |
+| 7880 | LiveKit (HTTP) |
+| 7881 | LiveKit (TCP) |
+| 7882/UDP | LiveKit (UDP, media) |
+| 443, 80 | Caddy reverse proxy (HTTPS) |
+
+## Connecting from daccord
+
+Once your server is running, open daccord and click the **+** button in the sidebar to add a new server. Enter your server's address (e.g., `chat.example.com` or `your-ip:39099`) and create an account.
+
+## Updating
+
+Pull the latest image and restart:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Migrations run automatically on startup, so the database schema is always kept up to date.

--- a/docs/self-hosting/desktop-app.md
+++ b/docs/self-hosting/desktop-app.md
@@ -1,0 +1,105 @@
+---
+title: Running Accord on Your Desktop
+description: Install the Accord desktop app to run your own server from your computer — no Docker, no command line, no configuration.
+order: 2
+section: self-hosting
+---
+
+# Running Accord on Your Desktop
+
+The **Accord desktop app** is the simplest way to host your own server. It is a small application that runs quietly in your system tray (or menu bar) and takes care of everything the server needs: it bundles `accordserver` and a LiveKit voice server, generates its own configuration the first time it runs, and updates itself in the background.
+
+There is no command line, no Docker, and nothing to configure. Install it, launch it, and your server is running.
+
+## Is the desktop app right for me?
+
+Use the desktop app when you want to run a server for yourself, friends, or a small community on a computer you already own. It is perfect for trying daccord out or for a home or LAN community. If you need a server that is online around the clock and reachable from anywhere, see [Deploying a Server](deploying-a-server.md) instead — and read the [Self-Hosting Overview](overview.md) for a side-by-side comparison.
+
+## Install
+
+Download the installer for your platform from the [accordserver releases page](https://github.com/DaccordProject/accordserver/releases/latest).
+
+| Platform | File |
+|----------|------|
+| macOS | `.dmg` |
+| Windows | `.msi` or `-setup.exe` (NSIS) |
+| Linux (Debian/Ubuntu) | `.deb` |
+| Linux (other) | `.AppImage` |
+
+Then install it the same way you would any other app:
+
+- **macOS** — open the `.dmg` and drag Accord to Applications.
+- **Windows** — run the installer. The NSIS (`-setup.exe`) build installs per-user and needs no administrator rights.
+- **Linux** — install the `.deb` with your package manager, or mark the `.AppImage` as executable and run it.
+
+> **First-launch security warnings:** current builds are not yet code-signed, so macOS Gatekeeper and Windows SmartScreen will warn you the first time. On macOS, right-click the app and choose **Open**. On Windows, click **More info → Run anyway**. This only happens once.
+
+## First launch
+
+Accord has no main window — when it starts, an icon appears in your system tray (Windows/Linux) or menu bar (macOS). On the very first launch it generates everything it needs in a data folder, including a random LiveKit voice key, a two-factor encryption key, and its default ports.
+
+Click the tray icon to open the menu:
+
+| Menu item | What it does |
+|-----------|--------------|
+| **Open in browser** | Opens `http://localhost:39099` — your running server |
+| **Open data folder** | Opens the folder holding your config, database, and logs |
+| **View logs** | Opens `accord.log` |
+| **Check for updates** | Shows update status; click to check now, or to restart and apply a staged update |
+| **Start on login** | Toggles whether Accord launches automatically when you sign in |
+| **Quit Accord** | Gracefully stops the server and voice server |
+
+## Connecting the daccord client
+
+With Accord running, open the daccord client, click the **+** button in the sidebar, and add a server.
+
+- **On the same computer:** use `localhost:39099`.
+- **From another device on your network:** use your computer's local IP address and port, for example `192.168.1.50:39099`.
+
+Create an account on your new server and you're in. See [Creating an Account](../getting-started/creating-an-account.md) and [Adding a Server](../getting-started/adding-a-server.md) for the client-side steps.
+
+## Inviting people from outside your network
+
+By default the server is reachable on your local network only. To let friends connect over the internet, forward these ports on your router to the computer running Accord:
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 39099 | TCP | Chat (HTTP + WebSocket) |
+| 7880, 7881 | TCP | LiveKit voice signaling |
+| 50000–60000 | UDP | LiveKit voice/video media |
+
+Then share your public IP address (and port `39099`) with the people you want to invite. If your home IP address changes over time, a dynamic-DNS hostname makes this easier.
+
+> If port-forwarding isn't an option, or you want a server that's always reachable, a full [server deployment](deploying-a-server.md) on a VPS is the better fit.
+
+## Where your data lives
+
+On first launch, Accord creates a data folder for your server:
+
+| Platform | Data folder |
+|----------|-------------|
+| macOS | `~/Library/Application Support/gg.daccord.Accord/` |
+| Linux | `$XDG_DATA_HOME/accord/` (usually `~/.local/share/accord/`) |
+| Windows | `%APPDATA%\Accord\Accord\` |
+
+Inside you'll find:
+
+- `config.toml` — generated ports and voice/security keys.
+- `livekit.yaml` — configuration for the bundled voice server.
+- `accord.db` — the SQLite database with your accounts, spaces, and messages.
+- `cdn/` — uploaded emoji, avatars, and file attachments.
+- `logs/` — `accord.log`, `livekit.log`, and the app's own `desktop.log`.
+
+**Backing up:** copy this folder while Accord is quit to back up your entire server. **Resetting:** delete the folder to start completely fresh. Keep it across reinstalls to preserve your community.
+
+## Automatic updates
+
+Accord keeps itself current. It checks for a new release shortly after launch and every few hours while it runs. When a newer signed version is available, it downloads in the background without interrupting your server. The update is applied the next time you restart the app — your running server keeps serving the old version until then.
+
+The tray menu reflects the progress (`Checking…`, `Downloading…`, `Update ready — restart to apply`), and a banner appears on the server's landing page while an update is downloading or ready. When an update is staged, choosing **Check for updates** restarts Accord to apply it.
+
+> **Linux note:** in-place automatic updates work for the `.AppImage` build. If you installed the `.deb`, update it through your package manager or by reinstalling. macOS and Windows builds update in place.
+
+## When to move to a full deployment
+
+The desktop app is ideal for getting started and for smaller communities, but it only serves while your computer is awake and online. When you outgrow it — you want guaranteed uptime, a real domain with HTTPS, PostgreSQL, or a listing in the public server browser — move to a [server deployment](deploying-a-server.md). Both run the same accordserver, so members reconnect to the new address and carry on.

--- a/docs/self-hosting/overview.md
+++ b/docs/self-hosting/overview.md
@@ -1,0 +1,57 @@
+---
+title: Self-Hosting Overview
+description: The two ways to run your own Accord server — the desktop app or a full server deployment — and how to choose between them.
+order: 1
+section: self-hosting
+---
+
+# Self-Hosting Overview
+
+daccord connects to servers running [accordserver](https://github.com/DaccordProject/accordserver). When you self-host, you run that server yourself, which means you keep full control of your community's data, accounts, uploads, and voice traffic. Nothing passes through a third party.
+
+There are two supported ways to host, depending on how much you want to manage.
+
+## Choose your path
+
+### Accord desktop app — the easy way
+
+The [Accord desktop app](desktop-app.md) is a small tray application you install like any other program (`.dmg`, `.deb`/`.AppImage`, or `.msi`). It bundles the server and the voice server together, generates all its own configuration on first launch, and keeps itself up to date. There is nothing to configure and no command line involved.
+
+This is the best choice if you want to:
+
+- Try self-hosting without touching Docker or a terminal.
+- Run a server for friends or family on a machine you already own.
+- Host a small community on a home computer or a spare desktop.
+
+The trade-off is that the server is only online while your computer is on, and letting people outside your home network connect requires a little router configuration.
+
+### Server deployment — the always-on way
+
+[Deploying a server](deploying-a-server.md) with Docker (or from source) on a Linux machine or VPS is the right choice for a community that needs to be reachable around the clock. You get automatic HTTPS, a choice of SQLite or PostgreSQL, and the ability to register your server in the public server list.
+
+This is the best choice if you want to:
+
+- Run a public or always-available community.
+- Use a real domain name with HTTPS.
+- Scale to many members on dedicated hardware or a cloud host.
+
+The trade-off is that you manage the host, DNS, and updates yourself.
+
+## At a glance
+
+| | Desktop app | Server deployment |
+|---|---|---|
+| Install effort | Run an installer | Docker / command line |
+| Configuration | Automatic | Environment variables |
+| Best for | Friends, small or home communities | Public or always-on communities |
+| Availability | While your computer is on | 24/7 |
+| HTTPS / domain | Optional (LAN by default) | Built in via Caddy |
+| Database | SQLite | SQLite or PostgreSQL |
+| Updates | Automatic, in the background | `docker compose pull` |
+| Voice & video | Bundled automatically | Bundled LiveKit |
+
+Both paths run the same accordserver, so you can start with the desktop app and move to a full deployment later without changing how the daccord client connects.
+
+## Connecting once you're hosting
+
+However you host, members connect the same way: open daccord, click the **+** button in the sidebar, and enter your server's address. See [Adding a Server](../getting-started/adding-a-server.md) for the client side.

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -1,0 +1,47 @@
+---
+title: Troubleshooting
+description: Solutions to common problems with daccord.
+order: 1
+section: troubleshooting
+---
+
+# Troubleshooting
+
+## Can't Connect to a Server
+
+- **Check the URL** -- Make sure you entered the server address correctly. It should look like `chat.example.com` or `chat.example.com:8443`.
+- **Server unreachable** -- The server may be down or behind a firewall. Contact the server admin.
+- **Wrong credentials** -- Double-check your username and password. Passwords are case-sensitive.
+
+## Connection Lost
+
+daccord automatically attempts to reconnect when the connection drops. If you see a disconnection banner:
+
+- Wait a moment for automatic reconnection.
+- Check your internet connection.
+- If the problem persists, right-click the space icon and select **Reconnect**.
+
+## No Sound in Voice Channels
+
+- Check that your microphone and speakers are selected in **App Settings > Voice & Video**.
+- Make sure you aren't muted or deafened (check the voice bar icons).
+- Ensure the server's voice backend (LiveKit) is running -- contact the server admin if voice isn't working for anyone.
+
+## Messages Not Loading
+
+- Check your connection status. A banner at the top of the message area indicates connection issues.
+- Try switching to another channel and back.
+- Right-click the space icon and select **Reconnect**.
+
+## App Won't Start
+
+- Make sure you're running a supported version for your operating system.
+- On Linux, verify the executable has the right permissions.
+- On macOS, right-click and choose "Open" to bypass Gatekeeper on first launch.
+- Try launching with `--profile default` to rule out a corrupted profile.
+
+## Reporting Issues
+
+If you encounter a bug, report it at the [daccord GitHub Issues page](https://github.com/DaccordProject/daccord/issues).
+
+daccord includes optional error reporting that sends crash data (with no personal information) to help developers fix issues. You can enable or disable this in App Settings.

--- a/docs/troubleshooting/keyboard-shortcuts.md
+++ b/docs/troubleshooting/keyboard-shortcuts.md
@@ -1,0 +1,29 @@
+---
+title: Keyboard Shortcuts
+description: Keyboard shortcuts for faster navigation in daccord.
+order: 2
+section: troubleshooting
+---
+
+# Keyboard Shortcuts
+
+## Messaging
+
+| Shortcut | Action |
+|----------|--------|
+| Enter | Send message |
+| Shift+Enter | New line in message |
+| Up Arrow | Edit your last message (when composer is empty) |
+| Escape | Cancel editing, close reply bar, or close search |
+| Ctrl+V / Cmd+V | Paste image or text from clipboard |
+
+## Editing a Message
+
+| Shortcut | Action |
+|----------|--------|
+| Enter | Save edited message |
+| Escape | Cancel edit and discard changes |
+
+## Mobile / Touch
+
+On Android and other touch devices, long-press a message to open the context menu (reply, edit, delete, react).

--- a/docs/voice-and-video/voice-channels.md
+++ b/docs/voice-and-video/voice-channels.md
@@ -1,0 +1,49 @@
+---
+title: Voice and Video
+description: Join voice channels for real-time audio and video conversations.
+order: 1
+section: voice-and-video
+---
+
+# Voice and Video
+
+Voice channels let you talk to other people in real time using your microphone, camera, or screen share.
+
+## Joining a Voice Channel
+
+1. In the channel list, click a **voice channel** (marked with a speaker icon).
+2. daccord connects you to the voice room.
+3. A **voice bar** appears at the bottom of the channel panel showing the channel name, a green status dot, and control buttons.
+
+Other participants in the channel are shown with their avatar, display name, and status indicators (muted, deafened, camera on, sharing screen).
+
+## Voice Controls
+
+The voice bar provides these controls:
+
+- **Mute** -- Toggle your microphone on/off
+- **Deafen** -- Mute all incoming audio (also mutes your mic)
+- **Camera** -- Toggle your camera on/off
+- **Screen Share** -- Share your screen or a specific window
+- **Soundboard** -- Play audio clips into the channel
+- **Settings** -- Open voice settings
+- **Disconnect** -- Leave the voice channel
+
+## Speaking Indicator
+
+When someone is speaking, a green ring appears around their avatar in the participant list.
+
+## Screen Sharing
+
+1. Click the **Screen Share** button in the voice bar.
+2. Choose which screen or window to share from the picker.
+3. Your screen share appears as a video tile for other participants.
+4. Click the button again to stop sharing.
+
+## Video
+
+Click the **Camera** button to share your camera feed. Other participants see your video as a tile in the voice channel view.
+
+## Voice Settings
+
+Access voice and video settings from the voice bar settings button or from **App Settings > Voice & Video**. Here you can configure your input/output devices and other audio preferences.


### PR DESCRIPTION
## Summary
- Restore the full `docs/` tree from `legacy-godot` — the migration had reduced it to only `MIGRATION.md`, which would have wiped every section the website build consumes.
- Expand self-hosting into three pages: a new **Overview** comparing the two hosting paths, a new **Running Accord on Your Desktop** guide for the Accord desktop app, and the existing **Deploying a Server** guide (reordered, cross-linked).
- Update `docs/index.md` to list all three self-hosting pages.

## Details
The website's `build-docs.js` reads markdown from this repo's `docs/` directory to generate `docs.html`. After the Godot→Flutter migration the docs were stripped down, breaking that pipeline. This restores the 18 unchanged pages (getting-started, messaging, voice-and-video, customization, administration, navigation, troubleshooting) plus README, and rewrites the self-hosting section around the new desktop hosting option.

## Test plan
- [ ] `npm run build:docs` in accordwebsite against this branch's `docs/` produces all sections without error
- [ ] Self-hosting pages render with correct sidebar icons and cross-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)