### PR TITLE
Fix custom emoji reactions rendering as literal name:id text

### DIFF
--- a/lib/features/events/utils/accord_event_handler.dart
+++ b/lib/features/events/utils/accord_event_handler.dart
@@ -10,6 +10,7 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
 import 'package:bonfire/features/messaging/controllers/typing.dart';
+import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:bonfire/features/notifications/controllers/notification.dart';
 import 'package:bonfire/features/notifications/controllers/sound.dart';
 import 'package:bonfire/features/notifications/utils/notification_gate.dart';
@@ -316,31 +317,32 @@ VoidCallback handleAccordEvents(
 
   // ── Reactions (per channel) ──────────────────────────────────────────────
   // Like messages, only mutate channels the UI has opened.
-  String emojiName(Map<String, dynamic> data) {
+  // The gateway echoes a reaction's emoji either as a map (`{name, id}`) or as
+  // a bare token — `name:id` for custom emoji, a glyph/shortcode otherwise. We
+  // split the token so the id survives; otherwise a custom reaction would be
+  // stored with id=null and a name of `name:id`, rendering as literal text and
+  // never matching the optimistic pill (leaving two pills for one reaction).
+  EmojiRef reactionEmoji(Map<String, dynamic> data) {
     final raw = data['emoji'];
-    if (raw is Map) return raw['name']?.toString() ?? '';
-    if (raw is String) return raw;
-    return '';
-  }
-
-  String? emojiId(Map<String, dynamic> data) {
-    final raw = data['emoji'];
-    if (raw is Map) return raw['id']?.toString();
-    return null;
+    if (raw is Map) {
+      return (name: raw['name']?.toString() ?? '', id: raw['id']?.toString());
+    }
+    if (raw is String) return parseEmojiToken(raw);
+    return (name: '', id: null);
   }
 
   void applyReactionEvent(Map<String, dynamic> data, {required bool added}) {
     if (!isActive()) return;
     final channelId = data['channel_id']?.toString();
     final messageId = data['message_id']?.toString();
-    final name = emojiName(data);
-    if (channelId == null || messageId == null || name.isEmpty) return;
+    final emoji = reactionEmoji(data);
+    if (channelId == null || messageId == null || emoji.name.isEmpty) return;
     if (!activeMessageChannels.contains(channelId)) return;
     final isOwn = data['user_id']?.toString() == currentUserId;
     container
         .read(accordMessagesControllerProvider(channelId).notifier)
-        .applyReaction(messageId, name,
-            added: added, isOwn: isOwn, emojiId: emojiId(data));
+        .applyReaction(messageId, emoji.name,
+            added: added, isOwn: isOwn, emojiId: emoji.id);
   }
 
   subs.add(client.onReactionAdd.listen((d) => applyReactionEvent(d, added: true)));
@@ -360,7 +362,7 @@ VoidCallback handleAccordEvents(
     if (!isActive()) return;
     final channelId = data['channel_id']?.toString();
     final messageId = data['message_id']?.toString();
-    final name = emojiName(data);
+    final name = reactionEmoji(data).name;
     if (channelId == null || messageId == null || name.isEmpty) return;
     if (!activeMessageChannels.contains(channelId)) return;
     container

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -1,6 +1,7 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -424,5 +425,13 @@ class AccordMessagesController extends _$AccordMessagesController {
     state = [...current];
   }
 
-  String _emojiName(AccordReaction r) => r.emoji['name']?.toString() ?? '';
+  // Dedup/match key for a reaction. Custom emoji may arrive with the id baked
+  // into the name (`name:id`) when the source didn't split it; strip it so a
+  // gateway echo and a REST-loaded reaction for the same emoji collapse to one.
+  String _emojiName(AccordReaction r) {
+    final name = r.emoji['name']?.toString() ?? '';
+    final id = r.emoji['id']?.toString();
+    if (id != null && id.isNotEmpty) return name;
+    return parseEmojiToken(name).name;
+  }
 }

--- a/lib/features/messaging/utils/emoji_catalog.dart
+++ b/lib/features/messaging/utils/emoji_catalog.dart
@@ -364,6 +364,28 @@ final Map<String, String> _emojiByName = {
   for (final e in kEmojiCatalog) e.name: e.char,
 };
 
+/// A reaction emoji's identity: a [name] (unicode shortcode or custom-emoji
+/// name) plus an optional custom-emoji [id].
+typedef EmojiRef = ({String name, String? id});
+
+/// Splits an emoji reference into its name and optional custom-emoji id.
+///
+/// Custom emoji travel as `name:id` (id a numeric snowflake) in REST tokens and
+/// in gateway reaction echoes, while unicode emoji arrive as a bare glyph or
+/// shortcode. Recovering the id lets the UI load the image instead of rendering
+/// `name:id` as literal text. A trailing `:` (the colon-wrapped shortcode form
+/// `:hamburger:`) or any non-numeric tail is left untouched as part of [name].
+EmojiRef parseEmojiToken(String value) {
+  final i = value.lastIndexOf(':');
+  if (i > 0 && i < value.length - 1) {
+    final id = value.substring(i + 1);
+    if (id.codeUnits.every((c) => c >= 0x30 && c <= 0x39)) {
+      return (name: value.substring(0, i), id: id);
+    }
+  }
+  return (name: value, id: null);
+}
+
 /// Resolves a unicode-emoji reference to its glyph. [value] may already be the
 /// glyph (returned as-is), a bare shortcode (`hamburger`), or a colon-wrapped
 /// shortcode (`:hamburger:`). Falls back to [value] when the shortcode isn't in

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -914,8 +914,13 @@ class _ReactionPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
-    final name = reaction.emoji['name']?.toString() ?? '';
-    final id = reaction.emoji['id']?.toString();
+    final rawName = reaction.emoji['name']?.toString() ?? '';
+    final rawId = reaction.emoji['id']?.toString();
+    // A custom emoji whose source didn't split it arrives as name=`name:id`,
+    // id=null; recover the id so we render the image instead of literal text.
+    final parsed = parseEmojiToken(rawName);
+    final id = rawId ?? parsed.id;
+    final name = rawId != null ? rawName : parsed.name;
     final mine = reaction.includesMe;
     return Material(
       color: mine ? colors.primary.withValues(alpha: 0.25) : colors.darkGray,


### PR DESCRIPTION
## Summary

Adding a reaction with a **custom emoji** rendered the chip as raw text — e.g. `cube2:323038910819074048` — and produced a *second* pill alongside the correct one.

Custom emoji travel from the Accord gateway as the bare token `name:id` (id a numeric snowflake). The reaction handler stored the whole string as the emoji `name` with a `null` id, so the pill took the unicode-glyph branch and printed the token verbatim. It also never matched the optimistic local pill (name `cube2`), so one reaction showed as two pills.

## Changes

- **`emoji_catalog.dart`** — add `parseEmojiToken()` / `EmojiRef`, which splits the `name:id` custom form (trailing all-digit segment) and leaves unicode glyphs/shortcodes untouched.
- **`accord_event_handler.dart`** — parse the gateway reaction token so the live reaction is stored with the correct `name` + `id`. This is the primary fix: the image renders **and** the pill merges with the optimistic one.
- **`accord_messages.dart`** / **`accord_home_message_row.dart`** — harden the dedup key and the renderer to recover an id baked into the name, so reactions loaded via REST (message history) render correctly as well.

Companion fix at the SDK source (`AccordReaction.fromJson`) is in DaccordProject/accordkit-dart — the two are complementary: the SDK fix covers REST-loaded reactions, this repo's handler fix covers live gateway echoes (raw JSON that never passes through `fromJson`).

## Test plan

- [x] `flutter analyze --no-fatal-infos` — clean
- [x] `flutter test` — 129 passing
- [ ] Manual: add a custom-emoji reaction on a live server → single pill, image renders (couldn't verify without a running server + the custom emoji)

🤖 Generated with [Claude Code](https://claude.com/claude-code)