### PR TITLE
chore: vendor accordkit SDK in-tree at packages/accordkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The Accord server backend is [`accordserver`](https://github.com/DaccordProject/
 - **Models / serialization:** primarily provided by `accordkit` (`Accord*` types). Client-side models use `json_serializable`; `freezed_annotation` is still a dependency but no `*.freezed.dart` files are generated in `lib/`.
 - **Routing:** `go_router`.
 - **Local storage:** `hive_ce` — boxes opened in `setupHive()`: `auth`, `last-location`, `added-accounts`, `accord-session`, `accord-settings`.
-- **Networking:** `accordkit` (git dependency). **The firebridge → accordkit swap is complete** — `packages/firebridge` and `firebridge_extensions` no longer exist and nothing in `lib/` imports them (a few doc comments still mention "firebridge" to describe what a controller replaced). Do not try to re-add firebridge.
+- **Networking:** `accordkit` (vendored in-tree at `packages/accordkit`, maintained here). **The firebridge → accordkit swap is complete** — `packages/firebridge` and `firebridge_extensions` no longer exist and nothing in `lib/` imports them (a few doc comments still mention "firebridge" to describe what a controller replaced). Do not try to re-add firebridge.
 - **Voice/video/screen share:** `livekit_client` (a local fork at `packages/livekit_client`, see #68) over WebRTC; credentials fetched via accordkit's `client.voice`. See `lib/features/voice/`.
 - **Media:** `media_kit` (+ `media_kit_video`, `video_player_media_kit`, pinned git forks) / `cached_network_image` / `file_picker` — re-point CDN URLs at the Accord server.
 - **Code generation is required during development:** `dart run build_runner watch -d`.
@@ -51,6 +51,7 @@ lib/
   router/          # go_router config
   main.dart        # startup: media_kit, Hive, ProviderScope, ProfileGate, deep links
 packages/
+  accordkit/       # Accord protocol SDK (REST + gateway + models) — networking layer, maintained here
   livekit_client/  # local fork of livekit_client 2.8.0 (#68 native-release fix) — voice transport
   markdown_viewer/ # custom markdown rendering — protocol-agnostic, KEEP
 docs/              # product + technical specs (see below)
@@ -82,14 +83,15 @@ Bonfire's code uses Discord vocabulary; Accord uses similar-but-distinct terms. 
 
 ## AccordKit-Dart: the new networking layer
 
-Add as a git dependency in `pubspec.yaml`:
+Vendored in-tree and wired via a path dependency in `pubspec.yaml`:
 
 ```yaml
 dependencies:
   accordkit:
-    git:
-      url: https://github.com/DaccordProject/accordkit-dart
+    path: packages/accordkit
 ```
+
+The SDK source now lives at `packages/accordkit` and is maintained in this repo (no longer a git dependency on `DaccordProject/accordkit-dart`). Edit it directly here.
 
 Entry point is `AccordClient` (`package:accordkit/accordkit.dart`):
 
@@ -137,7 +139,7 @@ CI lives in `.github/workflows/` and is Daccord-native (no OpenBonfire infra):
 
 The Discord → Accord migration is **essentially complete**: firebridge is gone, all 50+ feature files use `accordkit`, auth/spaces/channels/messaging/members/roles/voice are implemented, and there are no Discord/Firebase code paths left. Remaining work is **feature-parity polish** against the Godot `daccord` client (reactions, emojis, search, admin edge cases) rather than the wholesale swap.
 
-When in doubt about Accord behaviour, read `../accordkit-dart` (the SDK source) and `../daccord` (the reference client's scenes/scripts).
+When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SDK source) and `../daccord` (the reference client's scenes/scripts).
 
 ## Conventions
 

--- a/packages/accordkit/.gitignore
+++ b/packages/accordkit/.gitignore
@@ -1,0 +1,14 @@
+# Dart / Pub
+.dart_tool/
+.packages
+build/
+pubspec.lock
+doc/api/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# OS
+.DS_Store

--- a/packages/accordkit/CHANGELOG.md
+++ b/packages/accordkit/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 2.0.0
+
+- Initial Dart release. Port of the GDScript AccordKit addon.
+- REST client with all endpoint groups (users, spaces, channels, messages,
+  members, roles, bans, reports, invites, emojis, soundboard, reactions,
+  interactions, plugins, applications, auth, voice, audit logs, admin,
+  directory).
+- Gateway WebSocket client with IDENTIFY/RESUME handshake, heartbeating,
+  automatic reconnect with backoff, and typed event streams.
+- Data models with `fromJson`/`toJson`.
+- Voice manager, CDN/snowflake/permission/intent helpers, multipart uploads,
+  and cursor pagination.

--- a/packages/accordkit/CLAUDE.md
+++ b/packages/accordkit/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What this is
+
+`accordkit` is a Dart library — an Accord protocol client (REST + gateway
+WebSocket + models). It is a faithful port of the GDScript `accordkit` addon
+that ships with Daccord. The Dart and GDScript implementations should stay
+behaviourally aligned: same endpoints, same wire payloads, same event names,
+same parsing quirks.
+
+When in doubt about intended behaviour, the reference is the GDScript source at
+`daccord/addons/accordkit/` in the main Daccord repo.
+
+## Layout
+
+```
+lib/
+  accordkit.dart                 # barrel: exports the public API
+  src/
+    core/
+      accord_config.dart         # URLs + protocol constants
+      accord_client.dart         # top-level façade; owns rest + gateway + APIs
+    rest/
+      accord_rest.dart           # HTTP client: requests, envelope parsing, 429 retry
+      accord_error.dart          # AccordError
+      rest_result.dart           # RestResult (ok/data/error/cursor)
+      endpoint_base.dart         # base class for endpoint groups
+      multipart_form.dart        # multipart/form-data builder
+      paginator.dart             # cursor pagination
+      endpoints/*.dart           # one class per endpoint group
+    gateway/
+      gateway_opcodes.dart       # opcode constants
+      gateway_intents.dart       # intent constants + groupings
+      gateway_connection.dart    # GatewayConnection abstraction + WS impl
+      gateway_events.dart        # DisconnectInfo / ReconnectInfo / RawGatewayEvent
+      gateway_socket.dart        # handshake, heartbeat, reconnect, dispatch
+    voice/
+      voice_manager.dart         # voice REST + gateway glue
+    models/*.dart                # data models (fromJson / toJson)
+    utils/
+      json_utils.dart            # lenient coercion helpers (asString/asInt/...)
+      cdn.dart                   # CDN URL builders
+      snowflake.dart             # snowflake decode/encode
+test/
+  support/                       # test helpers (mock REST, fake gateway connection)
+  *_test.dart
+example/
+```
+
+## Conventions
+
+- **Naming.** GDScript `snake_case` members become Dart `camelCase`; classes
+  keep their `Accord*` names. JSON keys on the wire stay `snake_case` — only the
+  Dart-side field names are camelCased.
+- **Lenient parsing.** Server fields can arrive as ints or strings (snowflakes
+  especially). Always parse through the helpers in `utils/json_utils.dart`
+  (`asString`, `asStringOrNull`, `asInt`, `asDouble`, `asBool`, `asMap`,
+  `asList`) rather than casting directly.
+- **`toJson` omits nulls.** Optional fields are only included when non-null,
+  matching the GDScript `to_dict()` behaviour. Round-trip tests rely on this.
+- **REST results.** Endpoint methods return `RestResult`. Use
+  `result.deserialize(Model.fromJson)` for single objects and
+  `result.deserializeArray(Model.fromJson)` for lists. Don't throw on HTTP
+  errors — surface them via `RestResult.error`.
+- **Gateway events.** Each event is a broadcast `Stream` getter named
+  `on<Event>`. Typed events carry models; structural events carry
+  `Map<String, dynamic>`. Every event is also emitted on `onRawEvent`.
+
+## Testability (important)
+
+The library must be unit-testable without real network access:
+
+- `AccordRest` takes an injectable `http.Client` and a `sleep` callback (so
+  rate-limit retries don't actually wait). Tests use
+  `package:http/testing.dart`'s `MockClient`.
+- `GatewaySocket` takes a `GatewayConnectionFactory`, a `sleep` callback, and a
+  `random` callback. Tests inject `FakeGatewayConnection`
+  (`test/support/fake_gateway_connection.dart`) to drive frames and simulate
+  closes deterministically.
+
+When adding features, preserve these seams. Don't call `DateTime.now()`,
+`Random()`, real timers, or real sockets directly in logic that needs testing —
+thread them through constructor parameters.
+
+## Commands
+
+```bash
+dart pub get        # resolve dependencies
+dart analyze        # must be clean (lints in analysis_options.yaml)
+dart test           # run the suite
+dart test test/gateway_test.dart   # a single file
+```
+
+CI expectations: `dart analyze` reports no issues and `dart test` is green.
+
+## When adding an endpoint
+
+1. Add the method to the relevant `src/rest/endpoints/*_api.dart` class
+   (create a new class + wire it into `AccordClient` and the barrel if it's a
+   new group).
+2. Match the GDScript path, HTTP method, body shape, and deserialization.
+3. Add a test in `test/endpoints_test.dart` asserting method, path, body, and
+   the deserialized type using `mockRest`.
+
+## When adding a gateway event
+
+1. Add a controller + `on<Event>` getter in `gateway_socket.dart`.
+2. Add the `case` in `_dispatchEvent` using the exact server event-type string.
+3. Forward the getter on `AccordClient`.
+4. Add a dispatch test in `test/gateway_test.dart`.

--- a/packages/accordkit/LICENSE
+++ b/packages/accordkit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Daccord Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/accordkit/README.md
+++ b/packages/accordkit/README.md
@@ -1,0 +1,192 @@
+# AccordKit for Dart
+
+[![Dart](https://img.shields.io/badge/Dart-3.0%2B-0175C2?logo=dart)](https://dart.dev)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+An [Accord protocol](https://daccord.gg) client library for Dart. AccordKit
+gives you a typed REST client, a resilient gateway WebSocket client (with
+automatic heartbeating, resume, and reconnect), and data models for building
+bots, tools, and apps against [Daccord](https://daccord.gg) servers.
+
+This is a Dart port of the GDScript `accordkit` addon and tracks the same API
+surface and wire behaviour.
+
+## Features
+
+- **REST client** covering every endpoint group: users, spaces, channels,
+  messages, members, roles, bans, reports, invites, emojis, soundboard,
+  reactions, interactions, plugins, applications, auth, voice, audit logs,
+  admin, and the master-server directory.
+- **Gateway client** with IDENTIFY/RESUME handshake, heartbeating, exponential
+  backoff reconnect, and ~50 typed event streams.
+- **Typed models** with lenient JSON parsing (`fromJson`) and `toJson`.
+- **Voice manager** that ties the voice REST endpoints to gateway voice events.
+- **Helpers** for snowflakes, CDN URLs, permissions, intents, multipart
+  uploads, and cursor pagination.
+- **Testable by design** — inject an `http.Client` for REST and a connection
+  factory for the gateway.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  accordkit:
+    git:
+      url: https://github.com/DaccordProject/accordkit-dart.git
+```
+
+Then run `dart pub get` (or `flutter pub get`).
+
+## Quick start
+
+```dart
+import 'package:accordkit/accordkit.dart';
+
+Future<void> main() async {
+  final client = AccordClient(
+    token: 'YOUR_BOT_TOKEN',
+    tokenType: 'Bot',
+    baseUrl: 'https://your.daccord.server',
+    gatewayUrl: 'wss://your.daccord.server/ws',
+    intents: [
+      GatewayIntents.spaces,
+      GatewayIntents.messages,
+      GatewayIntents.messageContent,
+    ],
+  );
+
+  client.onMessageCreate.listen((message) async {
+    if (message.content == '!ping') {
+      await client.messages.create(message.channelId, {'content': 'pong'});
+    }
+  });
+
+  client.login();
+}
+```
+
+See [`example/accordkit_example.dart`](example/accordkit_example.dart) for a
+complete sample.
+
+## REST
+
+Every endpoint group hangs off `AccordClient`, and every call returns a
+`RestResult`:
+
+```dart
+final result = await client.spaces.fetch('space_id');
+if (result.ok) {
+  final space = result.data as AccordSpace;
+  print(space.name);
+} else {
+  print('Error: ${result.error}'); // AccordError(code, message)
+}
+```
+
+`RestResult.data` is the deserialized model (or list of models) on success, and
+`RestResult.error` is an `AccordError` on failure. Cursor-paginated endpoints
+expose `RestResult.hasMore` and `RestResult.cursor`; wrap them with
+`AccordPaginator` to page through results:
+
+```dart
+final first = await client.messages.list('channel_id', query: {'limit': 50});
+var page = AccordPaginator.fromResult(
+  first, client.rest, '/channels/channel_id/messages', {'limit': 50},
+  fromJson: AccordMessage.fromJson,
+);
+while (page.hasMore) {
+  page = await page.next();
+}
+```
+
+### File uploads
+
+```dart
+await client.messages.createWithAttachments(
+  'channel_id',
+  {'content': 'Here is a file'},
+  [
+    {
+      'filename': 'image.png',
+      'content': bytes,            // List<int> / Uint8List
+      'content_type': 'image/png',
+    },
+  ],
+);
+```
+
+## Gateway events
+
+Subscribe to typed broadcast streams on the client (or on `client.gateway`):
+
+```dart
+client.onReady.listen((data) => print('session ${data['session_id']}'));
+client.onMessageCreate.listen((m) => print('${m.authorId}: ${m.content}'));
+client.onPresenceUpdate.listen((p) => print('${p.userId} is ${p.status}'));
+
+// Catch-all for any event:
+client.onRawEvent.listen((e) => print('event ${e.type}'));
+```
+
+Lifecycle and presence:
+
+```dart
+client.login();                       // open the gateway
+client.updatePresence('online', activity: {'name': 'a game'});
+await client.logout();                // close the gateway
+```
+
+The gateway reconnects automatically with exponential backoff and resumes the
+session when possible. Fatal close codes (e.g. authentication failures) stop
+reconnection.
+
+## Voice
+
+```dart
+final vm = client.voiceManager;
+vm.onVoiceConnected.listen((info) => print('joined ${info.channelId}'));
+vm.onVoiceDisconnected.listen((channelId) => print('left $channelId'));
+
+await vm.join('voice_channel_id', selfMute: false);
+await vm.leave();
+```
+
+## Helpers
+
+```dart
+// Snowflakes
+final created = AccordSnowflake.decodeToDateTime(message.id);
+
+// CDN URLs
+final url = AccordCDN.avatar(user.id, user.avatar!, cdnUrl: client.config.cdnUrl);
+
+// Permissions
+if (AccordPermission.has(member.roles, AccordPermission.banMembers)) { /* ... */ }
+```
+
+## Testing your integration
+
+The REST client accepts any `http.Client`, and the gateway accepts a
+connection factory, so you can test without real network access:
+
+```dart
+final client = AccordClient(
+  token: 'tok',
+  httpClient: myMockHttpClient,        // package:http/testing.dart MockClient
+  connectionFactory: myFakeConnection, // GatewayConnection factory
+);
+```
+
+## Development
+
+```bash
+dart pub get
+dart analyze
+dart test
+```
+
+## License
+
+[MIT](LICENSE) © Daccord Project

--- a/packages/accordkit/analysis_options.yaml
+++ b/packages/accordkit/analysis_options.yaml
@@ -1,0 +1,12 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - prefer_final_locals
+    - avoid_print
+    - prefer_single_quotes

--- a/packages/accordkit/example/accordkit_example.dart
+++ b/packages/accordkit/example/accordkit_example.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: avoid_print
+import 'package:accordkit/accordkit.dart';
+
+/// A minimal echo bot: connects to the gateway and replies "pong" to "!ping".
+Future<void> main() async {
+  final client = AccordClient(
+    token: 'YOUR_BOT_TOKEN',
+    tokenType: 'Bot',
+    baseUrl: 'https://your.daccord.server',
+    gatewayUrl: 'wss://your.daccord.server/ws',
+    intents: [
+      GatewayIntents.spaces,
+      GatewayIntents.messages,
+      GatewayIntents.messageContent,
+    ],
+  );
+
+  client.onReady.listen((data) {
+    print('Ready! session=${data['session_id']}');
+  });
+
+  client.onMessageCreate.listen((message) async {
+    if (message.content == '!ping') {
+      await client.messages.create(message.channelId, {'content': 'pong'});
+    }
+  });
+
+  client.onDisconnected.listen((info) {
+    print('Disconnected: ${info.code} ${info.reason}');
+  });
+
+  client.login();
+
+  // A REST call works independently of the gateway:
+  final me = await client.users.getMe();
+  if (me.ok) {
+    print('Logged in as ${(me.data as AccordUser).username}');
+  } else {
+    print('Failed to fetch self: ${me.error}');
+  }
+}

--- a/packages/accordkit/lib/accordkit.dart
+++ b/packages/accordkit/lib/accordkit.dart
@@ -1,0 +1,79 @@
+/// AccordKit — an Accord protocol client for Dart.
+///
+/// Provides a REST client, a gateway WebSocket client with reconnect and
+/// heartbeating, and data models for working with Daccord servers.
+library;
+
+// Core
+export 'src/core/accord_client.dart';
+export 'src/core/accord_config.dart';
+
+// REST
+export 'src/rest/accord_error.dart';
+export 'src/rest/accord_rest.dart';
+export 'src/rest/endpoint_base.dart';
+export 'src/rest/multipart_form.dart';
+export 'src/rest/paginator.dart';
+export 'src/rest/rest_result.dart';
+
+// REST endpoints
+export 'src/rest/endpoints/admin_api.dart';
+export 'src/rest/endpoints/applications_api.dart';
+export 'src/rest/endpoints/audit_logs_api.dart';
+export 'src/rest/endpoints/auth_api.dart';
+export 'src/rest/endpoints/bans_api.dart';
+export 'src/rest/endpoints/channels_api.dart';
+export 'src/rest/endpoints/directory_api.dart';
+export 'src/rest/endpoints/emojis_api.dart';
+export 'src/rest/endpoints/interactions_api.dart';
+export 'src/rest/endpoints/invites_api.dart';
+export 'src/rest/endpoints/members_api.dart';
+export 'src/rest/endpoints/messages_api.dart';
+export 'src/rest/endpoints/plugins_api.dart';
+export 'src/rest/endpoints/reactions_api.dart';
+export 'src/rest/endpoints/reports_api.dart';
+export 'src/rest/endpoints/roles_api.dart';
+export 'src/rest/endpoints/soundboard_api.dart';
+export 'src/rest/endpoints/spaces_api.dart';
+export 'src/rest/endpoints/users_api.dart';
+export 'src/rest/endpoints/voice_api.dart';
+
+// Gateway
+export 'src/gateway/gateway_connection.dart';
+export 'src/gateway/gateway_events.dart';
+export 'src/gateway/gateway_intents.dart';
+export 'src/gateway/gateway_opcodes.dart';
+export 'src/gateway/gateway_socket.dart';
+
+// Voice
+export 'src/voice/voice_manager.dart';
+
+// Models
+export 'src/models/accord_relationship.dart';
+export 'src/models/activity.dart';
+export 'src/models/application.dart';
+export 'src/models/attachment.dart';
+export 'src/models/audit_log_entry.dart';
+export 'src/models/channel.dart';
+export 'src/models/command.dart';
+export 'src/models/embed.dart';
+export 'src/models/emoji.dart';
+export 'src/models/interaction.dart';
+export 'src/models/invite.dart';
+export 'src/models/member.dart';
+export 'src/models/message.dart';
+export 'src/models/permission.dart';
+export 'src/models/permission_overwrite.dart';
+export 'src/models/plugin_manifest.dart';
+export 'src/models/presence.dart';
+export 'src/models/reaction.dart';
+export 'src/models/role.dart';
+export 'src/models/sound.dart';
+export 'src/models/space.dart';
+export 'src/models/user.dart';
+export 'src/models/voice_server_update.dart';
+export 'src/models/voice_state.dart';
+
+// Utils
+export 'src/utils/cdn.dart';
+export 'src/utils/snowflake.dart';

--- a/packages/accordkit/lib/src/core/accord_client.dart
+++ b/packages/accordkit/lib/src/core/accord_client.dart
@@ -1,0 +1,277 @@
+import 'package:http/http.dart' as http;
+
+import '../gateway/gateway_connection.dart';
+import '../gateway/gateway_events.dart';
+import '../gateway/gateway_socket.dart';
+import '../models/accord_relationship.dart';
+import '../models/channel.dart';
+import '../models/interaction.dart';
+import '../models/invite.dart';
+import '../models/member.dart';
+import '../models/message.dart';
+import '../models/presence.dart';
+import '../models/sound.dart';
+import '../models/space.dart';
+import '../models/user.dart';
+import '../models/voice_server_update.dart';
+import '../models/voice_state.dart';
+import '../rest/accord_rest.dart';
+import '../rest/endpoints/admin_api.dart';
+import '../rest/endpoints/applications_api.dart';
+import '../rest/endpoints/audit_logs_api.dart';
+import '../rest/endpoints/auth_api.dart';
+import '../rest/endpoints/bans_api.dart';
+import '../rest/endpoints/channels_api.dart';
+import '../rest/endpoints/directory_api.dart';
+import '../rest/endpoints/emojis_api.dart';
+import '../rest/endpoints/interactions_api.dart';
+import '../rest/endpoints/invites_api.dart';
+import '../rest/endpoints/members_api.dart';
+import '../rest/endpoints/messages_api.dart';
+import '../rest/endpoints/plugins_api.dart';
+import '../rest/endpoints/reactions_api.dart';
+import '../rest/endpoints/reports_api.dart';
+import '../rest/endpoints/roles_api.dart';
+import '../rest/endpoints/soundboard_api.dart';
+import '../rest/endpoints/spaces_api.dart';
+import '../rest/endpoints/users_api.dart';
+import '../rest/endpoints/voice_api.dart';
+import '../voice/voice_manager.dart';
+import 'accord_config.dart';
+
+/// The top-level AccordKit entry point. Bundles the REST client, the gateway
+/// socket, every namespaced endpoint API, and the voice manager.
+///
+/// Gateway events are exposed both via the [gateway] field and as forwarding
+/// getters on the client itself (e.g. [onMessageCreate]).
+class AccordClient {
+  String token;
+  String tokenType;
+  List<String> intents;
+
+  final AccordConfig config;
+  late final AccordRest rest;
+  late final GatewaySocket gateway;
+
+  // Namespaced endpoint APIs.
+  late final UsersApi users;
+  late final SpacesApi spaces;
+  late final ChannelsApi channels;
+  late final MessagesApi messages;
+  late final MembersApi members;
+  late final RolesApi roles;
+  late final BansApi bans;
+  late final ReportsApi reports;
+  late final InvitesApi invites;
+  late final EmojisApi emojis;
+  late final SoundboardApi soundboard;
+  late final ReactionsApi reactions;
+  late final InteractionsApi interactions;
+  late final PluginsApi plugins;
+  late final ApplicationsApi applications;
+  late final AuthApi auth;
+  late final VoiceApi voice;
+  late final AuditLogsApi auditLogs;
+  late final AdminApi adminApi;
+  late final DirectoryApi directory;
+  late final VoiceManager voiceManager;
+
+  AccordClient({
+    this.token = '',
+    this.tokenType = 'Bot',
+    List<String>? intents,
+    String? baseUrl,
+    String? gatewayUrl,
+    String? cdnUrl,
+    http.Client? httpClient,
+    GatewayConnectionFactory? connectionFactory,
+    Future<void> Function(Duration)? sleep,
+  })  : intents = intents ?? [],
+        config = AccordConfig(
+          baseUrl: baseUrl ?? AccordConfig.defaultBaseUrl,
+          gatewayUrl: gatewayUrl ?? AccordConfig.defaultGatewayUrl,
+          cdnUrl: cdnUrl ?? AccordConfig.defaultCdnUrl,
+        ) {
+    rest = AccordRest(
+      config.apiUrl(),
+      token: token,
+      tokenType: tokenType,
+      client: httpClient,
+      sleep: sleep,
+    );
+
+    users = UsersApi(rest);
+    spaces = SpacesApi(rest);
+    channels = ChannelsApi(rest);
+    messages = MessagesApi(rest);
+    members = MembersApi(rest);
+    roles = RolesApi(rest);
+    bans = BansApi(rest);
+    reports = ReportsApi(rest);
+    invites = InvitesApi(rest);
+    emojis = EmojisApi(rest);
+    soundboard = SoundboardApi(rest);
+    reactions = ReactionsApi(rest);
+    interactions = InteractionsApi(rest);
+    plugins = PluginsApi(rest);
+    applications = ApplicationsApi(rest);
+    auth = AuthApi(rest);
+    voice = VoiceApi(rest);
+    auditLogs = AuditLogsApi(rest);
+    adminApi = AdminApi(rest);
+    directory = DirectoryApi(rest);
+
+    gateway = GatewaySocket(
+      connectionFactory: connectionFactory,
+      sleep: sleep,
+    );
+    gateway.setup(config, token, tknType: tokenType, intentList: this.intents);
+
+    voiceManager = VoiceManager(voice, gateway);
+  }
+
+  /// Opens the gateway connection.
+  void login() => gateway.connectToGateway();
+
+  /// Closes the gateway connection.
+  Future<void> logout() => gateway.disconnectFromGateway();
+
+  /// Sends a presence update through the gateway.
+  void updatePresence(String status,
+          {Map<String, dynamic> activity = const {}}) =>
+      gateway.updatePresence(status, activity: activity);
+
+  /// Sends a voice state update through the gateway.
+  void updateVoiceState(
+    String spaceId,
+    String? channelId, {
+    bool selfMute = false,
+    bool selfDeaf = false,
+    bool selfVideo = false,
+    bool selfStream = false,
+  }) =>
+      gateway.updateVoiceState(
+        spaceId,
+        channelId,
+        selfMute: selfMute,
+        selfDeaf: selfDeaf,
+        selfVideo: selfVideo,
+        selfStream: selfStream,
+      );
+
+  /// Requests the member list for a space through the gateway.
+  void requestMembers(String spaceId, {String query = '', int limit = 0}) =>
+      gateway.requestMembers(spaceId, query: query, limit: limit);
+
+  /// Sends a voice signalling payload through the gateway.
+  void sendVoiceSignal(String spaceId, String channelId, String signalType,
+          Map<String, dynamic> payload) =>
+      gateway.sendVoiceSignal(spaceId, channelId, signalType, payload);
+
+  /// Releases the REST client, gateway, and voice manager.
+  Future<void> dispose() async {
+    await voiceManager.dispose();
+    await gateway.dispose();
+    rest.close();
+  }
+
+  // ── Forwarded gateway event streams ──────────────────────────────────────
+
+  Stream<void> get onConnected => gateway.onConnected;
+  Stream<DisconnectInfo> get onDisconnected => gateway.onDisconnected;
+  Stream<ReconnectInfo> get onReconnecting => gateway.onReconnecting;
+  Stream<Map<String, dynamic>> get onReady => gateway.onReady;
+  Stream<void> get onResumed => gateway.onResumed;
+
+  Stream<AccordSpace> get onSpaceCreate => gateway.onSpaceCreate;
+  Stream<AccordSpace> get onSpaceUpdate => gateway.onSpaceUpdate;
+  Stream<Map<String, dynamic>> get onSpaceDelete => gateway.onSpaceDelete;
+
+  Stream<AccordChannel> get onChannelCreate => gateway.onChannelCreate;
+  Stream<AccordChannel> get onChannelUpdate => gateway.onChannelUpdate;
+  Stream<AccordChannel> get onChannelDelete => gateway.onChannelDelete;
+  Stream<Map<String, dynamic>> get onChannelReorder => gateway.onChannelReorder;
+  Stream<Map<String, dynamic>> get onChannelPinsUpdate =>
+      gateway.onChannelPinsUpdate;
+  Stream<Map<String, dynamic>> get onChannelMuteCreate =>
+      gateway.onChannelMuteCreate;
+  Stream<Map<String, dynamic>> get onChannelMuteDelete =>
+      gateway.onChannelMuteDelete;
+
+  Stream<AccordMember> get onMemberJoin => gateway.onMemberJoin;
+  Stream<Map<String, dynamic>> get onMemberLeave => gateway.onMemberLeave;
+  Stream<AccordMember> get onMemberUpdate => gateway.onMemberUpdate;
+  Stream<Map<String, dynamic>> get onMemberChunk => gateway.onMemberChunk;
+
+  Stream<Map<String, dynamic>> get onRoleCreate => gateway.onRoleCreate;
+  Stream<Map<String, dynamic>> get onRoleUpdate => gateway.onRoleUpdate;
+  Stream<Map<String, dynamic>> get onRoleDelete => gateway.onRoleDelete;
+
+  Stream<AccordMessage> get onMessageCreate => gateway.onMessageCreate;
+  Stream<AccordMessage> get onMessageUpdate => gateway.onMessageUpdate;
+  Stream<Map<String, dynamic>> get onMessageDelete => gateway.onMessageDelete;
+  Stream<Map<String, dynamic>> get onMessageDeleteBulk =>
+      gateway.onMessageDeleteBulk;
+  Stream<Map<String, dynamic>> get onReadStateUpdate =>
+      gateway.onReadStateUpdate;
+
+  Stream<Map<String, dynamic>> get onReactionAdd => gateway.onReactionAdd;
+  Stream<Map<String, dynamic>> get onReactionRemove => gateway.onReactionRemove;
+  Stream<Map<String, dynamic>> get onReactionClear => gateway.onReactionClear;
+  Stream<Map<String, dynamic>> get onReactionClearEmoji =>
+      gateway.onReactionClearEmoji;
+
+  Stream<AccordPresence> get onPresenceUpdate => gateway.onPresenceUpdate;
+  Stream<Map<String, dynamic>> get onTypingStart => gateway.onTypingStart;
+
+  Stream<AccordUser> get onUserUpdate => gateway.onUserUpdate;
+
+  Stream<AccordVoiceState> get onVoiceStateUpdate => gateway.onVoiceStateUpdate;
+  Stream<AccordVoiceServerUpdate> get onVoiceServerUpdate =>
+      gateway.onVoiceServerUpdate;
+  Stream<Map<String, dynamic>> get onVoiceSignal => gateway.onVoiceSignal;
+
+  Stream<Map<String, dynamic>> get onBanCreate => gateway.onBanCreate;
+  Stream<Map<String, dynamic>> get onBanDelete => gateway.onBanDelete;
+
+  Stream<Map<String, dynamic>> get onReportCreate => gateway.onReportCreate;
+
+  Stream<AccordInvite> get onInviteCreate => gateway.onInviteCreate;
+  Stream<Map<String, dynamic>> get onInviteDelete => gateway.onInviteDelete;
+
+  Stream<AccordInteraction> get onInteractionCreate =>
+      gateway.onInteractionCreate;
+
+  Stream<Map<String, dynamic>> get onPluginInstalled =>
+      gateway.onPluginInstalled;
+  Stream<Map<String, dynamic>> get onPluginUninstalled =>
+      gateway.onPluginUninstalled;
+  Stream<Map<String, dynamic>> get onPluginEvent => gateway.onPluginEvent;
+  Stream<Map<String, dynamic>> get onPluginSessionState =>
+      gateway.onPluginSessionState;
+  Stream<Map<String, dynamic>> get onPluginRoleChanged =>
+      gateway.onPluginRoleChanged;
+  Stream<Map<String, dynamic>> get onPluginLeaderboardUpdated =>
+      gateway.onPluginLeaderboardUpdated;
+
+  Stream<Map<String, dynamic>> get onEmojiCreate => gateway.onEmojiCreate;
+  Stream<Map<String, dynamic>> get onEmojiUpdate => gateway.onEmojiUpdate;
+  Stream<Map<String, dynamic>> get onEmojiDelete => gateway.onEmojiDelete;
+
+  Stream<AccordSound> get onSoundboardCreate => gateway.onSoundboardCreate;
+  Stream<AccordSound> get onSoundboardUpdate => gateway.onSoundboardUpdate;
+  Stream<Map<String, dynamic>> get onSoundboardDelete =>
+      gateway.onSoundboardDelete;
+  Stream<Map<String, dynamic>> get onSoundboardPlay => gateway.onSoundboardPlay;
+
+  Stream<AccordRelationship> get onRelationshipAdd => gateway.onRelationshipAdd;
+  Stream<AccordRelationship> get onRelationshipUpdate =>
+      gateway.onRelationshipUpdate;
+  Stream<Map<String, dynamic>> get onRelationshipRemove =>
+      gateway.onRelationshipRemove;
+
+  Stream<Map<String, dynamic>> get onAuditLogCreate => gateway.onAuditLogCreate;
+  Stream<Map<String, dynamic>> get onAnonymousCountUpdated =>
+      gateway.onAnonymousCountUpdated;
+  Stream<RawGatewayEvent> get onRawEvent => gateway.onRawEvent;
+}

--- a/packages/accordkit/lib/src/core/accord_config.dart
+++ b/packages/accordkit/lib/src/core/accord_config.dart
@@ -1,0 +1,31 @@
+/// Connection configuration for an [AccordClient]: base, gateway, and CDN
+/// URLs plus protocol-level constants shared across the REST and gateway
+/// layers.
+class AccordConfig {
+  static const String apiVersion = 'v1';
+  static const String apiBasePath = '/api/$apiVersion';
+  static const String defaultBaseUrl = 'http://localhost:3000';
+  static const String defaultGatewayUrl = 'ws://localhost:3000/ws';
+  static const String defaultCdnUrl = 'http://localhost:3000/cdn';
+
+  static const String userAgent = 'AccordKit (Dart, 2.0.0)';
+  static const String clientVersion = '2.0.0';
+
+  static const int heartbeatIntervalDefault = 45000;
+
+  String baseUrl;
+  String gatewayUrl;
+  String cdnUrl;
+
+  AccordConfig({
+    this.baseUrl = defaultBaseUrl,
+    this.gatewayUrl = defaultGatewayUrl,
+    this.cdnUrl = defaultCdnUrl,
+  });
+
+  /// The fully-qualified REST API root (base URL + versioned API path).
+  String apiUrl() => baseUrl + apiBasePath;
+
+  /// The gateway WebSocket URL including the version/encoding query string.
+  String gatewayConnectUrl() => '$gatewayUrl?v=1&encoding=json';
+}

--- a/packages/accordkit/lib/src/gateway/gateway_connection.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_connection.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Transport abstraction the gateway uses to talk to a WebSocket. Abstracted
+/// so the reconnect/heartbeat/dispatch logic can be unit-tested against a fake
+/// connection without real networking.
+abstract class GatewayConnection {
+  /// Resolves once the connection is open (or rejects on failure).
+  Future<void> get ready;
+
+  /// Inbound text frames.
+  Stream<String> get messages;
+
+  /// Sends a text frame.
+  void sendText(String text);
+
+  /// Closes the connection with an optional close [code] and [reason].
+  Future<void> close([int? code, String? reason]);
+
+  /// The close code observed after the connection ended, if any.
+  int? get closeCode;
+
+  /// The close reason observed after the connection ended, if any.
+  String? get closeReason;
+}
+
+/// Factory signature used by the gateway to create a connection for a URL.
+typedef GatewayConnectionFactory = GatewayConnection Function(String url);
+
+/// Default [GatewayConnection] backed by `package:web_socket_channel`.
+class WebSocketGatewayConnection implements GatewayConnection {
+  final WebSocketChannel _channel;
+
+  WebSocketGatewayConnection(this._channel);
+
+  /// Connects to [url] using [WebSocketChannel.connect].
+  factory WebSocketGatewayConnection.connect(String url) {
+    return WebSocketGatewayConnection(WebSocketChannel.connect(Uri.parse(url)));
+  }
+
+  @override
+  Future<void> get ready => _channel.ready;
+
+  @override
+  Stream<String> get messages => _channel.stream.map((event) {
+        if (event is String) return event;
+        if (event is List<int>) return utf8.decode(event);
+        return event.toString();
+      });
+
+  @override
+  void sendText(String text) => _channel.sink.add(text);
+
+  @override
+  Future<void> close([int? code, String? reason]) =>
+      _channel.sink.close(code, reason);
+
+  @override
+  int? get closeCode => _channel.closeCode;
+
+  @override
+  String? get closeReason => _channel.closeReason;
+}

--- a/packages/accordkit/lib/src/gateway/gateway_events.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_events.dart
@@ -1,0 +1,31 @@
+/// Payload for the `disconnected` event.
+class DisconnectInfo {
+  final int code;
+  final String reason;
+  const DisconnectInfo(this.code, this.reason);
+
+  @override
+  String toString() => 'DisconnectInfo(code: $code, reason: $reason)';
+}
+
+/// Payload for the `reconnecting` event.
+class ReconnectInfo {
+  final int attempt;
+  final int maxAttempts;
+  const ReconnectInfo(this.attempt, this.maxAttempts);
+
+  @override
+  String toString() =>
+      'ReconnectInfo(attempt: $attempt, maxAttempts: $maxAttempts)';
+}
+
+/// A raw, undispatched gateway event (`type` + `data`). Emitted for every
+/// event in addition to any typed stream.
+class RawGatewayEvent {
+  final String type;
+  final Map<String, dynamic> data;
+  const RawGatewayEvent(this.type, this.data);
+
+  @override
+  String toString() => 'RawGatewayEvent(type: $type)';
+}

--- a/packages/accordkit/lib/src/gateway/gateway_intents.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_intents.dart
@@ -1,0 +1,52 @@
+/// Gateway intent identifiers and convenience groupings. Intents control which
+/// event categories the gateway streams to a connection.
+class GatewayIntents {
+  static const String spaces = 'spaces';
+  static const String moderation = 'moderation';
+  static const String emojis = 'emojis';
+  static const String voiceStates = 'voice_states';
+  static const String messages = 'messages';
+  static const String messageReactions = 'message_reactions';
+  static const String messageTyping = 'message_typing';
+  static const String directMessages = 'direct_messages';
+  static const String dmReactions = 'dm_reactions';
+  static const String dmTyping = 'dm_typing';
+  static const String scheduledEvents = 'scheduled_events';
+  static const String plugins = 'plugins';
+  static const String relationships = 'relationships';
+  static const String soundboard = 'soundboard';
+
+  // Privileged intents.
+  static const String members = 'members';
+  static const String presences = 'presences';
+  static const String messageContent = 'message_content';
+
+  static List<String> unprivileged() => const [
+        spaces,
+        moderation,
+        emojis,
+        voiceStates,
+        messages,
+        messageReactions,
+        messageTyping,
+        directMessages,
+        dmReactions,
+        dmTyping,
+        scheduledEvents,
+        plugins,
+        relationships,
+        soundboard,
+      ];
+
+  static List<String> privileged() =>
+      const [members, presences, messageContent];
+
+  static List<String> all() => [...unprivileged(), ...privileged()];
+
+  static List<String> defaults() => const [spaces, messages, messageContent];
+
+  /// Reduced intent set for anonymous guest connections — space structure,
+  /// messages, and member count updates only.
+  static List<String> guest() =>
+      const [spaces, messages, messageContent, members];
+}

--- a/packages/accordkit/lib/src/gateway/gateway_opcodes.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_opcodes.dart
@@ -1,0 +1,15 @@
+/// Gateway protocol opcodes.
+class GatewayOpcodes {
+  static const int event = 0;
+  static const int heartbeat = 1;
+  static const int identify = 2;
+  static const int resume = 3;
+  static const int heartbeatAck = 4;
+  static const int hello = 5;
+  static const int reconnect = 6;
+  static const int invalidSession = 7;
+  static const int presenceUpdate = 8;
+  static const int voiceStateUpdate = 9;
+  static const int requestMembers = 10;
+  static const int voiceSignal = 11;
+}

--- a/packages/accordkit/lib/src/gateway/gateway_socket.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_socket.dart
@@ -1,0 +1,769 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import '../core/accord_config.dart';
+import '../models/accord_relationship.dart';
+import '../models/channel.dart';
+import '../models/interaction.dart';
+import '../models/invite.dart';
+import '../models/member.dart';
+import '../models/message.dart';
+import '../models/presence.dart';
+import '../models/sound.dart';
+import '../models/space.dart';
+import '../models/user.dart';
+import '../models/voice_server_update.dart';
+import '../models/voice_state.dart';
+import '../utils/json_utils.dart';
+import 'gateway_connection.dart';
+import 'gateway_events.dart';
+import 'gateway_intents.dart';
+import 'gateway_opcodes.dart';
+
+/// Connection lifecycle state of the gateway socket.
+enum GatewayState { disconnected, connecting, connected, resuming }
+
+/// Manages a single gateway WebSocket connection: the IDENTIFY/RESUME
+/// handshake, heartbeating, automatic reconnect with backoff, and dispatch of
+/// inbound events to typed broadcast streams.
+class GatewaySocket {
+  String token;
+  String tokenType;
+  List<String> intents;
+
+  final GatewayConnectionFactory _factory;
+  final Future<void> Function(Duration) _sleep;
+  final double Function() _random;
+  final String _osName;
+  final int maxReconnectAttempts;
+
+  AccordConfig? _config;
+  GatewayConnection? _conn;
+  StreamSubscription<String>? _sub;
+  Timer? _heartbeatTimer;
+
+  GatewayState _state = GatewayState.disconnected;
+  String _sessionId = '';
+  int _sequence = 0;
+  int _heartbeatIntervalMs = AccordConfig.heartbeatIntervalDefault;
+  bool _heartbeatAckReceived = true;
+  String _gatewayUrl = '';
+  int _reconnectAttempts = 0;
+  bool _reconnectCancelled = false;
+  bool _resumePending = false;
+
+  GatewaySocket({
+    GatewayConnectionFactory? connectionFactory,
+    Future<void> Function(Duration)? sleep,
+    double Function()? random,
+    String osName = 'dart',
+    this.maxReconnectAttempts = 10,
+    this.token = '',
+    this.tokenType = 'Bot',
+    List<String>? intents,
+  })  : _factory = connectionFactory ?? WebSocketGatewayConnection.connect,
+        _sleep = sleep ?? Future.delayed,
+        _random = random ?? Random().nextDouble,
+        _osName = osName,
+        intents = intents ?? [];
+
+  // ── Event streams ────────────────────────────────────────────────────────
+
+  final _controllers = <StreamController<dynamic>>[];
+
+  StreamController<T> _ctrl<T>() {
+    final c = StreamController<T>.broadcast();
+    _controllers.add(c);
+    return c;
+  }
+
+  late final _connected = _ctrl<void>();
+  late final _disconnected = _ctrl<DisconnectInfo>();
+  late final _reconnecting = _ctrl<ReconnectInfo>();
+  late final _readyReceived = _ctrl<Map<String, dynamic>>();
+  late final _resumed = _ctrl<void>();
+
+  late final _spaceCreate = _ctrl<AccordSpace>();
+  late final _spaceUpdate = _ctrl<AccordSpace>();
+  late final _spaceDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _channelCreate = _ctrl<AccordChannel>();
+  late final _channelUpdate = _ctrl<AccordChannel>();
+  late final _channelDelete = _ctrl<AccordChannel>();
+  late final _channelReorder = _ctrl<Map<String, dynamic>>();
+  late final _channelPinsUpdate = _ctrl<Map<String, dynamic>>();
+  late final _channelMuteCreate = _ctrl<Map<String, dynamic>>();
+  late final _channelMuteDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _memberJoin = _ctrl<AccordMember>();
+  late final _memberLeave = _ctrl<Map<String, dynamic>>();
+  late final _memberUpdate = _ctrl<AccordMember>();
+  late final _memberChunk = _ctrl<Map<String, dynamic>>();
+
+  late final _roleCreate = _ctrl<Map<String, dynamic>>();
+  late final _roleUpdate = _ctrl<Map<String, dynamic>>();
+  late final _roleDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _messageCreate = _ctrl<AccordMessage>();
+  late final _messageUpdate = _ctrl<AccordMessage>();
+  late final _messageDelete = _ctrl<Map<String, dynamic>>();
+  late final _messageDeleteBulk = _ctrl<Map<String, dynamic>>();
+  late final _readStateUpdate = _ctrl<Map<String, dynamic>>();
+
+  late final _reactionAdd = _ctrl<Map<String, dynamic>>();
+  late final _reactionRemove = _ctrl<Map<String, dynamic>>();
+  late final _reactionClear = _ctrl<Map<String, dynamic>>();
+  late final _reactionClearEmoji = _ctrl<Map<String, dynamic>>();
+
+  late final _presenceUpdate = _ctrl<AccordPresence>();
+  late final _typingStart = _ctrl<Map<String, dynamic>>();
+
+  late final _userUpdate = _ctrl<AccordUser>();
+
+  late final _voiceStateUpdate = _ctrl<AccordVoiceState>();
+  late final _voiceServerUpdate = _ctrl<AccordVoiceServerUpdate>();
+  late final _voiceSignal = _ctrl<Map<String, dynamic>>();
+
+  late final _banCreate = _ctrl<Map<String, dynamic>>();
+  late final _banDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _reportCreate = _ctrl<Map<String, dynamic>>();
+
+  late final _inviteCreate = _ctrl<AccordInvite>();
+  late final _inviteDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _interactionCreate = _ctrl<AccordInteraction>();
+
+  late final _pluginInstalled = _ctrl<Map<String, dynamic>>();
+  late final _pluginUninstalled = _ctrl<Map<String, dynamic>>();
+  late final _pluginEvent = _ctrl<Map<String, dynamic>>();
+  late final _pluginSessionState = _ctrl<Map<String, dynamic>>();
+  late final _pluginRoleChanged = _ctrl<Map<String, dynamic>>();
+  late final _pluginLeaderboardUpdated = _ctrl<Map<String, dynamic>>();
+
+  late final _emojiCreate = _ctrl<Map<String, dynamic>>();
+  late final _emojiUpdate = _ctrl<Map<String, dynamic>>();
+  late final _emojiDelete = _ctrl<Map<String, dynamic>>();
+
+  late final _soundboardCreate = _ctrl<AccordSound>();
+  late final _soundboardUpdate = _ctrl<AccordSound>();
+  late final _soundboardDelete = _ctrl<Map<String, dynamic>>();
+  late final _soundboardPlay = _ctrl<Map<String, dynamic>>();
+
+  late final _relationshipAdd = _ctrl<AccordRelationship>();
+  late final _relationshipUpdate = _ctrl<AccordRelationship>();
+  late final _relationshipRemove = _ctrl<Map<String, dynamic>>();
+
+  late final _auditLogCreate = _ctrl<Map<String, dynamic>>();
+  late final _anonymousCountUpdated = _ctrl<Map<String, dynamic>>();
+  late final _rawEvent = _ctrl<RawGatewayEvent>();
+
+  Stream<void> get onConnected => _connected.stream;
+  Stream<DisconnectInfo> get onDisconnected => _disconnected.stream;
+  Stream<ReconnectInfo> get onReconnecting => _reconnecting.stream;
+  Stream<Map<String, dynamic>> get onReady => _readyReceived.stream;
+  Stream<void> get onResumed => _resumed.stream;
+
+  Stream<AccordSpace> get onSpaceCreate => _spaceCreate.stream;
+  Stream<AccordSpace> get onSpaceUpdate => _spaceUpdate.stream;
+  Stream<Map<String, dynamic>> get onSpaceDelete => _spaceDelete.stream;
+
+  Stream<AccordChannel> get onChannelCreate => _channelCreate.stream;
+  Stream<AccordChannel> get onChannelUpdate => _channelUpdate.stream;
+  Stream<AccordChannel> get onChannelDelete => _channelDelete.stream;
+  Stream<Map<String, dynamic>> get onChannelReorder => _channelReorder.stream;
+  Stream<Map<String, dynamic>> get onChannelPinsUpdate =>
+      _channelPinsUpdate.stream;
+  Stream<Map<String, dynamic>> get onChannelMuteCreate =>
+      _channelMuteCreate.stream;
+  Stream<Map<String, dynamic>> get onChannelMuteDelete =>
+      _channelMuteDelete.stream;
+
+  Stream<AccordMember> get onMemberJoin => _memberJoin.stream;
+  Stream<Map<String, dynamic>> get onMemberLeave => _memberLeave.stream;
+  Stream<AccordMember> get onMemberUpdate => _memberUpdate.stream;
+  Stream<Map<String, dynamic>> get onMemberChunk => _memberChunk.stream;
+
+  Stream<Map<String, dynamic>> get onRoleCreate => _roleCreate.stream;
+  Stream<Map<String, dynamic>> get onRoleUpdate => _roleUpdate.stream;
+  Stream<Map<String, dynamic>> get onRoleDelete => _roleDelete.stream;
+
+  Stream<AccordMessage> get onMessageCreate => _messageCreate.stream;
+  Stream<AccordMessage> get onMessageUpdate => _messageUpdate.stream;
+  Stream<Map<String, dynamic>> get onMessageDelete => _messageDelete.stream;
+  Stream<Map<String, dynamic>> get onMessageDeleteBulk =>
+      _messageDeleteBulk.stream;
+
+  /// Fired when the server reports that the authenticated user read a channel on
+  /// another session (multi-device sync). Carries `channel_id`,
+  /// `last_read_message_id`, and `mention_count`.
+  Stream<Map<String, dynamic>> get onReadStateUpdate =>
+      _readStateUpdate.stream;
+
+  Stream<Map<String, dynamic>> get onReactionAdd => _reactionAdd.stream;
+  Stream<Map<String, dynamic>> get onReactionRemove => _reactionRemove.stream;
+  Stream<Map<String, dynamic>> get onReactionClear => _reactionClear.stream;
+  Stream<Map<String, dynamic>> get onReactionClearEmoji =>
+      _reactionClearEmoji.stream;
+
+  Stream<AccordPresence> get onPresenceUpdate => _presenceUpdate.stream;
+  Stream<Map<String, dynamic>> get onTypingStart => _typingStart.stream;
+
+  Stream<AccordUser> get onUserUpdate => _userUpdate.stream;
+
+  Stream<AccordVoiceState> get onVoiceStateUpdate => _voiceStateUpdate.stream;
+  Stream<AccordVoiceServerUpdate> get onVoiceServerUpdate =>
+      _voiceServerUpdate.stream;
+  Stream<Map<String, dynamic>> get onVoiceSignal => _voiceSignal.stream;
+
+  Stream<Map<String, dynamic>> get onBanCreate => _banCreate.stream;
+  Stream<Map<String, dynamic>> get onBanDelete => _banDelete.stream;
+
+  Stream<Map<String, dynamic>> get onReportCreate => _reportCreate.stream;
+
+  Stream<AccordInvite> get onInviteCreate => _inviteCreate.stream;
+  Stream<Map<String, dynamic>> get onInviteDelete => _inviteDelete.stream;
+
+  Stream<AccordInteraction> get onInteractionCreate =>
+      _interactionCreate.stream;
+
+  Stream<Map<String, dynamic>> get onPluginInstalled => _pluginInstalled.stream;
+  Stream<Map<String, dynamic>> get onPluginUninstalled =>
+      _pluginUninstalled.stream;
+  Stream<Map<String, dynamic>> get onPluginEvent => _pluginEvent.stream;
+  Stream<Map<String, dynamic>> get onPluginSessionState =>
+      _pluginSessionState.stream;
+  Stream<Map<String, dynamic>> get onPluginRoleChanged =>
+      _pluginRoleChanged.stream;
+  Stream<Map<String, dynamic>> get onPluginLeaderboardUpdated =>
+      _pluginLeaderboardUpdated.stream;
+
+  Stream<Map<String, dynamic>> get onEmojiCreate => _emojiCreate.stream;
+  Stream<Map<String, dynamic>> get onEmojiUpdate => _emojiUpdate.stream;
+  Stream<Map<String, dynamic>> get onEmojiDelete => _emojiDelete.stream;
+
+  Stream<AccordSound> get onSoundboardCreate => _soundboardCreate.stream;
+  Stream<AccordSound> get onSoundboardUpdate => _soundboardUpdate.stream;
+  Stream<Map<String, dynamic>> get onSoundboardDelete =>
+      _soundboardDelete.stream;
+  Stream<Map<String, dynamic>> get onSoundboardPlay => _soundboardPlay.stream;
+
+  Stream<AccordRelationship> get onRelationshipAdd => _relationshipAdd.stream;
+  Stream<AccordRelationship> get onRelationshipUpdate =>
+      _relationshipUpdate.stream;
+  Stream<Map<String, dynamic>> get onRelationshipRemove =>
+      _relationshipRemove.stream;
+
+  Stream<Map<String, dynamic>> get onAuditLogCreate => _auditLogCreate.stream;
+  Stream<Map<String, dynamic>> get onAnonymousCountUpdated =>
+      _anonymousCountUpdated.stream;
+  Stream<RawGatewayEvent> get onRawEvent => _rawEvent.stream;
+
+  // ── Public API ─────────────────────────────────────────────────────────
+
+  /// Current lifecycle state.
+  GatewayState get state => _state;
+
+  /// Current resumable session ID (empty when none).
+  String get sessionId => _sessionId;
+
+  /// Configures the socket before connecting.
+  void setup(
+    AccordConfig config,
+    String tkn, {
+    String tknType = 'Bot',
+    List<String> intentList = const [],
+  }) {
+    _config = config;
+    token = tkn;
+    tokenType = tknType;
+    intents = intentList.isNotEmpty ? intentList : GatewayIntents.defaults();
+  }
+
+  /// Opens the gateway connection. No-op unless currently disconnected.
+  void connectToGateway([String url = '']) {
+    if (_state != GatewayState.disconnected) return;
+    final config = _config;
+    _gatewayUrl = url.isNotEmpty
+        ? url
+        : (config != null ? config.gatewayConnectUrl() : '');
+    _reconnectAttempts = 0;
+    _reconnectCancelled = false;
+    _openConnection(GatewayState.connecting);
+  }
+
+  /// Closes the gateway connection and suppresses reconnects.
+  Future<void> disconnectFromGateway(
+      [int code = 1000, String reason = 'client disconnect']) async {
+    _reconnectCancelled = true;
+    if (_state == GatewayState.disconnected) return;
+    _state = GatewayState.disconnected;
+    _stopHeartbeat();
+    final conn = _conn;
+    await _sub?.cancel();
+    _sub = null;
+    await conn?.close(code, reason);
+    _disconnected.add(DisconnectInfo(code, reason));
+  }
+
+  /// Sends a presence update.
+  void updatePresence(String status,
+      {Map<String, dynamic> activity = const {}}) {
+    final data = <String, dynamic>{'status': status};
+    if (activity.isNotEmpty) data['activity'] = activity;
+    _send({'op': GatewayOpcodes.presenceUpdate, 'data': data});
+  }
+
+  /// Sends a voice state update. [channelId] may be null to disconnect.
+  void updateVoiceState(
+    String spaceId,
+    String? channelId, {
+    bool selfMute = false,
+    bool selfDeaf = false,
+    bool selfVideo = false,
+    bool selfStream = false,
+  }) {
+    _send({
+      'op': GatewayOpcodes.voiceStateUpdate,
+      'data': {
+        'space_id': spaceId,
+        'channel_id': channelId,
+        'self_mute': selfMute,
+        'self_deaf': selfDeaf,
+        'self_video': selfVideo,
+        'self_stream': selfStream,
+      },
+    });
+  }
+
+  /// Requests the member list (or a filtered subset) for a space.
+  void requestMembers(String spaceId, {String query = '', int limit = 0}) {
+    _send({
+      'op': GatewayOpcodes.requestMembers,
+      'data': {'space_id': spaceId, 'query': query, 'limit': limit},
+    });
+  }
+
+  /// Sends a voice signalling payload through the gateway.
+  void sendVoiceSignal(String spaceId, String channelId, String signalType,
+      Map<String, dynamic> payload) {
+    _send({
+      'op': GatewayOpcodes.voiceSignal,
+      'data': {
+        'space_id': spaceId,
+        'channel_id': channelId,
+        'type': signalType,
+        'payload': payload,
+      },
+    });
+  }
+
+  /// Closes all event streams and tears down the connection. The socket cannot
+  /// be reused after calling this.
+  Future<void> dispose() async {
+    _reconnectCancelled = true;
+    _stopHeartbeat();
+    await _sub?.cancel();
+    _sub = null;
+    // 1000 (normal closure) is the only RFC 6455 code the dart `web_socket`
+    // package permits an application to send; 1001 ("going away") is reserved
+    // and throws ArgumentError when passed to WebSocketChannel.sink.close.
+    await _conn?.close(1000, 'going away');
+    _conn = null;
+    for (final c in _controllers) {
+      await c.close();
+    }
+  }
+
+  // ── Connection management ────────────────────────────────────────────────
+
+  void _openConnection(GatewayState initialState) {
+    _teardownConnection();
+    _state = initialState;
+    final conn = _factory(_gatewayUrl);
+    _conn = conn;
+    _sub = conn.messages.listen(
+      _handleMessage,
+      onDone: _onClosed,
+      onError: (_) {},
+      cancelOnError: false,
+    );
+    conn.ready.then((_) {
+      if (_state == GatewayState.connecting) {
+        _state = GatewayState.connected;
+        _connected.add(null);
+      }
+    }).catchError((_) {
+      // Failure surfaces via the stream's onDone/onError → _onClosed.
+    });
+  }
+
+  void _teardownConnection() {
+    _sub?.cancel();
+    _sub = null;
+    _conn?.close();
+    _conn = null;
+  }
+
+  void _onClosed() {
+    final code = _conn?.closeCode ?? 1006;
+    final reason = _conn?.closeReason ?? '';
+    if (_resumePending) {
+      _sessionId = '';
+      _sequence = 0;
+      _resumePending = false;
+    }
+    _stopHeartbeat();
+    final wasDisconnected = _state == GatewayState.disconnected;
+    _state = GatewayState.disconnected;
+    if (!wasDisconnected) {
+      _disconnected.add(DisconnectInfo(code, reason));
+    }
+    if (!_reconnectCancelled && _shouldReconnect(code)) {
+      _attemptReconnect();
+    }
+  }
+
+  bool _shouldReconnect(int code) {
+    const fatalCodes = [4003, 4004, 4012, 4013, 4014];
+    if (fatalCodes.contains(code)) return false;
+    return _reconnectAttempts < maxReconnectAttempts;
+  }
+
+  Future<void> _attemptReconnect() async {
+    _reconnectAttempts += 1;
+    _reconnecting.add(ReconnectInfo(_reconnectAttempts, maxReconnectAttempts));
+    // Exponential backoff with jitter: base * 2^attempt + random jitter.
+    const baseDelay = 1.0;
+    final delay =
+        baseDelay * pow(2.0, min(_reconnectAttempts - 1, 5)) + _random();
+    await _sleep(Duration(milliseconds: (delay * 1000).round()));
+    if (_reconnectCancelled) return;
+    final initial =
+        _sessionId.isNotEmpty ? GatewayState.resuming : GatewayState.connecting;
+    _openConnection(initial);
+  }
+
+  // ── Heartbeat ────────────────────────────────────────────────────────────
+
+  void _startHeartbeat() {
+    _stopHeartbeat();
+    _heartbeatTimer = Timer.periodic(
+      Duration(milliseconds: _heartbeatIntervalMs),
+      (_) => _sendHeartbeat(),
+    );
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+  }
+
+  void _sendHeartbeat() {
+    if (!_heartbeatAckReceived) {
+      // No ACK since the last beat — the connection is stale.
+      _conn?.close(4000, 'heartbeat timeout');
+      return;
+    }
+    _heartbeatAckReceived = false;
+    _send({'op': GatewayOpcodes.heartbeat, 'data': _sequence});
+  }
+
+  // ── Outbound ─────────────────────────────────────────────────────────────
+
+  void _send(Map<String, dynamic> payload) {
+    _conn?.sendText(jsonEncode(payload));
+  }
+
+  void _sendIdentify() {
+    _send({
+      'op': GatewayOpcodes.identify,
+      'data': {
+        'token': '$tokenType $token',
+        'intents': intents,
+        'properties': {
+          'os': _osName,
+          'client': 'AccordKit',
+          'version': AccordConfig.clientVersion,
+        },
+      },
+    });
+  }
+
+  void _sendResume() {
+    _state = GatewayState.resuming;
+    _resumePending = true;
+    _send({
+      'op': GatewayOpcodes.resume,
+      'data': {
+        'token': '$tokenType $token',
+        'session_id': _sessionId,
+        'seq': _sequence,
+      },
+    });
+  }
+
+  // ── Inbound ──────────────────────────────────────────────────────────────
+
+  void _handleMessage(String text) {
+    Object? parsed;
+    try {
+      parsed = jsonDecode(text);
+    } catch (_) {
+      return;
+    }
+    if (parsed is! Map) return;
+    final map = parsed.cast<String, dynamic>();
+
+    final op = asInt(map['op'], -1);
+    final data = map['data'];
+    final seq = map['seq'];
+    final eventType = asString(map['type']);
+
+    if (seq is num) {
+      _sequence = seq.toInt();
+    }
+
+    switch (op) {
+      case GatewayOpcodes.hello:
+        final dataMap = asMap(data) ?? const {};
+        _heartbeatIntervalMs = asInt(dataMap['heartbeat_interval'],
+            AccordConfig.heartbeatIntervalDefault);
+        _heartbeatAckReceived = true;
+        _startHeartbeat();
+        if (_sessionId.isNotEmpty && _state == GatewayState.resuming) {
+          _sendResume();
+        } else {
+          _sendIdentify();
+        }
+        break;
+
+      case GatewayOpcodes.heartbeatAck:
+        _heartbeatAckReceived = true;
+        break;
+
+      case GatewayOpcodes.heartbeat:
+        _sendHeartbeat();
+        break;
+
+      case GatewayOpcodes.reconnect:
+        _conn?.close(4000, 'server requested reconnect');
+        break;
+
+      case GatewayOpcodes.invalidSession:
+        _handleInvalidSession(data);
+        break;
+
+      case GatewayOpcodes.event:
+        _dispatchEvent(eventType, asMap(data) ?? const {});
+        break;
+    }
+  }
+
+  Future<void> _handleInvalidSession(Object? data) async {
+    final resumable = data is bool ? data : false;
+    if (!resumable) {
+      _sessionId = '';
+      _sequence = 0;
+    }
+    if (_reconnectAttempts >= maxReconnectAttempts) {
+      _state = GatewayState.disconnected;
+      _stopHeartbeat();
+      await _conn?.close(1000, 'max reconnect attempts');
+      _disconnected.add(
+          const DisconnectInfo(4004, 'session invalid after max attempts'));
+      return;
+    }
+    // Wait 1–5 seconds, then reconnect.
+    await _sleep(Duration(milliseconds: (1000 + _random() * 4000).round()));
+    if (_reconnectCancelled) return;
+    _attemptReconnect();
+  }
+
+  void _dispatchEvent(String eventType, Map<String, dynamic> data) {
+    switch (eventType) {
+      case 'ready':
+        _sessionId = asString(data['session_id']);
+        _reconnectAttempts = 0;
+        _resumePending = false;
+        _readyReceived.add(data);
+        break;
+      case 'resumed':
+        _reconnectAttempts = 0;
+        _resumePending = false;
+        _resumed.add(null);
+        break;
+      case 'space.create':
+        _spaceCreate.add(AccordSpace.fromJson(data));
+        break;
+      case 'space.update':
+        _spaceUpdate.add(AccordSpace.fromJson(data));
+        break;
+      case 'space.delete':
+        _spaceDelete.add(data);
+        break;
+      case 'channel.create':
+        _channelCreate.add(AccordChannel.fromJson(data));
+        break;
+      case 'channel.update':
+        _channelUpdate.add(AccordChannel.fromJson(data));
+        break;
+      case 'channel.delete':
+        _channelDelete.add(AccordChannel.fromJson(data));
+        break;
+      case 'channel.reorder':
+        _channelReorder.add(data);
+        break;
+      case 'channel.pins_update':
+        _channelPinsUpdate.add(data);
+        break;
+      case 'channel_mute.create':
+        _channelMuteCreate.add(data);
+        break;
+      case 'channel_mute.delete':
+        _channelMuteDelete.add(data);
+        break;
+      case 'member.join':
+        _memberJoin.add(AccordMember.fromJson(data));
+        break;
+      case 'member.leave':
+        _memberLeave.add(data);
+        break;
+      case 'member.update':
+        _memberUpdate.add(AccordMember.fromJson(data));
+        break;
+      case 'member.chunk':
+        _memberChunk.add(data);
+        break;
+      case 'role.create':
+        _roleCreate.add(data);
+        break;
+      case 'role.update':
+        _roleUpdate.add(data);
+        break;
+      case 'role.delete':
+        _roleDelete.add(data);
+        break;
+      case 'message.create':
+        _messageCreate.add(AccordMessage.fromJson(data));
+        break;
+      case 'message.update':
+        _messageUpdate.add(AccordMessage.fromJson(data));
+        break;
+      case 'message.delete':
+        _messageDelete.add(data);
+        break;
+      case 'message.delete_bulk':
+        _messageDeleteBulk.add(data);
+        break;
+      case 'read_state.update':
+        _readStateUpdate.add(data);
+        break;
+      case 'reaction.add':
+        _reactionAdd.add(data);
+        break;
+      case 'reaction.remove':
+        _reactionRemove.add(data);
+        break;
+      case 'reaction.clear':
+        _reactionClear.add(data);
+        break;
+      case 'reaction.clear_emoji':
+        _reactionClearEmoji.add(data);
+        break;
+      case 'presence.update':
+        _presenceUpdate.add(AccordPresence.fromJson(data));
+        break;
+      case 'typing.start':
+        _typingStart.add(data);
+        break;
+      case 'user.update':
+        _userUpdate.add(AccordUser.fromJson(data));
+        break;
+      case 'voice.state_update':
+        _voiceStateUpdate.add(AccordVoiceState.fromJson(data));
+        break;
+      case 'voice.server_update':
+        _voiceServerUpdate.add(AccordVoiceServerUpdate.fromJson(data));
+        break;
+      case 'voice.signal':
+        _voiceSignal.add(data);
+        break;
+      case 'ban.create':
+        _banCreate.add(data);
+        break;
+      case 'ban.delete':
+        _banDelete.add(data);
+        break;
+      case 'report.create':
+        _reportCreate.add(data);
+        break;
+      case 'invite.create':
+        _inviteCreate.add(AccordInvite.fromJson(data));
+        break;
+      case 'invite.delete':
+        _inviteDelete.add(data);
+        break;
+      case 'interaction.create':
+        _interactionCreate.add(AccordInteraction.fromJson(data));
+        break;
+      case 'plugin.installed':
+        _pluginInstalled.add(data);
+        break;
+      case 'plugin.uninstalled':
+        _pluginUninstalled.add(data);
+        break;
+      case 'plugin.event':
+        _pluginEvent.add(data);
+        break;
+      case 'plugin.session_state':
+        _pluginSessionState.add(data);
+        break;
+      case 'plugin.role_changed':
+        _pluginRoleChanged.add(data);
+        break;
+      case 'plugin.leaderboard_updated':
+        _pluginLeaderboardUpdated.add(data);
+        break;
+      case 'anonymous_count.update':
+        _anonymousCountUpdated.add(data);
+        break;
+      case 'emoji.create':
+        _emojiCreate.add(data);
+        break;
+      case 'emoji.update':
+        _emojiUpdate.add(data);
+        break;
+      case 'emoji.delete':
+        _emojiDelete.add(data);
+        break;
+      case 'soundboard.create':
+        _soundboardCreate.add(AccordSound.fromJson(data));
+        break;
+      case 'soundboard.update':
+        _soundboardUpdate.add(AccordSound.fromJson(data));
+        break;
+      case 'soundboard.delete':
+        _soundboardDelete.add(data);
+        break;
+      case 'soundboard.play':
+        _soundboardPlay.add(data);
+        break;
+      case 'relationship.add':
+        _relationshipAdd.add(AccordRelationship.fromJson(data));
+        break;
+      case 'relationship.update':
+        _relationshipUpdate.add(AccordRelationship.fromJson(data));
+        break;
+      case 'relationship.remove':
+        _relationshipRemove.add(data);
+        break;
+      case 'audit_log.create':
+        _auditLogCreate.add(data);
+        break;
+    }
+
+    _rawEvent.add(RawGatewayEvent(eventType, data));
+  }
+}

--- a/packages/accordkit/lib/src/models/accord_relationship.dart
+++ b/packages/accordkit/lib/src/models/accord_relationship.dart
@@ -1,0 +1,43 @@
+import '../utils/json_utils.dart';
+import 'user.dart';
+
+/// A relationship between the current user and another user.
+///
+/// [type] mirrors the server enum: 1 = friend, 2 = blocked,
+/// 3 = pending incoming, 4 = pending outgoing.
+class AccordRelationship {
+  String id;
+  AccordUser? user;
+  int type;
+  String since;
+
+  /// Presence status of the related user (online/idle/dnd/offline).
+  String userStatus;
+
+  /// Presence activities of the related user.
+  List<dynamic> userActivities;
+
+  AccordRelationship({
+    this.id = '',
+    this.user,
+    this.type = 0,
+    this.since = '',
+    this.userStatus = '',
+    List<dynamic>? userActivities,
+  }) : userActivities = userActivities ?? [];
+
+  factory AccordRelationship.fromJson(Map<String, dynamic> d) {
+    final r = AccordRelationship(
+      id: asString(d['id']),
+      type: asInt(d['type']),
+      since: asString(d['since']),
+    );
+    final rawUser = asMap(d['user']);
+    if (rawUser != null) {
+      r.user = AccordUser.fromJson(rawUser);
+      r.userStatus = asString(rawUser['status']);
+      r.userActivities = asList(rawUser['activities']) ?? [];
+    }
+    return r;
+  }
+}

--- a/packages/accordkit/lib/src/models/activity.dart
+++ b/packages/accordkit/lib/src/models/activity.dart
@@ -1,0 +1,47 @@
+import '../utils/json_utils.dart';
+
+/// An activity entry within a presence (e.g. "Playing X").
+class AccordActivity {
+  String name;
+  String type;
+  Object? url;
+  Object? state;
+  Object? details;
+  Object? timestamps;
+  Object? assets;
+
+  AccordActivity({
+    this.name = '',
+    this.type = 'playing',
+    this.url,
+    this.state,
+    this.details,
+    this.timestamps,
+    this.assets,
+  });
+
+  factory AccordActivity.fromJson(Map<String, dynamic> d) {
+    return AccordActivity(
+      name: asString(d['name']),
+      type: asString(d['type'], 'playing'),
+      url: d['url'],
+      state: d['state'],
+      details: d['details'],
+      timestamps: d['timestamps'],
+      assets: d['assets'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'name': name,
+      'type': type,
+    };
+    if (url != null) d['url'] = url;
+    if (state != null) d['state'] = state;
+    if (details != null) d['details'] = details;
+    if (timestamps != null) d['timestamps'] = timestamps;
+    if (assets != null) d['assets'] = assets;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/application.dart
+++ b/packages/accordkit/lib/src/models/application.dart
@@ -1,0 +1,49 @@
+import '../utils/json_utils.dart';
+
+/// An application (bot) registered on an instance.
+class AccordApplication {
+  String id;
+  String name;
+  Object? icon;
+  String description;
+  bool botPublic;
+  String ownerId;
+  int flags;
+
+  AccordApplication({
+    this.id = '',
+    this.name = '',
+    this.icon,
+    this.description = '',
+    this.botPublic = false,
+    this.ownerId = '',
+    this.flags = 0,
+  });
+
+  factory AccordApplication.fromJson(Map<String, dynamic> d) {
+    final rawOwner = asMap(d['owner']);
+    return AccordApplication(
+      id: asString(d['id']),
+      name: asString(d['name']),
+      icon: d['icon'],
+      description: asString(d['description']),
+      botPublic: asBool(d['bot_public']),
+      ownerId:
+          rawOwner != null ? asString(rawOwner['id']) : asString(d['owner_id']),
+      flags: asInt(d['flags']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'name': name,
+      'description': description,
+      'bot_public': botPublic,
+      'owner_id': ownerId,
+      'flags': flags,
+    };
+    if (icon != null) d['icon'] = icon;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/attachment.dart
+++ b/packages/accordkit/lib/src/models/attachment.dart
@@ -1,0 +1,51 @@
+import '../utils/json_utils.dart';
+
+/// A file attachment on a message.
+class AccordAttachment {
+  String id;
+  String filename;
+  String? description;
+  String? contentType;
+  int size;
+  String url;
+  Object? width;
+  Object? height;
+
+  AccordAttachment({
+    this.id = '',
+    this.filename = '',
+    this.description,
+    this.contentType,
+    this.size = 0,
+    this.url = '',
+    this.width,
+    this.height,
+  });
+
+  factory AccordAttachment.fromJson(Map<String, dynamic> d) {
+    return AccordAttachment(
+      id: asString(d['id']),
+      filename: asString(d['filename']),
+      description: d['description'] as String?,
+      contentType: d['content_type'] as String?,
+      size: asInt(d['size']),
+      url: asString(d['url']),
+      width: d['width'],
+      height: d['height'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'filename': filename,
+      'size': size,
+      'url': url,
+    };
+    if (description != null) d['description'] = description;
+    if (contentType != null) d['content_type'] = contentType;
+    if (width != null) d['width'] = width;
+    if (height != null) d['height'] = height;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/audit_log_entry.dart
+++ b/packages/accordkit/lib/src/models/audit_log_entry.dart
@@ -1,0 +1,50 @@
+import '../utils/json_utils.dart';
+
+/// A single entry in a space's audit log.
+class AccordAuditLogEntry {
+  String id;
+  String userId;
+  String actionType;
+  String targetId;
+  String targetType;
+  String reason;
+  List<dynamic> changes;
+  String createdAt;
+
+  AccordAuditLogEntry({
+    this.id = '',
+    this.userId = '',
+    this.actionType = '',
+    this.targetId = '',
+    this.targetType = '',
+    this.reason = '',
+    List<dynamic>? changes,
+    this.createdAt = '',
+  }) : changes = changes ?? [];
+
+  factory AccordAuditLogEntry.fromJson(Map<String, dynamic> d) {
+    return AccordAuditLogEntry(
+      id: asString(d['id']),
+      userId: asString(d['user_id']),
+      actionType: asString(d['action_type']),
+      targetId: asString(d['target_id']),
+      targetType: asString(d['target_type']),
+      reason: asString(d['reason']),
+      changes: asList(d['changes']) ?? [],
+      createdAt: asString(d['created_at']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'user_id': userId,
+      'action_type': actionType,
+      'target_id': targetId,
+      'target_type': targetType,
+      'reason': reason,
+      'changes': changes,
+      'created_at': createdAt,
+    };
+  }
+}

--- a/packages/accordkit/lib/src/models/channel.dart
+++ b/packages/accordkit/lib/src/models/channel.dart
@@ -1,0 +1,112 @@
+import '../utils/json_utils.dart';
+import 'permission_overwrite.dart';
+import 'user.dart';
+
+/// A channel within a space or a DM/group channel.
+class AccordChannel {
+  String id;
+  String type;
+  String? spaceId;
+  String? name;
+  String? topic;
+  Object? position;
+  String? parentId;
+  bool nsfw;
+  Object? rateLimit;
+  Object? bitrate;
+  Object? userLimit;
+  List<AccordUser>? recipients;
+  String? ownerId;
+  String? lastMessageId;
+  List<AccordPermissionOverwrite> permissionOverwrites;
+  bool allowAnonymousRead;
+  Object? archived;
+  Object? autoArchiveAfter;
+  String createdAt;
+
+  AccordChannel({
+    this.id = '',
+    this.type = 'text',
+    this.spaceId,
+    this.name,
+    this.topic,
+    this.position,
+    this.parentId,
+    this.nsfw = false,
+    this.rateLimit,
+    this.bitrate,
+    this.userLimit,
+    this.recipients,
+    this.ownerId,
+    this.lastMessageId,
+    List<AccordPermissionOverwrite>? permissionOverwrites,
+    this.allowAnonymousRead = false,
+    this.archived,
+    this.autoArchiveAfter,
+    this.createdAt = '',
+  }) : permissionOverwrites = permissionOverwrites ?? [];
+
+  factory AccordChannel.fromJson(Map<String, dynamic> d) {
+    final c = AccordChannel(
+      id: asString(d['id']),
+      type: asString(d['type'], 'text'),
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+      name: d['name'] as String?,
+      topic: d['topic'] as String?,
+      position: d['position'],
+      parentId: asStringOrNull(d['parent_id']),
+      nsfw: asBool(d['nsfw']),
+      rateLimit: d['rate_limit'] ?? d['rate_limit_per_user'],
+      bitrate: d['bitrate'],
+      userLimit: d['user_limit'],
+      ownerId: asStringOrNull(d['owner_id']),
+      lastMessageId: asStringOrNull(d['last_message_id']),
+      allowAnonymousRead: asBool(d['allow_anonymous_read']),
+      archived: d['archived'],
+      autoArchiveAfter: d['auto_archive_after'] ?? d['auto_archive_duration'],
+      createdAt: asString(d['created_at']),
+    );
+
+    final rawRecipients = asList(d['recipients']);
+    if (rawRecipients != null) {
+      c.recipients = [
+        for (final r in rawRecipients)
+          if (asMap(r) != null) AccordUser.fromJson(asMap(r)!),
+      ];
+    }
+
+    final rawOverwrites = asList(d['permission_overwrites']) ?? const [];
+    for (final o in rawOverwrites) {
+      final m = asMap(o);
+      if (m != null) {
+        c.permissionOverwrites.add(AccordPermissionOverwrite.fromJson(m));
+      }
+    }
+    return c;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'type': type,
+      'nsfw': nsfw,
+      'created_at': createdAt,
+      'permission_overwrites': toJsonList(permissionOverwrites),
+    };
+    if (spaceId != null) d['space_id'] = spaceId;
+    if (name != null) d['name'] = name;
+    if (topic != null) d['topic'] = topic;
+    if (position != null) d['position'] = position;
+    if (parentId != null) d['parent_id'] = parentId;
+    if (rateLimit != null) d['rate_limit'] = rateLimit;
+    if (bitrate != null) d['bitrate'] = bitrate;
+    if (userLimit != null) d['user_limit'] = userLimit;
+    if (recipients != null) d['recipients'] = toJsonList(recipients!);
+    if (ownerId != null) d['owner_id'] = ownerId;
+    if (lastMessageId != null) d['last_message_id'] = lastMessageId;
+    if (allowAnonymousRead) d['allow_anonymous_read'] = true;
+    if (archived != null) d['archived'] = archived;
+    if (autoArchiveAfter != null) d['auto_archive_after'] = autoArchiveAfter;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/command.dart
+++ b/packages/accordkit/lib/src/models/command.dart
@@ -1,0 +1,47 @@
+import '../utils/json_utils.dart';
+
+/// An application (slash) command.
+class AccordCommand {
+  String id;
+  String applicationId;
+  String? spaceId;
+  String name;
+  String description;
+  Object? options;
+  String type;
+
+  AccordCommand({
+    this.id = '',
+    this.applicationId = '',
+    this.spaceId,
+    this.name = '',
+    this.description = '',
+    this.options,
+    this.type = 'chat_input',
+  });
+
+  factory AccordCommand.fromJson(Map<String, dynamic> d) {
+    return AccordCommand(
+      id: asString(d['id']),
+      applicationId: asString(d['application_id']),
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+      name: asString(d['name']),
+      description: asString(d['description']),
+      options: d['options'],
+      type: asString(d['type'], 'chat_input'),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'application_id': applicationId,
+      'name': name,
+      'description': description,
+      'type': type,
+    };
+    if (spaceId != null) d['space_id'] = spaceId;
+    if (options != null) d['options'] = options;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/embed.dart
+++ b/packages/accordkit/lib/src/models/embed.dart
@@ -1,0 +1,120 @@
+/// A message embed, with a chainable builder API mirroring the reference
+/// client. All setters return `this` so calls can be fluently chained.
+class AccordEmbed {
+  Object? title;
+  Object? type;
+  Object? description;
+  Object? url;
+  Object? timestamp;
+  Object? color;
+  Object? footer;
+  Object? image;
+  Object? thumbnail;
+  Object? author;
+  List<dynamic>? fields;
+
+  AccordEmbed({
+    this.title,
+    this.type,
+    this.description,
+    this.url,
+    this.timestamp,
+    this.color,
+    this.footer,
+    this.image,
+    this.thumbnail,
+    this.author,
+    this.fields,
+  });
+
+  factory AccordEmbed.fromJson(Map<String, dynamic> d) {
+    return AccordEmbed(
+      title: d['title'],
+      type: d['type'],
+      description: d['description'],
+      url: d['url'],
+      timestamp: d['timestamp'],
+      color: d['color'],
+      footer: d['footer'],
+      image: d['image'],
+      thumbnail: d['thumbnail'],
+      author: d['author'],
+      fields: d['fields'] as List<dynamic>?,
+    );
+  }
+
+  /// Creates an empty embed to start building from.
+  static AccordEmbed build() => AccordEmbed();
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{};
+    if (title != null) d['title'] = title;
+    if (type != null) d['type'] = type;
+    if (description != null) d['description'] = description;
+    if (url != null) d['url'] = url;
+    if (timestamp != null) d['timestamp'] = timestamp;
+    if (color != null) d['color'] = color;
+    if (footer != null) d['footer'] = footer;
+    if (image != null) d['image'] = image;
+    if (thumbnail != null) d['thumbnail'] = thumbnail;
+    if (author != null) d['author'] = author;
+    if (fields != null) d['fields'] = fields;
+    return d;
+  }
+
+  AccordEmbed setTitle(String t) {
+    title = t;
+    return this;
+  }
+
+  AccordEmbed setDescription(String desc) {
+    description = desc;
+    return this;
+  }
+
+  AccordEmbed setColor(int c) {
+    color = c;
+    return this;
+  }
+
+  AccordEmbed setUrl(String u) {
+    url = u;
+    return this;
+  }
+
+  AccordEmbed setTimestamp(String ts) {
+    timestamp = ts;
+    return this;
+  }
+
+  AccordEmbed addField(String name, String value, {bool inline = false}) {
+    fields ??= [];
+    fields!.add({'name': name, 'value': value, 'inline': inline});
+    return this;
+  }
+
+  AccordEmbed setFooter(String text, {String? iconUrl}) {
+    final f = <String, dynamic>{'text': text};
+    if (iconUrl != null) f['icon_url'] = iconUrl;
+    footer = f;
+    return this;
+  }
+
+  AccordEmbed setImage(String imageUrl) {
+    image = {'url': imageUrl};
+    return this;
+  }
+
+  AccordEmbed setThumbnail(String thumbnailUrl) {
+    thumbnail = {'url': thumbnailUrl};
+    return this;
+  }
+
+  AccordEmbed setAuthor(String name, {String? authorUrl, String? iconUrl}) {
+    final a = <String, dynamic>{'name': name};
+    if (authorUrl != null) a['url'] = authorUrl;
+    if (iconUrl != null) a['icon_url'] = iconUrl;
+    author = a;
+    return this;
+  }
+}

--- a/packages/accordkit/lib/src/models/emoji.dart
+++ b/packages/accordkit/lib/src/models/emoji.dart
@@ -1,0 +1,56 @@
+import '../utils/json_utils.dart';
+
+/// A custom emoji. The [id] is null for built-in unicode emoji.
+class AccordEmoji {
+  String? id;
+  String name;
+  bool animated;
+  bool managed;
+  bool available;
+  bool requireColons;
+  List<String> roleIds;
+  String? creatorId;
+  String imageUrl;
+
+  AccordEmoji({
+    this.id,
+    this.name = '',
+    this.animated = false,
+    this.managed = false,
+    this.available = true,
+    this.requireColons = true,
+    List<String>? roleIds,
+    this.creatorId,
+    this.imageUrl = '',
+  }) : roleIds = roleIds ?? [];
+
+  factory AccordEmoji.fromJson(Map<String, dynamic> d) {
+    final rawRoles = asList(d['role_ids'] ?? d['roles']) ?? const [];
+    return AccordEmoji(
+      id: asStringOrNull(d['id']),
+      name: asString(d['name']),
+      animated: asBool(d['animated']),
+      managed: asBool(d['managed']),
+      available: asBool(d['available'], true),
+      requireColons: asBool(d['require_colons'], true),
+      imageUrl: asString(d['image_url']),
+      roleIds: [for (final r in rawRoles) asString(r)],
+      creatorId: asStringOrNull(d['creator_id']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'name': name,
+      'animated': animated,
+      'managed': managed,
+      'available': available,
+      'require_colons': requireColons,
+      'role_ids': roleIds,
+    };
+    if (id != null) d['id'] = id;
+    if (creatorId != null) d['creator_id'] = creatorId;
+    if (imageUrl.isNotEmpty) d['image_url'] = imageUrl;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/interaction.dart
+++ b/packages/accordkit/lib/src/models/interaction.dart
@@ -1,0 +1,81 @@
+import '../utils/json_utils.dart';
+import 'message.dart';
+
+/// An interaction (slash command invocation, component use, etc.).
+class AccordInteraction {
+  String id;
+  String applicationId;
+  String type;
+  Object? data;
+  String? spaceId;
+  String? channelId;
+  String? memberId;
+  String? userId;
+  String token;
+  AccordMessage? message;
+  Object? locale;
+
+  AccordInteraction({
+    this.id = '',
+    this.applicationId = '',
+    this.type = 'command',
+    this.data,
+    this.spaceId,
+    this.channelId,
+    this.memberId,
+    this.userId,
+    this.token = '',
+    this.message,
+    this.locale,
+  });
+
+  factory AccordInteraction.fromJson(Map<String, dynamic> d) {
+    final i = AccordInteraction(
+      id: asString(d['id']),
+      applicationId: asString(d['application_id']),
+      type: asString(d['type'], 'command'),
+      data: d['data'],
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+      channelId: asStringOrNull(d['channel_id']),
+      token: asString(d['token']),
+      locale: d['locale'],
+    );
+
+    final rawMember = asMap(d['member']);
+    if (rawMember != null) {
+      final memberUser = asMap(rawMember['user']);
+      if (memberUser != null) i.memberId = asString(memberUser['id']);
+    } else {
+      i.memberId = asStringOrNull(d['member_id']);
+    }
+
+    final rawUser = asMap(d['user']);
+    if (rawUser != null) {
+      i.userId = asString(rawUser['id']);
+    } else {
+      i.userId = asStringOrNull(d['user_id']);
+    }
+
+    final rawMessage = asMap(d['message']);
+    if (rawMessage != null) i.message = AccordMessage.fromJson(rawMessage);
+
+    return i;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'application_id': applicationId,
+      'type': type,
+      'token': token,
+    };
+    if (data != null) d['data'] = data;
+    if (spaceId != null) d['space_id'] = spaceId;
+    if (channelId != null) d['channel_id'] = channelId;
+    if (memberId != null) d['member_id'] = memberId;
+    if (userId != null) d['user_id'] = userId;
+    if (message != null) d['message'] = message!.toJson();
+    if (locale != null) d['locale'] = locale;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/invite.dart
+++ b/packages/accordkit/lib/src/models/invite.dart
@@ -1,0 +1,65 @@
+import '../utils/json_utils.dart';
+
+/// An invite to a space or channel.
+class AccordInvite {
+  String code;
+  String spaceId;
+  String channelId;
+  String? inviterId;
+  Object? maxUses;
+  int uses;
+  Object? maxAge;
+  bool temporary;
+  String createdAt;
+  Object? expiresAt;
+
+  AccordInvite({
+    this.code = '',
+    this.spaceId = '',
+    this.channelId = '',
+    this.inviterId,
+    this.maxUses,
+    this.uses = 0,
+    this.maxAge,
+    this.temporary = false,
+    this.createdAt = '',
+    this.expiresAt,
+  });
+
+  factory AccordInvite.fromJson(Map<String, dynamic> d) {
+    final i = AccordInvite(
+      code: asString(d['code']),
+      spaceId: asString(d['space_id'] ?? d['guild_id']),
+      channelId: asString(d['channel_id']),
+      maxUses: d['max_uses'],
+      uses: asInt(d['uses']),
+      maxAge: d['max_age'],
+      temporary: asBool(d['temporary']),
+      createdAt: asString(d['created_at']),
+      expiresAt: d['expires_at'],
+    );
+    final rawInviter = asMap(d['inviter']);
+    if (rawInviter != null) {
+      i.inviterId = asString(rawInviter['id']);
+    } else {
+      i.inviterId = asStringOrNull(d['inviter_id']);
+    }
+    return i;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'code': code,
+      'space_id': spaceId,
+      'channel_id': channelId,
+      'uses': uses,
+      'temporary': temporary,
+      'created_at': createdAt,
+    };
+    if (inviterId != null) d['inviter_id'] = inviterId;
+    if (maxUses != null) d['max_uses'] = maxUses;
+    if (maxAge != null) d['max_age'] = maxAge;
+    if (expiresAt != null) d['expires_at'] = expiresAt;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/member.dart
+++ b/packages/accordkit/lib/src/models/member.dart
@@ -1,0 +1,81 @@
+import '../utils/json_utils.dart';
+import 'user.dart';
+
+/// A member of a space (a user plus space-scoped data).
+class AccordMember {
+  String userId;
+  AccordUser? user;
+  String spaceId;
+  String? nickname;
+  Object? avatar;
+  List<String> roles;
+  String joinedAt;
+  Object? premiumSince;
+  bool deaf;
+  bool mute;
+  Object? pending;
+  Object? timedOutUntil;
+  Object? permissions;
+
+  AccordMember({
+    this.userId = '',
+    this.user,
+    this.spaceId = '',
+    this.nickname,
+    this.avatar,
+    List<String>? roles,
+    this.joinedAt = '',
+    this.premiumSince,
+    this.deaf = false,
+    this.mute = false,
+    this.pending,
+    this.timedOutUntil,
+    this.permissions,
+  }) : roles = roles ?? [];
+
+  factory AccordMember.fromJson(Map<String, dynamic> d) {
+    final m = AccordMember(
+      spaceId: asString(d['space_id'] ?? d['guild_id']),
+      nickname: (d['nick'] ?? d['nickname']) as String?,
+      avatar: d['avatar'],
+      joinedAt: asString(d['joined_at']),
+      premiumSince: d['premium_since'],
+      deaf: asBool(d['deaf']),
+      mute: asBool(d['mute']),
+      pending: d['pending'],
+      timedOutUntil: d['communication_disabled_until'] ?? d['timed_out_until'],
+      permissions: d['permissions'],
+    );
+
+    final rawUser = asMap(d['user']);
+    if (rawUser != null) {
+      m.userId = asString(rawUser['id']);
+      m.user = AccordUser.fromJson(rawUser);
+    } else {
+      m.userId = asString(d['user_id']);
+    }
+
+    for (final r in asList(d['roles']) ?? const []) {
+      m.roles.add(asString(r));
+    }
+    return m;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'user_id': userId,
+      'space_id': spaceId,
+      'roles': roles,
+      'joined_at': joinedAt,
+      'deaf': deaf,
+      'mute': mute,
+    };
+    if (nickname != null) d['nickname'] = nickname;
+    if (avatar != null) d['avatar'] = avatar;
+    if (premiumSince != null) d['premium_since'] = premiumSince;
+    if (pending != null) d['pending'] = pending;
+    if (timedOutUntil != null) d['timed_out_until'] = timedOutUntil;
+    if (permissions != null) d['permissions'] = permissions;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/message.dart
+++ b/packages/accordkit/lib/src/models/message.dart
@@ -1,0 +1,181 @@
+import '../utils/json_utils.dart';
+import 'attachment.dart';
+import 'embed.dart';
+import 'reaction.dart';
+
+/// A message in a channel, thread, or DM.
+class AccordMessage {
+  String id;
+  String channelId;
+  String? spaceId;
+  String authorId;
+  String content;
+  String type;
+  String timestamp;
+  Object? editedAt;
+  bool tts;
+  bool pinned;
+  bool mentionEveryone;
+  List<String> mentions;
+  List<String> mentionRoles;
+  List<AccordAttachment> attachments;
+  List<AccordEmbed> embeds;
+  List<AccordReaction>? reactions;
+  String? replyTo;
+  int flags;
+  Object? components;
+  List<String>? stickerIds;
+  String? webhookId;
+  String? threadId;
+  int replyCount;
+  Object? lastReplyAt;
+  List<String> threadParticipants;
+  Object? title;
+
+  AccordMessage({
+    this.id = '',
+    this.channelId = '',
+    this.spaceId,
+    this.authorId = '',
+    this.content = '',
+    this.type = 'default',
+    this.timestamp = '',
+    this.editedAt,
+    this.tts = false,
+    this.pinned = false,
+    this.mentionEveryone = false,
+    List<String>? mentions,
+    List<String>? mentionRoles,
+    List<AccordAttachment>? attachments,
+    List<AccordEmbed>? embeds,
+    this.reactions,
+    this.replyTo,
+    this.flags = 0,
+    this.components,
+    this.stickerIds,
+    this.webhookId,
+    this.threadId,
+    this.replyCount = 0,
+    this.lastReplyAt,
+    List<String>? threadParticipants,
+    this.title,
+  })  : mentions = mentions ?? [],
+        mentionRoles = mentionRoles ?? [],
+        attachments = attachments ?? [],
+        embeds = embeds ?? [],
+        threadParticipants = threadParticipants ?? [];
+
+  factory AccordMessage.fromJson(Map<String, dynamic> d) {
+    final m = AccordMessage(
+      id: asString(d['id']),
+      channelId: asString(d['channel_id']),
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+      content: asString(d['content']),
+      type: asString(d['type'], 'default'),
+      timestamp: asString(d['timestamp']),
+      editedAt: d['edited_at'] ?? d['edited_timestamp'],
+      tts: asBool(d['tts']),
+      pinned: asBool(d['pinned']),
+      mentionEveryone: asBool(d['mention_everyone']),
+      flags: asInt(d['flags']),
+      components: d['components'],
+      webhookId: asStringOrNull(d['webhook_id']),
+      threadId: asStringOrNull(d['thread_id']),
+      replyCount: asInt(d['reply_count']),
+      lastReplyAt: d['last_reply_at'],
+      title: d['title'],
+    );
+
+    final rawAuthor = asMap(d['author']);
+    m.authorId = rawAuthor != null
+        ? asString(rawAuthor['id'])
+        : asString(d['author_id']);
+
+    for (final u in asList(d['mentions']) ?? const []) {
+      final um = asMap(u);
+      if (um != null) {
+        m.mentions.add(asString(um['id']));
+      } else if (u is String) {
+        m.mentions.add(u);
+      }
+    }
+
+    for (final r in asList(d['mention_roles']) ?? const []) {
+      m.mentionRoles.add(asString(r));
+    }
+
+    for (final a in asList(d['attachments']) ?? const []) {
+      final am = asMap(a);
+      if (am != null) m.attachments.add(AccordAttachment.fromJson(am));
+    }
+
+    for (final e in asList(d['embeds']) ?? const []) {
+      final em = asMap(e);
+      if (em != null) m.embeds.add(AccordEmbed.fromJson(em));
+    }
+
+    final rawReactions = asList(d['reactions']);
+    if (rawReactions != null) {
+      m.reactions = [
+        for (final r in rawReactions)
+          if (asMap(r) != null) AccordReaction.fromJson(asMap(r)!),
+      ];
+    }
+
+    final rawRef = d['reply_to'] ?? d['message_reference'];
+    final refMap = asMap(rawRef);
+    if (refMap != null) {
+      m.replyTo = asStringOrNull(refMap['message_id']);
+    } else if (rawRef is String) {
+      m.replyTo = rawRef;
+    }
+
+    final rawStickers = asList(d['sticker_ids'] ?? d['sticker_items']);
+    if (rawStickers != null) {
+      m.stickerIds = [
+        for (final s in rawStickers)
+          asMap(s) != null ? asString(asMap(s)!['id']) : asString(s),
+      ];
+    }
+
+    for (final p in asList(d['thread_participants']) ?? const []) {
+      m.threadParticipants.add(asString(p));
+    }
+
+    return m;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'channel_id': channelId,
+      'author_id': authorId,
+      'content': content,
+      'type': type,
+      'timestamp': timestamp,
+      'tts': tts,
+      'pinned': pinned,
+      'mention_everyone': mentionEveryone,
+      'mentions': mentions,
+      'mention_roles': mentionRoles,
+      'flags': flags,
+      'attachments': toJsonList(attachments),
+      'embeds': toJsonList(embeds),
+    };
+    if (spaceId != null) d['space_id'] = spaceId;
+    if (editedAt != null) d['edited_at'] = editedAt;
+    if (reactions != null) d['reactions'] = toJsonList(reactions!);
+    if (replyTo != null) d['reply_to'] = replyTo;
+    if (components != null) d['components'] = components;
+    if (stickerIds != null) d['sticker_ids'] = stickerIds;
+    if (webhookId != null) d['webhook_id'] = webhookId;
+    if (threadId != null) d['thread_id'] = threadId;
+    if (replyCount > 0) d['reply_count'] = replyCount;
+    if (lastReplyAt != null) d['last_reply_at'] = lastReplyAt;
+    if (threadParticipants.isNotEmpty) {
+      d['thread_participants'] = threadParticipants;
+    }
+    if (title != null) d['title'] = title;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/permission.dart
+++ b/packages/accordkit/lib/src/models/permission.dart
@@ -1,0 +1,180 @@
+/// Permission name constants and helpers. Permissions are represented as
+/// string identifiers throughout the API.
+class AccordPermission {
+  static const String createInvites = 'create_invites';
+  static const String kickMembers = 'kick_members';
+  static const String banMembers = 'ban_members';
+  static const String administrator = 'administrator';
+  static const String manageChannels = 'manage_channels';
+  static const String manageSpace = 'manage_space';
+  static const String addReactions = 'add_reactions';
+  static const String viewAuditLog = 'view_audit_log';
+  static const String prioritySpeaker = 'priority_speaker';
+  static const String stream = 'stream';
+  static const String viewChannel = 'view_channel';
+  static const String sendMessages = 'send_messages';
+  static const String sendTts = 'send_tts';
+  static const String manageMessages = 'manage_messages';
+  static const String embedLinks = 'embed_links';
+  static const String attachFiles = 'attach_files';
+  static const String readHistory = 'read_history';
+  static const String mentionEveryone = 'mention_everyone';
+  static const String useExternalEmojis = 'use_external_emojis';
+  static const String connect = 'connect';
+  static const String speak = 'speak';
+  static const String muteMembers = 'mute_members';
+  static const String deafenMembers = 'deafen_members';
+  static const String moveMembers = 'move_members';
+  static const String useVad = 'use_vad';
+  static const String changeNickname = 'change_nickname';
+  static const String manageNicknames = 'manage_nicknames';
+  static const String manageRoles = 'manage_roles';
+  static const String manageWebhooks = 'manage_webhooks';
+  static const String manageEmojis = 'manage_emojis';
+  static const String manageSoundboard = 'manage_soundboard';
+  static const String useSoundboard = 'use_soundboard';
+  static const String useCommands = 'use_commands';
+  static const String manageEvents = 'manage_events';
+  static const String manageThreads = 'manage_threads';
+  static const String createThreads = 'create_threads';
+  static const String useExternalStickers = 'use_external_stickers';
+  static const String sendInThreads = 'send_in_threads';
+  static const String moderateMembers = 'moderate_members';
+  static const String manageAutomod = 'manage_automod';
+
+  /// Every known permission identifier.
+  static List<String> all() => const [
+        createInvites,
+        kickMembers,
+        banMembers,
+        administrator,
+        manageChannels,
+        manageSpace,
+        addReactions,
+        viewAuditLog,
+        prioritySpeaker,
+        stream,
+        viewChannel,
+        sendMessages,
+        sendTts,
+        manageMessages,
+        embedLinks,
+        attachFiles,
+        readHistory,
+        mentionEveryone,
+        useExternalEmojis,
+        connect,
+        speak,
+        muteMembers,
+        deafenMembers,
+        moveMembers,
+        useVad,
+        changeNickname,
+        manageNicknames,
+        manageRoles,
+        manageWebhooks,
+        manageEmojis,
+        manageSoundboard,
+        useSoundboard,
+        useCommands,
+        manageEvents,
+        manageThreads,
+        createThreads,
+        useExternalStickers,
+        sendInThreads,
+        moderateMembers,
+        manageAutomod,
+      ];
+
+  /// Whether [permissions] grants [perm]. [administrator] implies all.
+  static bool has(List<String> permissions, String perm) {
+    return permissions.contains(perm) || permissions.contains(administrator);
+  }
+
+  /// A human-readable description for a permission, or empty if unknown.
+  static String description(String perm) {
+    switch (perm) {
+      case createInvites:
+        return 'Allows creating invite links to the space';
+      case kickMembers:
+        return 'Allows kicking members from the space';
+      case banMembers:
+        return 'Allows banning members from the space';
+      case administrator:
+        return 'Grants all permissions and bypasses all checks';
+      case manageChannels:
+        return 'Allows creating, editing, and deleting channels';
+      case manageSpace:
+        return 'Allows editing space name, icon, and settings';
+      case addReactions:
+        return 'Allows adding reactions to messages';
+      case viewAuditLog:
+        return 'Allows viewing the audit log';
+      case prioritySpeaker:
+        return 'Allows being heard over other users in voice';
+      case stream:
+        return 'Allows screen sharing in voice channels';
+      case viewChannel:
+        return 'Allows viewing a channel';
+      case sendMessages:
+        return 'Allows sending messages in text channels';
+      case sendTts:
+        return 'Allows sending text-to-speech messages';
+      case manageMessages:
+        return 'Allows deleting and pinning messages from other users';
+      case embedLinks:
+        return 'Allows link previews to be shown for sent messages';
+      case attachFiles:
+        return 'Allows uploading files and images';
+      case readHistory:
+        return 'Allows reading message history';
+      case mentionEveryone:
+        return 'Allows using @everyone and @here mentions';
+      case useExternalEmojis:
+        return 'Allows using emojis from other spaces';
+      case connect:
+        return 'Allows joining voice channels';
+      case speak:
+        return 'Allows speaking in voice channels';
+      case muteMembers:
+        return 'Allows muting other members in voice channels';
+      case deafenMembers:
+        return 'Allows deafening other members in voice channels';
+      case moveMembers:
+        return 'Allows moving members between voice channels';
+      case useVad:
+        return 'Allows using voice activity detection instead of push-to-talk';
+      case changeNickname:
+        return 'Allows changing own nickname';
+      case manageNicknames:
+        return 'Allows changing nicknames of other members';
+      case manageRoles:
+        return 'Allows creating and editing roles below their highest role';
+      case manageWebhooks:
+        return 'Allows creating, editing, and deleting webhooks';
+      case manageEmojis:
+        return 'Allows managing custom emojis';
+      case manageSoundboard:
+        return 'Allows managing soundboard sounds';
+      case useSoundboard:
+        return 'Allows playing soundboard sounds';
+      case useCommands:
+        return 'Allows using bot and slash commands';
+      case manageEvents:
+        return 'Allows creating, editing, and deleting events';
+      case manageThreads:
+        return 'Allows managing threads and forum posts';
+      case createThreads:
+        return 'Allows creating threads and forum posts';
+      case useExternalStickers:
+        return 'Allows using stickers from other spaces';
+      case sendInThreads:
+        return 'Allows sending messages in threads';
+      case moderateMembers:
+        return 'Allows timing out and moderating members';
+      case manageAutomod:
+        return 'Allows configuring auto-moderation rules';
+    }
+    return '';
+  }
+}

--- a/packages/accordkit/lib/src/models/permission_overwrite.dart
+++ b/packages/accordkit/lib/src/models/permission_overwrite.dart
@@ -1,0 +1,36 @@
+import '../utils/json_utils.dart';
+
+/// A channel permission overwrite targeting a role or member.
+class AccordPermissionOverwrite {
+  String id;
+  String type;
+  List<dynamic> allow;
+  List<dynamic> deny;
+
+  AccordPermissionOverwrite({
+    this.id = '',
+    this.type = 'role',
+    List<dynamic>? allow,
+    List<dynamic>? deny,
+  })  : allow = allow ?? [],
+        deny = deny ?? [];
+
+  factory AccordPermissionOverwrite.fromJson(Map<String, dynamic> d) {
+    final rawType = asString(d['type'], 'role');
+    return AccordPermissionOverwrite(
+      id: asString(d['id']),
+      type: rawType == 'member' ? 'user' : rawType,
+      allow: asList(d['allow']) ?? [],
+      deny: asList(d['deny']) ?? [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type,
+      'allow': allow,
+      'deny': deny,
+    };
+  }
+}

--- a/packages/accordkit/lib/src/models/plugin_manifest.dart
+++ b/packages/accordkit/lib/src/models/plugin_manifest.dart
@@ -1,0 +1,149 @@
+import '../utils/json_utils.dart';
+
+/// Runtime kind of a plugin.
+enum PluginRuntime { scripted, native }
+
+/// Lifecycle state of an activity session.
+enum SessionState { lobby, running, ended }
+
+/// A participant's role within an activity session.
+enum ParticipantRole { spectator, player }
+
+/// A manifest describing a server-installed plugin.
+class AccordPluginManifest {
+  String id;
+  String name;
+
+  /// "activity", "bot", "theme", or "command".
+  String type;
+
+  /// "scripted" or "native".
+  String runtime;
+  String description;
+  String? iconUrl;
+
+  /// Lua source URL (scripted plugins).
+  String? sourceUrl;
+
+  /// Scene path within the bundle (native plugins).
+  String? entryPoint;
+
+  /// "lua" for scripted plugins.
+  String format;
+  int bundleSize;
+
+  /// "sha256:<hex>" (native plugins).
+  String bundleHash;
+
+  /// 0 = unlimited.
+  int maxParticipants;
+
+  /// 0 = unlimited; -1 = no spectators.
+  int maxSpectators;
+
+  /// Max user-supplied file size in bytes (0 = no file sharing).
+  int maxFileSize;
+  String version;
+  List<dynamic> permissions;
+  bool lobby;
+  List<dynamic> dataTopics;
+  bool signed;
+  String? signature;
+
+  /// `[width, height]` canvas size for scripted plugins.
+  List<int> canvasSize;
+
+  /// `{leaderboards: [...], achievements: [...], ...}`.
+  Map<String, dynamic> services;
+
+  AccordPluginManifest({
+    this.id = '',
+    this.name = '',
+    this.type = '',
+    this.runtime = '',
+    this.description = '',
+    this.iconUrl,
+    this.sourceUrl,
+    this.entryPoint,
+    this.format = '',
+    this.bundleSize = 0,
+    this.bundleHash = '',
+    this.maxParticipants = 0,
+    this.maxSpectators = 0,
+    this.maxFileSize = 0,
+    this.version = '',
+    List<dynamic>? permissions,
+    this.lobby = false,
+    List<dynamic>? dataTopics,
+    this.signed = false,
+    this.signature,
+    List<int>? canvasSize,
+    Map<String, dynamic>? services,
+  })  : permissions = permissions ?? [],
+        dataTopics = dataTopics ?? [],
+        canvasSize = canvasSize ?? [480, 360],
+        services = services ?? {};
+
+  factory AccordPluginManifest.fromJson(Map<String, dynamic> d) {
+    final m = AccordPluginManifest(
+      id: asString(d['id']),
+      name: asString(d['name']),
+      type: asString(d['type']),
+      runtime: asString(d['runtime']),
+      description: asString(d['description']),
+      iconUrl: asStringOrNull(d['icon_url']),
+      sourceUrl: asStringOrNull(d['source_url']),
+      entryPoint: asStringOrNull(d['entry_point']),
+      format: asString(d['format']),
+      bundleSize: asInt(d['bundle_size']),
+      bundleHash: asString(d['bundle_hash']),
+      maxParticipants: asInt(d['max_participants']),
+      maxSpectators: asInt(d['max_spectators']),
+      maxFileSize: asInt(d['max_file_size']),
+      version: asString(d['version']),
+      permissions: asList(d['permissions']) ?? [],
+      lobby: asBool(d['lobby']),
+      dataTopics: asList(d['data_topics']) ?? [],
+      signed: asBool(d['signed']),
+      signature: asStringOrNull(d['signature']),
+      services: asMap(d['services']) ?? {},
+    );
+
+    final rawCanvas = asList(d['canvas_size']);
+    if (rawCanvas != null && rawCanvas.length >= 2) {
+      m.canvasSize = [asInt(rawCanvas[0]), asInt(rawCanvas[1])];
+    } else if (d.containsKey('canvas_width') &&
+        d.containsKey('canvas_height')) {
+      m.canvasSize = [asInt(d['canvas_width']), asInt(d['canvas_height'])];
+    }
+    return m;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'name': name,
+      'type': type,
+      'runtime': runtime,
+      'description': description,
+      'bundle_size': bundleSize,
+      'bundle_hash': bundleHash,
+      'max_participants': maxParticipants,
+      'max_spectators': maxSpectators,
+      'max_file_size': maxFileSize,
+      'version': version,
+      'permissions': permissions,
+      'lobby': lobby,
+      'data_topics': dataTopics,
+      'signed': signed,
+      'canvas_size': canvasSize,
+    };
+    if (services.isNotEmpty) d['services'] = services;
+    if (format.isNotEmpty) d['format'] = format;
+    if (iconUrl != null) d['icon_url'] = iconUrl;
+    if (sourceUrl != null) d['source_url'] = sourceUrl;
+    if (entryPoint != null) d['entry_point'] = entryPoint;
+    if (signature != null) d['signature'] = signature;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/presence.dart
+++ b/packages/accordkit/lib/src/models/presence.dart
@@ -1,0 +1,49 @@
+import '../utils/json_utils.dart';
+import 'activity.dart';
+
+/// A presence update describing a user's status and activities.
+class AccordPresence {
+  String userId;
+  String status;
+  Map<String, dynamic> clientStatus;
+  List<AccordActivity> activities;
+  String? spaceId;
+
+  AccordPresence({
+    this.userId = '',
+    this.status = 'offline',
+    Map<String, dynamic>? clientStatus,
+    List<AccordActivity>? activities,
+    this.spaceId,
+  })  : clientStatus = clientStatus ?? {},
+        activities = activities ?? [];
+
+  factory AccordPresence.fromJson(Map<String, dynamic> d) {
+    final p = AccordPresence(
+      status: asString(d['status'], 'offline'),
+      clientStatus: asMap(d['client_status']) ?? {},
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+    );
+
+    final rawUser = asMap(d['user']);
+    p.userId =
+        rawUser != null ? asString(rawUser['id']) : asString(d['user_id']);
+
+    for (final a in asList(d['activities']) ?? const []) {
+      final am = asMap(a);
+      if (am != null) p.activities.add(AccordActivity.fromJson(am));
+    }
+    return p;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'user_id': userId,
+      'status': status,
+      'client_status': clientStatus,
+      'activities': toJsonList(activities),
+    };
+    if (spaceId != null) d['space_id'] = spaceId;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/reaction.dart
+++ b/packages/accordkit/lib/src/models/reaction.dart
@@ -1,0 +1,56 @@
+import '../utils/json_utils.dart';
+
+/// An aggregated reaction on a message.
+class AccordReaction {
+  /// `{ "id": String?, "name": String }`.
+  Map<String, dynamic> emoji;
+  int count;
+  bool includesMe;
+
+  AccordReaction({
+    Map<String, dynamic>? emoji,
+    this.count = 0,
+    this.includesMe = false,
+  }) : emoji = emoji ?? {};
+
+  factory AccordReaction.fromJson(Map<String, dynamic> d) {
+    final emoji = <String, dynamic>{};
+    final rawEmoji = d['emoji'];
+    if (rawEmoji is Map) {
+      final m = rawEmoji.cast<String, dynamic>();
+      emoji['id'] = asStringOrNull(m['id']);
+      emoji['name'] = asString(m['name']);
+    } else if (rawEmoji is String) {
+      // Custom emoji travel as the bare token `name:id` (id a numeric
+      // snowflake); unicode emoji arrive as a glyph or shortcode. Split the
+      // custom form so the id survives — otherwise the whole `name:id` string
+      // lands in `name` with a null id and renders as literal text.
+      final i = rawEmoji.lastIndexOf(':');
+      if (i > 0 &&
+          i < rawEmoji.length - 1 &&
+          rawEmoji
+              .substring(i + 1)
+              .codeUnits
+              .every((c) => c >= 0x30 && c <= 0x39)) {
+        emoji['id'] = rawEmoji.substring(i + 1);
+        emoji['name'] = rawEmoji.substring(0, i);
+      } else {
+        emoji['id'] = null;
+        emoji['name'] = rawEmoji;
+      }
+    }
+    return AccordReaction(
+      emoji: emoji,
+      count: asInt(d['count']),
+      includesMe: asBool(d['me'] ?? d['includes_me']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'emoji': emoji,
+      'count': count,
+      'includes_me': includesMe,
+    };
+  }
+}

--- a/packages/accordkit/lib/src/models/role.dart
+++ b/packages/accordkit/lib/src/models/role.dart
@@ -1,0 +1,55 @@
+import '../utils/json_utils.dart';
+
+/// A role within a space.
+class AccordRole {
+  String id;
+  String name;
+  int color;
+  bool hoist;
+  Object? icon;
+  int position;
+  List<dynamic> permissions;
+  bool managed;
+  bool mentionable;
+
+  AccordRole({
+    this.id = '',
+    this.name = '',
+    this.color = 0,
+    this.hoist = false,
+    this.icon,
+    this.position = 0,
+    List<dynamic>? permissions,
+    this.managed = false,
+    this.mentionable = false,
+  }) : permissions = permissions ?? [];
+
+  factory AccordRole.fromJson(Map<String, dynamic> d) {
+    return AccordRole(
+      id: asString(d['id']),
+      name: asString(d['name']),
+      color: asInt(d['color']),
+      hoist: asBool(d['hoist']),
+      icon: d['icon'],
+      position: asInt(d['position']),
+      permissions: asList(d['permissions']) ?? [],
+      managed: asBool(d['managed']),
+      mentionable: asBool(d['mentionable']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'name': name,
+      'color': color,
+      'hoist': hoist,
+      'position': position,
+      'permissions': permissions,
+      'managed': managed,
+      'mentionable': mentionable,
+    };
+    if (icon != null) d['icon'] = icon;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/sound.dart
+++ b/packages/accordkit/lib/src/models/sound.dart
@@ -1,0 +1,47 @@
+import '../utils/json_utils.dart';
+
+/// A soundboard sound.
+class AccordSound {
+  String? id;
+  String name;
+  String audioUrl;
+  double volume;
+  String? creatorId;
+  String createdAt;
+  String updatedAt;
+
+  AccordSound({
+    this.id,
+    this.name = '',
+    this.audioUrl = '',
+    this.volume = 1.0,
+    this.creatorId,
+    this.createdAt = '',
+    this.updatedAt = '',
+  });
+
+  factory AccordSound.fromJson(Map<String, dynamic> d) {
+    return AccordSound(
+      id: asStringOrNull(d['id']),
+      name: asString(d['name']),
+      audioUrl: asString(d['audio_url']),
+      volume: asDouble(d['volume'], 1.0),
+      creatorId: asStringOrNull(d['creator_id']),
+      createdAt: asString(d['created_at']),
+      updatedAt: asString(d['updated_at']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'name': name,
+      'audio_url': audioUrl,
+      'volume': volume,
+      'created_at': createdAt,
+      'updated_at': updatedAt,
+    };
+    if (id != null) d['id'] = id;
+    if (creatorId != null) d['creator_id'] = creatorId;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/space.dart
+++ b/packages/accordkit/lib/src/models/space.dart
@@ -1,0 +1,147 @@
+import '../utils/json_utils.dart';
+import 'emoji.dart';
+import 'role.dart';
+
+/// A space (server/guild).
+class AccordSpace {
+  String id;
+  String name;
+  String slug;
+  String? description;
+  Object? icon;
+  Object? banner;
+  Object? splash;
+  String ownerId;
+  List<dynamic> features;
+  bool public;
+  bool allowGuestAccess;
+  String verificationLevel;
+  String defaultNotifications;
+  String explicitContentFilter;
+  List<AccordRole> roles;
+  List<AccordEmoji> emojis;
+  Object? memberCount;
+  Object? presenceCount;
+  Object? maxMembers;
+  Object? vanityUrlCode;
+  String preferredLocale;
+  String? afkChannelId;
+  int afkTimeout;
+  String? systemChannelId;
+  String? rulesChannelId;
+  String nsfwLevel;
+  String premiumTier;
+  int premiumSubscriptionCount;
+  String createdAt;
+
+  AccordSpace({
+    this.id = '',
+    this.name = '',
+    this.slug = '',
+    this.description,
+    this.icon,
+    this.banner,
+    this.splash,
+    this.ownerId = '',
+    List<dynamic>? features,
+    this.public = false,
+    this.allowGuestAccess = true,
+    this.verificationLevel = 'none',
+    this.defaultNotifications = 'all',
+    this.explicitContentFilter = 'disabled',
+    List<AccordRole>? roles,
+    List<AccordEmoji>? emojis,
+    this.memberCount,
+    this.presenceCount,
+    this.maxMembers,
+    this.vanityUrlCode,
+    this.preferredLocale = 'en-US',
+    this.afkChannelId,
+    this.afkTimeout = 0,
+    this.systemChannelId,
+    this.rulesChannelId,
+    this.nsfwLevel = 'default',
+    this.premiumTier = 'none',
+    this.premiumSubscriptionCount = 0,
+    this.createdAt = '',
+  })  : features = features ?? [],
+        roles = roles ?? [],
+        emojis = emojis ?? [];
+
+  factory AccordSpace.fromJson(Map<String, dynamic> d) {
+    final s = AccordSpace(
+      id: asString(d['id']),
+      name: asString(d['name']),
+      slug: asString(d['slug']),
+      description: d['description'] as String?,
+      icon: d['icon'],
+      banner: d['banner'],
+      splash: d['splash'],
+      ownerId: asString(d['owner_id']),
+      features: asList(d['features']) ?? [],
+      public: asBool(d['public']),
+      allowGuestAccess: asBool(d['allow_guest_access'], true),
+      verificationLevel: asString(d['verification_level'], 'none'),
+      defaultNotifications: asString(d['default_notifications'], 'all'),
+      explicitContentFilter: asString(d['explicit_content_filter'], 'disabled'),
+      memberCount: d['member_count'],
+      presenceCount: d['presence_count'],
+      maxMembers: d['max_members'],
+      vanityUrlCode: d['vanity_url_code'],
+      preferredLocale: asString(d['preferred_locale'], 'en-US'),
+      afkChannelId: asStringOrNull(d['afk_channel_id']),
+      afkTimeout: asInt(d['afk_timeout']),
+      systemChannelId: asStringOrNull(d['system_channel_id']),
+      rulesChannelId: asStringOrNull(d['rules_channel_id']),
+      nsfwLevel: asString(d['nsfw_level'], 'default'),
+      premiumTier: asString(d['premium_tier'], 'none'),
+      premiumSubscriptionCount: asInt(d['premium_subscription_count']),
+      createdAt: asString(d['created_at']),
+    );
+
+    for (final r in asList(d['roles']) ?? const []) {
+      final rm = asMap(r);
+      if (rm != null) s.roles.add(AccordRole.fromJson(rm));
+    }
+    for (final e in asList(d['emojis']) ?? const []) {
+      final em = asMap(e);
+      if (em != null) s.emojis.add(AccordEmoji.fromJson(em));
+    }
+    return s;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'name': name,
+      'slug': slug,
+      'owner_id': ownerId,
+      'features': features,
+      'public': public,
+      'allow_guest_access': allowGuestAccess,
+      'verification_level': verificationLevel,
+      'default_notifications': defaultNotifications,
+      'explicit_content_filter': explicitContentFilter,
+      'preferred_locale': preferredLocale,
+      'afk_timeout': afkTimeout,
+      'nsfw_level': nsfwLevel,
+      'premium_tier': premiumTier,
+      'premium_subscription_count': premiumSubscriptionCount,
+      'created_at': createdAt,
+      'roles': toJsonList(roles),
+      'emojis': toJsonList(emojis),
+    };
+    if (description != null) d['description'] = description;
+    if (icon != null) d['icon'] = icon;
+    if (banner != null) d['banner'] = banner;
+    if (splash != null) d['splash'] = splash;
+    if (memberCount != null) d['member_count'] = memberCount;
+    if (presenceCount != null) d['presence_count'] = presenceCount;
+    if (maxMembers != null) d['max_members'] = maxMembers;
+    if (vanityUrlCode != null) d['vanity_url_code'] = vanityUrlCode;
+    if (afkChannelId != null) d['afk_channel_id'] = afkChannelId;
+    if (systemChannelId != null) d['system_channel_id'] = systemChannelId;
+    if (rulesChannelId != null) d['rules_channel_id'] = rulesChannelId;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/user.dart
+++ b/packages/accordkit/lib/src/models/user.dart
@@ -1,0 +1,83 @@
+import '../utils/json_utils.dart';
+
+/// A user account on an Accord instance.
+class AccordUser {
+  String id;
+  String username;
+  String? displayName;
+  String? avatar;
+  String? banner;
+  Object? accentColor;
+  String? bio;
+  bool bot;
+  bool system;
+  int flags;
+  int publicFlags;
+  bool isAdmin;
+  bool mfaEnabled;
+  bool disabled;
+  bool isGuest;
+  String createdAt;
+
+  AccordUser({
+    this.id = '',
+    this.username = '',
+    this.displayName,
+    this.avatar,
+    this.banner,
+    this.accentColor,
+    this.bio,
+    this.bot = false,
+    this.system = false,
+    this.flags = 0,
+    this.publicFlags = 0,
+    this.isAdmin = false,
+    this.mfaEnabled = false,
+    this.disabled = false,
+    this.isGuest = false,
+    this.createdAt = '',
+  });
+
+  factory AccordUser.fromJson(Map<String, dynamic> d) {
+    return AccordUser(
+      id: asString(d['id']),
+      username: asString(d['username']),
+      displayName: d['display_name'] as String?,
+      avatar: d['avatar'] as String?,
+      banner: d['banner'] as String?,
+      accentColor: d['accent_color'],
+      bio: d['bio'] as String?,
+      bot: asBool(d['bot']),
+      system: asBool(d['system']),
+      flags: asInt(d['flags']),
+      publicFlags: asInt(d['public_flags']),
+      isAdmin: asBool(d['is_admin']),
+      mfaEnabled: asBool(d['mfa_enabled']),
+      disabled: asBool(d['disabled']),
+      isGuest: asBool(d['is_guest']),
+      createdAt: asString(d['created_at']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'id': id,
+      'username': username,
+      'bot': bot,
+      'system': system,
+      'flags': flags,
+      'public_flags': publicFlags,
+      'is_admin': isAdmin,
+      'mfa_enabled': mfaEnabled,
+      'disabled': disabled,
+      'is_guest': isGuest,
+      'created_at': createdAt,
+    };
+    if (displayName != null) d['display_name'] = displayName;
+    if (avatar != null) d['avatar'] = avatar;
+    if (banner != null) d['banner'] = banner;
+    if (accentColor != null) d['accent_color'] = accentColor;
+    if (bio != null) d['bio'] = bio;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/voice_server_update.dart
+++ b/packages/accordkit/lib/src/models/voice_server_update.dart
@@ -1,0 +1,55 @@
+import '../utils/json_utils.dart';
+import 'voice_state.dart';
+
+/// Voice backend connection info returned by the REST join endpoint or the
+/// gateway `voice.server_update` event. Carries the backend type and the
+/// credentials needed to connect to LiveKit or the custom SFU.
+class AccordVoiceServerUpdate {
+  String spaceId;
+  String channelId;
+  String backend;
+  String? livekitUrl;
+  String? token;
+  String? sfuEndpoint;
+
+  /// Present in the REST join response, absent in the gateway event.
+  AccordVoiceState? voiceState;
+
+  AccordVoiceServerUpdate({
+    this.spaceId = '',
+    this.channelId = '',
+    this.backend = '',
+    this.livekitUrl,
+    this.token,
+    this.sfuEndpoint,
+    this.voiceState,
+  });
+
+  factory AccordVoiceServerUpdate.fromJson(Map<String, dynamic> d) {
+    final v = AccordVoiceServerUpdate(
+      spaceId: asString(d['space_id']),
+      channelId: asString(d['channel_id']),
+      backend: asString(d['backend']),
+      // REST uses livekit_url / sfu_endpoint; gateway uses url / endpoint.
+      livekitUrl: asStringOrNull(d['livekit_url'] ?? d['url']),
+      token: asStringOrNull(d['token']),
+      sfuEndpoint: asStringOrNull(d['sfu_endpoint'] ?? d['endpoint']),
+    );
+    final rawVs = asMap(d['voice_state']);
+    if (rawVs != null) v.voiceState = AccordVoiceState.fromJson(rawVs);
+    return v;
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'space_id': spaceId,
+      'channel_id': channelId,
+      'backend': backend,
+    };
+    if (livekitUrl != null) d['livekit_url'] = livekitUrl;
+    if (token != null) d['token'] = token;
+    if (sfuEndpoint != null) d['sfu_endpoint'] = sfuEndpoint;
+    if (voiceState != null) d['voice_state'] = voiceState!.toJson();
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/models/voice_state.dart
+++ b/packages/accordkit/lib/src/models/voice_state.dart
@@ -1,0 +1,63 @@
+import '../utils/json_utils.dart';
+
+/// A user's voice connection state in a channel.
+class AccordVoiceState {
+  String userId;
+  String? spaceId;
+  String? channelId;
+  String sessionId;
+  bool deaf;
+  bool mute;
+  bool selfDeaf;
+  bool selfMute;
+  bool selfStream;
+  bool selfVideo;
+  bool suppress;
+
+  AccordVoiceState({
+    this.userId = '',
+    this.spaceId,
+    this.channelId,
+    this.sessionId = '',
+    this.deaf = false,
+    this.mute = false,
+    this.selfDeaf = false,
+    this.selfMute = false,
+    this.selfStream = false,
+    this.selfVideo = false,
+    this.suppress = false,
+  });
+
+  factory AccordVoiceState.fromJson(Map<String, dynamic> d) {
+    return AccordVoiceState(
+      userId: asString(d['user_id']),
+      spaceId: asStringOrNull(d['space_id'] ?? d['guild_id']),
+      channelId: asStringOrNull(d['channel_id']),
+      sessionId: asString(d['session_id']),
+      deaf: asBool(d['deaf']),
+      mute: asBool(d['mute']),
+      selfDeaf: asBool(d['self_deaf']),
+      selfMute: asBool(d['self_mute']),
+      selfStream: asBool(d['self_stream']),
+      selfVideo: asBool(d['self_video']),
+      suppress: asBool(d['suppress']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final d = <String, dynamic>{
+      'user_id': userId,
+      'session_id': sessionId,
+      'deaf': deaf,
+      'mute': mute,
+      'self_deaf': selfDeaf,
+      'self_mute': selfMute,
+      'self_stream': selfStream,
+      'self_video': selfVideo,
+      'suppress': suppress,
+    };
+    if (spaceId != null) d['space_id'] = spaceId;
+    if (channelId != null) d['channel_id'] = channelId;
+    return d;
+  }
+}

--- a/packages/accordkit/lib/src/rest/accord_error.dart
+++ b/packages/accordkit/lib/src/rest/accord_error.dart
@@ -1,0 +1,26 @@
+import '../utils/json_utils.dart';
+
+/// An error returned by the Accord API (or generated client-side for transport
+/// failures, where [code] is "INTERNAL").
+class AccordError {
+  String code;
+  String message;
+  Map<String, dynamic> details;
+
+  AccordError({
+    this.code = '',
+    this.message = '',
+    Map<String, dynamic>? details,
+  }) : details = details ?? {};
+
+  factory AccordError.fromJson(Map<String, dynamic> d) {
+    return AccordError(
+      code: asString(d['code']),
+      message: asString(d['message']),
+      details: asMap(d['details']) ?? {},
+    );
+  }
+
+  @override
+  String toString() => 'AccordError(code: $code, message: $message)';
+}

--- a/packages/accordkit/lib/src/rest/accord_rest.dart
+++ b/packages/accordkit/lib/src/rest/accord_rest.dart
@@ -1,0 +1,366 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../core/accord_config.dart';
+import 'accord_error.dart';
+import 'multipart_form.dart';
+import 'rest_result.dart';
+
+/// Central HTTP client for AccordKit. Handles authentication, request
+/// construction, response-envelope parsing, and automatic rate-limit retry.
+///
+/// The underlying [http.Client] is injectable for testing, as is the [sleep]
+/// callback used between rate-limit retries.
+class AccordRest {
+  static const int maxRetries = 3;
+
+  String token;
+  String tokenType; // "Bot" or "Bearer"
+  String baseUrl;
+
+  final http.Client _client;
+  final Future<void> Function(Duration) _sleep;
+
+  AccordRest(
+    this.baseUrl, {
+    this.token = '',
+    this.tokenType = 'Bot',
+    http.Client? client,
+    Future<void> Function(Duration)? sleep,
+  })  : _client = client ?? http.Client(),
+        _sleep = sleep ?? _defaultSleep;
+
+  static Future<void> _defaultSleep(Duration d) => Future.delayed(d);
+
+  /// Releases the underlying HTTP client.
+  void close() => _client.close();
+
+  /// Performs a JSON HTTP request and returns a parsed [RestResult].
+  ///
+  /// [method] is one of GET/POST/PUT/PATCH/DELETE. A non-null [body]
+  /// (Map or List) is JSON-encoded for non-GET requests. [query] is
+  /// URL-encoded and appended.
+  Future<RestResult> makeRequest(
+    String method,
+    String path, {
+    Object? body,
+    Map<String, dynamic> query = const {},
+  }) async {
+    final uri = _buildUri(path, query);
+    final headers = _buildHeaders();
+    final bodyText = body != null ? jsonEncode(body) : '';
+
+    var attempt = 0;
+    while (attempt < maxRetries) {
+      final http.Response response;
+      try {
+        response = await _send(method, uri, headers, bodyText);
+      } catch (e) {
+        return RestResult.failure(
+          0,
+          _internalError('Failed to start request: $e'),
+        );
+      }
+
+      if (response.statusCode == 429) {
+        final retryAfter = _getRetryAfter(response);
+        attempt += 1;
+        if (attempt < maxRetries) {
+          await _sleep(Duration(milliseconds: (retryAfter * 1000).round()));
+          continue;
+        }
+        return RestResult.failure(
+          429,
+          _internalError('Rate limited after $maxRetries retries'),
+        );
+      }
+
+      return _parseResponse(
+          response.statusCode, utf8.decode(response.bodyBytes));
+    }
+
+    return RestResult.failure(
+      0,
+      _internalError('Request exhausted all retries'),
+    );
+  }
+
+  /// Performs a GET and returns the raw response bytes as [RestResult.data]
+  /// instead of parsing JSON.
+  Future<RestResult> makeRawRequest(
+    String path, {
+    Map<String, dynamic> query = const {},
+  }) async {
+    final uri = _buildUri(path, query);
+    final headers = <String, String>{
+      'User-Agent': AccordConfig.userAgent,
+    };
+    if (token.isNotEmpty) {
+      headers['Authorization'] = '$tokenType $token';
+    }
+
+    var attempt = 0;
+    while (attempt < maxRetries) {
+      final http.Response response;
+      try {
+        response = await _client.get(uri, headers: headers);
+      } catch (e) {
+        return RestResult.failure(
+          0,
+          _internalError('Failed to start request: $e'),
+        );
+      }
+
+      if (response.statusCode == 429) {
+        final retryAfter = _getRetryAfter(response);
+        attempt += 1;
+        if (attempt < maxRetries) {
+          await _sleep(Duration(milliseconds: (retryAfter * 1000).round()));
+          continue;
+        }
+        return RestResult.failure(
+          429,
+          _internalError('Rate limited after $maxRetries retries'),
+        );
+      }
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return RestResult.success(response.statusCode, response.bodyBytes);
+      }
+      return RestResult.failure(
+        response.statusCode,
+        _internalError('HTTP ${response.statusCode}'),
+      );
+    }
+
+    return RestResult.failure(
+      0,
+      _internalError('Request exhausted all retries'),
+    );
+  }
+
+  /// Performs a `multipart/form-data` request (file uploads).
+  Future<RestResult> makeMultipartRequest(
+    String method,
+    String path,
+    MultipartForm form, {
+    Map<String, dynamic> query = const {},
+  }) async {
+    final uri = _buildUri(path, query);
+    final bodyBytes = form.build();
+    final headers = <String, String>{
+      'Content-Type': form.contentType(),
+      'User-Agent': AccordConfig.userAgent,
+    };
+    if (token.isNotEmpty) {
+      headers['Authorization'] = '$tokenType $token';
+    }
+
+    var attempt = 0;
+    while (attempt < maxRetries) {
+      final http.Response response;
+      try {
+        final request = http.Request(method, uri)
+          ..headers.addAll(headers)
+          ..bodyBytes = bodyBytes;
+        final streamed = await _client.send(request);
+        response = await http.Response.fromStream(streamed);
+      } catch (e) {
+        return RestResult.failure(
+          0,
+          _internalError('Failed to start multipart request: $e'),
+        );
+      }
+
+      if (response.statusCode == 429) {
+        final retryAfter = _getRetryAfter(response);
+        attempt += 1;
+        if (attempt < maxRetries) {
+          await _sleep(Duration(milliseconds: (retryAfter * 1000).round()));
+          continue;
+        }
+        return RestResult.failure(
+          429,
+          _internalError('Rate limited after $maxRetries retries'),
+        );
+      }
+
+      return _parseResponse(
+          response.statusCode, utf8.decode(response.bodyBytes));
+    }
+
+    return RestResult.failure(
+      0,
+      _internalError('Multipart request exhausted all retries'),
+    );
+  }
+
+  Future<http.Response> _send(
+    String method,
+    Uri uri,
+    Map<String, String> headers,
+    String bodyText,
+  ) {
+    final hasBody = bodyText.isNotEmpty;
+    switch (method.toUpperCase()) {
+      case 'GET':
+        return _client.get(uri, headers: headers);
+      case 'POST':
+        return _client.post(uri,
+            headers: headers, body: hasBody ? bodyText : null);
+      case 'PUT':
+        return _client.put(uri,
+            headers: headers, body: hasBody ? bodyText : null);
+      case 'PATCH':
+        return _client.patch(uri,
+            headers: headers, body: hasBody ? bodyText : null);
+      case 'DELETE':
+        return _client.delete(uri,
+            headers: headers, body: hasBody ? bodyText : null);
+      default:
+        return _client.get(uri, headers: headers);
+    }
+  }
+
+  Uri _buildUri(String path, Map<String, dynamic> query) {
+    final uri = Uri.parse(baseUrl + path);
+    final encoded = _encodeQuery(query);
+    if (encoded.isEmpty) return uri;
+    final existing = uri.query;
+    final combined = existing.isEmpty ? encoded : '$existing&$encoded';
+    return uri.replace(query: combined);
+  }
+
+  Map<String, String> _buildHeaders() {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'User-Agent': AccordConfig.userAgent,
+    };
+    if (token.isNotEmpty) {
+      headers['Authorization'] = '$tokenType $token';
+    }
+    return headers;
+  }
+
+  /// URL-encodes [params], skipping null values.
+  String _encodeQuery(Map<String, dynamic> params) {
+    if (params.isEmpty) return '';
+    final parts = <String>[];
+    params.forEach((key, value) {
+      if (value == null) return;
+      parts.add(
+        '${Uri.encodeQueryComponent(key.toString())}='
+        '${Uri.encodeQueryComponent(value.toString())}',
+      );
+    });
+    return parts.join('&');
+  }
+
+  /// Parses a JSON response envelope into a [RestResult].
+  RestResult _parseResponse(int status, String body) {
+    final isSuccess = status >= 200 && status < 300;
+
+    if (body.trim().isEmpty) {
+      if (isSuccess) return RestResult.success(status, null);
+      return RestResult.failure(
+        status,
+        _internalError('Empty response with status $status'),
+      );
+    }
+
+    Object? parsed;
+    try {
+      parsed = jsonDecode(body);
+    } catch (_) {
+      if (isSuccess) return RestResult.success(status, null);
+      return RestResult.failure(
+        status,
+        _internalError('Failed to parse JSON response'),
+      );
+    }
+
+    return _interpretParsed(status, parsed, isSuccess);
+  }
+
+  RestResult _interpretParsed(int status, Object? parsed, bool isSuccess) {
+    if (parsed is! Map) {
+      if (isSuccess) return RestResult.success(status, parsed);
+      return RestResult.failure(
+        status,
+        _internalError('Unexpected response format'),
+      );
+    }
+
+    final map = parsed.cast<String, dynamic>();
+
+    // Error envelope.
+    if (map.containsKey('error')) {
+      final errorData = map['error'];
+      final AccordError accordError;
+      if (errorData is Map) {
+        accordError = AccordError.fromJson(errorData.cast<String, dynamic>());
+      } else {
+        accordError = AccordError(message: errorData.toString());
+      }
+      return RestResult.failure(status, accordError);
+    }
+
+    // Success envelope with "data" key.
+    if (map.containsKey('data')) {
+      var cursor = <String, dynamic>{};
+      final rawCursor = map['cursor'];
+      final rawPagination = map['pagination'];
+      if (rawCursor is Map) {
+        cursor = rawCursor.cast<String, dynamic>();
+      } else if (rawPagination is Map) {
+        cursor = rawPagination.cast<String, dynamic>();
+      }
+      // Normalise cursor to always carry has_more.
+      if (cursor.isNotEmpty && !cursor.containsKey('has_more')) {
+        cursor['has_more'] = (cursor['after'] ?? '') != '';
+      }
+      return RestResult.success(status, map['data'], cursor);
+    }
+
+    // Plain dictionary response (no envelope).
+    if (isSuccess) return RestResult.success(status, map);
+
+    return RestResult.failure(
+      status,
+      AccordError(
+        code: (map['code'] ?? '').toString(),
+        message: (map['message'] ?? 'Unknown error').toString(),
+      ),
+    );
+  }
+
+  /// Extracts a Retry-After value (seconds) from headers or body, defaulting
+  /// to 1.0 second.
+  double _getRetryAfter(http.Response response) {
+    final header = response.headers['retry-after'];
+    if (header != null) {
+      final value = double.tryParse(header.trim());
+      if (value != null) return value;
+    }
+    try {
+      final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+      if (decoded is Map && decoded['retry_after'] != null) {
+        final v = decoded['retry_after'];
+        if (v is num) return v.toDouble();
+        if (v is String) return double.tryParse(v) ?? 1.0;
+      }
+    } catch (_) {
+      // ignore
+    }
+    return 1.0;
+  }
+
+  AccordError _internalError(String msg) {
+    return AccordError(code: 'INTERNAL', message: msg);
+  }
+}
+
+/// Exposed for tests: convert raw bytes to a UTF-8 string.
+String decodeBytes(Uint8List bytes) => utf8.decode(bytes);

--- a/packages/accordkit/lib/src/rest/endpoint_base.dart
+++ b/packages/accordkit/lib/src/rest/endpoint_base.dart
@@ -1,0 +1,8 @@
+import 'accord_rest.dart';
+
+/// Base class for namespaced endpoint groups; holds the shared [AccordRest].
+abstract class EndpointBase {
+  final AccordRest rest;
+
+  EndpointBase(this.rest);
+}

--- a/packages/accordkit/lib/src/rest/endpoints/admin_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/admin_api.dart
@@ -1,0 +1,59 @@
+import '../../models/space.dart';
+import '../../models/user.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Instance-level admin routes (`/admin/*`).
+class AdminApi extends EndpointBase {
+  AdminApi(super.rest);
+
+  /// Lists all spaces on the instance (admin view).
+  Future<RestResult> listSpaces({Map<String, dynamic> query = const {}}) async {
+    final result = await rest.makeRequest('GET', '/admin/spaces', query: query);
+    return result.deserializeArray(AccordSpace.fromJson);
+  }
+
+  /// Updates a space via the admin endpoint (supports owner transfer).
+  Future<RestResult> updateSpace(
+      String spaceId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('PATCH', '/admin/spaces/$spaceId', body: data);
+    return result.deserialize(AccordSpace.fromJson);
+  }
+
+  /// Lists all users on the instance, paginated.
+  Future<RestResult> listUsers({Map<String, dynamic> query = const {}}) async {
+    final result = await rest.makeRequest('GET', '/admin/users', query: query);
+    return result.deserializeArray(AccordUser.fromJson);
+  }
+
+  /// Updates a user via the admin endpoint (toggle is_admin, disable, etc.).
+  Future<RestResult> updateUser(
+      String userId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('PATCH', '/admin/users/$userId', body: data);
+    return result.deserialize(AccordUser.fromJson);
+  }
+
+  /// Deletes a user from the instance (cascades).
+  Future<RestResult> deleteUser(String userId) {
+    return rest.makeRequest('DELETE', '/admin/users/$userId');
+  }
+
+  /// Fetches server-wide settings.
+  Future<RestResult> getSettings() {
+    return rest.makeRequest('GET', '/admin/settings');
+  }
+
+  /// Updates server-wide settings.
+  Future<RestResult> updateSettings(Map<String, dynamic> data) {
+    return rest.makeRequest('PATCH', '/admin/settings', body: data);
+  }
+
+  /// Resets a user's password. [data] needs `new_password` (8–128 chars).
+  Future<RestResult> resetUserPassword(
+      String userId, Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/admin/users/$userId/reset-password',
+        body: data);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/applications_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/applications_api.dart
@@ -1,0 +1,27 @@
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Application management: create, fetch/update current app, reset bot token.
+class ApplicationsApi extends EndpointBase {
+  ApplicationsApi(super.rest);
+
+  /// Creates a new application.
+  Future<RestResult> create(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/applications', body: data);
+  }
+
+  /// Fetches the current application's details.
+  Future<RestResult> getMe() {
+    return rest.makeRequest('GET', '/applications/@me');
+  }
+
+  /// Updates the current application's settings.
+  Future<RestResult> updateMe(Map<String, dynamic> data) {
+    return rest.makeRequest('PATCH', '/applications/@me', body: data);
+  }
+
+  /// Resets the current application's bot token, invalidating the old one.
+  Future<RestResult> resetToken() {
+    return rest.makeRequest('POST', '/applications/@me/reset-token');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/audit_logs_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/audit_logs_api.dart
@@ -1,0 +1,14 @@
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Audit log routes for a space.
+class AuditLogsApi extends EndpointBase {
+  AuditLogsApi(super.rest);
+
+  /// Lists audit log entries. Supports `limit`/`before`/`user_id`/
+  /// `action_type`.
+  Future<RestResult> list(String spaceId,
+      {Map<String, dynamic> query = const {}}) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/audit-log', query: query);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/auth_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/auth_api.dart
@@ -1,0 +1,96 @@
+import '../../models/user.dart';
+import '../../utils/json_utils.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Authentication routes (register, login, MFA, guest tokens, 2FA, sessions).
+///
+/// On successful register/login, [RestResult.data] is a map shaped like
+/// `{ "user": AccordUser, "token": String, "force_password_reset"?: true }`.
+class AuthApi extends EndpointBase {
+  AuthApi(super.rest);
+
+  /// Registers a new user account. [data] needs `username` and `password`,
+  /// optionally `display_name`.
+  Future<RestResult> register(Map<String, dynamic> data) async {
+    final result = await rest.makeRequest('POST', '/auth/register', body: data);
+    final d = result.data;
+    if (result.ok && d is Map<String, dynamic>) {
+      result.data = _parseAuthResponse(d);
+    }
+    return result;
+  }
+
+  /// Logs in with existing credentials. Returns the auth map, or
+  /// `{ "mfa_required": true, "ticket": String }` when 2FA is enabled.
+  Future<RestResult> login(Map<String, dynamic> data) async {
+    final result = await rest.makeRequest('POST', '/auth/login', body: data);
+    final d = result.data;
+    if (result.ok && d is Map<String, dynamic>) {
+      if (d['mfa_required'] != true) {
+        result.data = _parseAuthResponse(d);
+      }
+    }
+    return result;
+  }
+
+  /// Completes MFA login with a TOTP or backup code. [data] needs `ticket`
+  /// and `code`.
+  Future<RestResult> loginMfa(Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('POST', '/auth/login/mfa', body: data);
+    final d = result.data;
+    if (result.ok && d is Map<String, dynamic>) {
+      result.data = _parseAuthResponse(d);
+    }
+    return result;
+  }
+
+  /// Requests a short-lived guest token for anonymous read-only access.
+  Future<RestResult> guest() {
+    return rest.makeRequest('POST', '/auth/guest');
+  }
+
+  /// Changes the current user's password. [data] needs `old_password` and
+  /// `new_password`.
+  Future<RestResult> changePassword(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/auth/change-password', body: data);
+  }
+
+  /// Enables 2FA, returning a TOTP secret and otpauth URI. [data] needs
+  /// `password`.
+  Future<RestResult> enable2fa(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/auth/2fa/enable', body: data);
+  }
+
+  /// Verifies a 2FA code during setup. [data] needs `code`.
+  Future<RestResult> verify2fa(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/auth/2fa/verify', body: data);
+  }
+
+  /// Disables 2FA. [data] needs `password`.
+  Future<RestResult> disable2fa(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/auth/2fa/disable', body: data);
+  }
+
+  /// Regenerates 2FA backup codes. [data] needs `password`.
+  Future<RestResult> regenerateBackupCodes(Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/auth/2fa/backup-codes', body: data);
+  }
+
+  /// Revokes all sessions for the current user.
+  Future<RestResult> revokeAllSessions() {
+    return rest.makeRequest('POST', '/auth/sessions/revoke-all');
+  }
+
+  Map<String, dynamic> _parseAuthResponse(Map<String, dynamic> d) {
+    final parsed = <String, dynamic>{};
+    final user = asMap(d['user']);
+    if (user != null) parsed['user'] = AccordUser.fromJson(user);
+    if (d.containsKey('token')) parsed['token'] = asString(d['token']);
+    if (d['force_password_reset'] == true) {
+      parsed['force_password_reset'] = true;
+    }
+    return parsed;
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/bans_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/bans_api.dart
@@ -1,0 +1,29 @@
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Ban management within a space: list, fetch, create, remove.
+class BansApi extends EndpointBase {
+  BansApi(super.rest);
+
+  /// Lists bans in a space. Supports `limit`/`before`/`after`.
+  Future<RestResult> list(String spaceId,
+      {Map<String, dynamic> query = const {}}) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/bans', query: query);
+  }
+
+  /// Fetches a single ban entry.
+  Future<RestResult> fetch(String spaceId, String userId) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/bans/$userId');
+  }
+
+  /// Creates a ban. [data] may include `delete_message_seconds`.
+  Future<RestResult> create(String spaceId, String userId,
+      {Map<String, dynamic> data = const {}}) {
+    return rest.makeRequest('PUT', '/spaces/$spaceId/bans/$userId', body: data);
+  }
+
+  /// Removes a ban (unban).
+  Future<RestResult> remove(String spaceId, String userId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/bans/$userId');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/channels_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/channels_api.dart
@@ -1,0 +1,80 @@
+import '../../models/channel.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Channel-level routes (get, update, delete, overwrites, recipients, mute).
+class ChannelsApi extends EndpointBase {
+  ChannelsApi(super.rest);
+
+  /// Fetches a channel by snowflake ID.
+  Future<RestResult> fetch(String channelId) async {
+    final result = await rest.makeRequest('GET', '/channels/$channelId');
+    return result.deserialize(AccordChannel.fromJson);
+  }
+
+  /// Updates a channel's settings.
+  Future<RestResult> update(String channelId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('PATCH', '/channels/$channelId', body: data);
+    return result.deserialize(AccordChannel.fromJson);
+  }
+
+  /// Deletes or closes a channel.
+  Future<RestResult> delete(String channelId) async {
+    final result = await rest.makeRequest('DELETE', '/channels/$channelId');
+    return result.deserialize(AccordChannel.fromJson);
+  }
+
+  /// Lists all permission overwrites for a channel.
+  Future<RestResult> listOverwrites(String channelId) {
+    return rest.makeRequest('GET', '/channels/$channelId/permissions');
+  }
+
+  /// Creates or updates a permission overwrite for a role or member.
+  Future<RestResult> upsertOverwrite(
+      String channelId, String overwriteId, Map<String, dynamic> data) {
+    return rest.makeRequest(
+      'PUT',
+      '/channels/$channelId/permissions/$overwriteId',
+      body: data,
+    );
+  }
+
+  /// Deletes a permission overwrite from a channel.
+  Future<RestResult> deleteOverwrite(String channelId, String overwriteId) {
+    return rest.makeRequest(
+      'DELETE',
+      '/channels/$channelId/permissions/$overwriteId',
+    );
+  }
+
+  /// Adds a user to a group DM channel.
+  Future<RestResult> addRecipient(String channelId, String userId) {
+    return rest.makeRequest('PUT', '/channels/$channelId/recipients/$userId');
+  }
+
+  /// Removes a user from a group DM channel.
+  Future<RestResult> removeRecipient(String channelId, String userId) {
+    return rest.makeRequest(
+        'DELETE', '/channels/$channelId/recipients/$userId');
+  }
+
+  /// Mutes a channel or category for the current user.
+  Future<RestResult> mute(String channelId) {
+    return rest.makeRequest('PUT', '/channels/$channelId/mute');
+  }
+
+  /// Unmutes a channel or category for the current user.
+  Future<RestResult> unmute(String channelId) {
+    return rest.makeRequest('DELETE', '/channels/$channelId/mute');
+  }
+
+  /// Acknowledges (marks read) a channel up to [messageId].
+  Future<RestResult> ack(String channelId, String messageId) {
+    return rest.makeRequest(
+      'POST',
+      '/channels/$channelId/ack',
+      body: {'message_id': messageId},
+    );
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/directory_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/directory_api.dart
@@ -1,0 +1,33 @@
+import '../../core/accord_config.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Master-server directory routes. Unlike other endpoint groups this targets
+/// the master server (not an instance) and requires no authentication.
+class DirectoryApi extends EndpointBase {
+  DirectoryApi(super.rest);
+
+  /// Browses the public space directory with optional [query], [tag], and
+  /// [page]. [RestResult.data] is the raw response map.
+  Future<RestResult> browse({
+    String query = '',
+    String tag = '',
+    int page = 1,
+  }) {
+    final params = <String, dynamic>{};
+    if (query.isNotEmpty) params['q'] = query;
+    if (tag.isNotEmpty) params['tag'] = tag;
+    if (page > 1) params['page'] = page;
+    return rest.makeRequest(
+      'GET',
+      '${AccordConfig.apiBasePath}/directory',
+      query: params,
+    );
+  }
+
+  /// Fetches detail for a specific space listing in the directory.
+  Future<RestResult> getSpace(String spaceId) {
+    return rest.makeRequest(
+        'GET', '${AccordConfig.apiBasePath}/directory/$spaceId');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/emojis_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/emojis_api.dart
@@ -1,0 +1,42 @@
+import '../../models/emoji.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Custom emoji management within a space.
+class EmojisApi extends EndpointBase {
+  EmojisApi(super.rest);
+
+  /// Lists all custom emojis in a space.
+  Future<RestResult> list(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId/emojis');
+    return result.deserializeArray(AccordEmoji.fromJson);
+  }
+
+  /// Fetches a single emoji by ID.
+  Future<RestResult> fetch(String spaceId, String emojiId) async {
+    final result =
+        await rest.makeRequest('GET', '/spaces/$spaceId/emojis/$emojiId');
+    return result.deserialize(AccordEmoji.fromJson);
+  }
+
+  /// Creates an emoji. [data] should include `name` and `image` (data URI),
+  /// optionally `roles`.
+  Future<RestResult> create(String spaceId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('POST', '/spaces/$spaceId/emojis', body: data);
+    return result.deserialize(AccordEmoji.fromJson);
+  }
+
+  /// Updates an emoji's name or role restrictions.
+  Future<RestResult> update(
+      String spaceId, String emojiId, Map<String, dynamic> data) async {
+    final result = await rest
+        .makeRequest('PATCH', '/spaces/$spaceId/emojis/$emojiId', body: data);
+    return result.deserialize(AccordEmoji.fromJson);
+  }
+
+  /// Deletes an emoji from a space.
+  Future<RestResult> delete(String spaceId, String emojiId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/emojis/$emojiId');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/interactions_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/interactions_api.dart
@@ -1,0 +1,84 @@
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Application command and interaction-response management.
+class InteractionsApi extends EndpointBase {
+  InteractionsApi(super.rest);
+
+  /// Lists all global application commands.
+  Future<RestResult> listGlobalCommands(String appId) {
+    return rest.makeRequest('GET', '/applications/$appId/commands');
+  }
+
+  /// Creates a global application command.
+  Future<RestResult> createGlobalCommand(
+      String appId, Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/applications/$appId/commands',
+        body: data);
+  }
+
+  /// Fetches a single global command by ID.
+  Future<RestResult> getGlobalCommand(String appId, String commandId) {
+    return rest.makeRequest('GET', '/applications/$appId/commands/$commandId');
+  }
+
+  /// Updates an existing global command.
+  Future<RestResult> updateGlobalCommand(
+      String appId, String commandId, Map<String, dynamic> data) {
+    return rest.makeRequest('PATCH', '/applications/$appId/commands/$commandId',
+        body: data);
+  }
+
+  /// Deletes a global command.
+  Future<RestResult> deleteGlobalCommand(String appId, String commandId) {
+    return rest.makeRequest(
+        'DELETE', '/applications/$appId/commands/$commandId');
+  }
+
+  /// Overwrites all global commands with [data]; absent ones are deleted.
+  Future<RestResult> bulkOverwriteGlobal(String appId, List<dynamic> data) {
+    return rest.makeRequest('PUT', '/applications/$appId/commands', body: data);
+  }
+
+  /// Lists all commands registered to a specific space.
+  Future<RestResult> listSpaceCommands(String appId, String spaceId) {
+    return rest.makeRequest(
+        'GET', '/applications/$appId/spaces/$spaceId/commands');
+  }
+
+  /// Creates a command scoped to a specific space.
+  Future<RestResult> createSpaceCommand(
+      String appId, String spaceId, Map<String, dynamic> data) {
+    return rest.makeRequest(
+        'POST', '/applications/$appId/spaces/$spaceId/commands',
+        body: data);
+  }
+
+  /// Sends an initial response to an interaction.
+  Future<RestResult> respond(
+      String interactionId, String token, Map<String, dynamic> data) {
+    return rest.makeRequest(
+        'POST', '/interactions/$interactionId/$token/callback',
+        body: data);
+  }
+
+  /// Edits the original interaction response message.
+  Future<RestResult> editOriginal(
+      String appId, String token, Map<String, dynamic> data) {
+    return rest.makeRequest(
+        'PATCH', '/webhooks/$appId/$token/messages/@original',
+        body: data);
+  }
+
+  /// Deletes the original interaction response message.
+  Future<RestResult> deleteOriginal(String appId, String token) {
+    return rest.makeRequest(
+        'DELETE', '/webhooks/$appId/$token/messages/@original');
+  }
+
+  /// Sends a follow-up message (valid for up to 15 minutes).
+  Future<RestResult> followup(
+      String appId, String token, Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/webhooks/$appId/$token', body: data);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/invites_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/invites_api.dart
@@ -1,0 +1,55 @@
+import '../../models/invite.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Invite management: fetch, delete, accept, list, and create.
+class InvitesApi extends EndpointBase {
+  InvitesApi(super.rest);
+
+  /// Fetches invite details by code.
+  Future<RestResult> fetch(String code) async {
+    final result = await rest.makeRequest('GET', '/invites/$code');
+    return result.deserialize(AccordInvite.fromJson);
+  }
+
+  /// Deletes (revokes) an invite by code.
+  Future<RestResult> delete(String code) {
+    return rest.makeRequest('DELETE', '/invites/$code');
+  }
+
+  /// Accepts an invite, joining the associated space.
+  Future<RestResult> accept(String code) {
+    return rest.makeRequest('POST', '/invites/$code/accept');
+  }
+
+  /// Lists all active invites for a space.
+  Future<RestResult> listSpace(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId/invites');
+    return result.deserializeArray(AccordInvite.fromJson);
+  }
+
+  /// Lists all active invites for a channel.
+  Future<RestResult> listChannel(String channelId) async {
+    final result =
+        await rest.makeRequest('GET', '/channels/$channelId/invites');
+    return result.deserializeArray(AccordInvite.fromJson);
+  }
+
+  /// Creates a space-level invite. [data] may include `max_age`/`max_uses`/
+  /// `temporary`.
+  Future<RestResult> createSpace(String spaceId,
+      {Map<String, dynamic> data = const {}}) async {
+    final result =
+        await rest.makeRequest('POST', '/spaces/$spaceId/invites', body: data);
+    return result.deserialize(AccordInvite.fromJson);
+  }
+
+  /// Creates a channel-level invite. [data] may include `max_age`/`max_uses`/
+  /// `temporary`.
+  Future<RestResult> createChannel(String channelId,
+      {Map<String, dynamic> data = const {}}) async {
+    final result = await rest
+        .makeRequest('POST', '/channels/$channelId/invites', body: data);
+    return result.deserialize(AccordInvite.fromJson);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/members_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/members_api.dart
@@ -1,0 +1,73 @@
+import '../../models/member.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Space member management: list, search, fetch, update, kick, roles, leave.
+class MembersApi extends EndpointBase {
+  MembersApi(super.rest);
+
+  /// Lists members of a space. Supports `limit`/`after`.
+  Future<RestResult> list(String spaceId,
+      {Map<String, dynamic> query = const {}}) async {
+    final result =
+        await rest.makeRequest('GET', '/spaces/$spaceId/members', query: query);
+    return result.deserializeArray(AccordMember.fromJson);
+  }
+
+  /// Searches members by username or nickname.
+  Future<RestResult> search(String spaceId, String queryStr,
+      {Map<String, dynamic> query = const {}}) async {
+    final q = Map<String, dynamic>.from(query)..['query'] = queryStr;
+    final result = await rest
+        .makeRequest('GET', '/spaces/$spaceId/members/search', query: q);
+    return result.deserializeArray(AccordMember.fromJson);
+  }
+
+  /// Fetches a single member by user ID.
+  Future<RestResult> fetch(String spaceId, String userId) async {
+    final result =
+        await rest.makeRequest('GET', '/spaces/$spaceId/members/$userId');
+    return result.deserialize(AccordMember.fromJson);
+  }
+
+  /// Updates a member (nickname, roles, mute, deaf, etc.).
+  Future<RestResult> update(
+      String spaceId, String userId, Map<String, dynamic> data) async {
+    final result = await rest
+        .makeRequest('PATCH', '/spaces/$spaceId/members/$userId', body: data);
+    return result.deserialize(AccordMember.fromJson);
+  }
+
+  /// Removes a member from a space (kick).
+  Future<RestResult> kick(String spaceId, String userId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/members/$userId');
+  }
+
+  /// Updates the current bot's own member profile in a space.
+  Future<RestResult> updateMe(String spaceId, Map<String, dynamic> data) async {
+    final result = await rest
+        .makeRequest('PATCH', '/spaces/$spaceId/members/@me', body: data);
+    return result.deserialize(AccordMember.fromJson);
+  }
+
+  /// Leaves a space. When [deleteData] is true, the user's per-space data is
+  /// also erased (GDPR).
+  Future<RestResult> leaveMe(String spaceId, {bool deleteData = false}) {
+    final query = <String, dynamic>{};
+    if (deleteData) query['delete_data'] = 'true';
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/members/@me',
+        query: query);
+  }
+
+  /// Adds a role to a member.
+  Future<RestResult> addRole(String spaceId, String userId, String roleId) {
+    return rest.makeRequest(
+        'PUT', '/spaces/$spaceId/members/$userId/roles/$roleId');
+  }
+
+  /// Removes a role from a member.
+  Future<RestResult> removeRole(String spaceId, String userId, String roleId) {
+    return rest.makeRequest(
+        'DELETE', '/spaces/$spaceId/members/$userId/roles/$roleId');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/messages_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/messages_api.dart
@@ -1,0 +1,142 @@
+import 'dart:typed_data';
+
+import '../../models/message.dart';
+import '../endpoint_base.dart';
+import '../multipart_form.dart';
+import '../rest_result.dart';
+
+/// Message operations within a channel: list, create, edit, delete, pin,
+/// threads/forum posts, search, and the typing indicator.
+class MessagesApi extends EndpointBase {
+  MessagesApi(super.rest);
+
+  /// Lists messages in a channel. Supports `before`/`after`/`around`/`limit`.
+  Future<RestResult> list(String channelId,
+      {Map<String, dynamic> query = const {}}) async {
+    final result = await rest
+        .makeRequest('GET', '/channels/$channelId/messages', query: query);
+    return result.deserializeArray(AccordMessage.fromJson);
+  }
+
+  /// Fetches a single message by snowflake ID.
+  Future<RestResult> fetch(String channelId, String messageId) async {
+    final result = await rest.makeRequest(
+        'GET', '/channels/$channelId/messages/$messageId');
+    return result.deserialize(AccordMessage.fromJson);
+  }
+
+  /// Creates a message. [data] needs at least `content` or `embeds`.
+  Future<RestResult> create(String channelId, Map<String, dynamic> data) async {
+    final result = await rest
+        .makeRequest('POST', '/channels/$channelId/messages', body: data);
+    return result.deserialize(AccordMessage.fromJson);
+  }
+
+  /// Creates a message with file attachments via multipart/form-data.
+  ///
+  /// Each entry in [files] is a map with `filename` (String),
+  /// `content` (List<int>/Uint8List), and `content_type` (String).
+  Future<RestResult> createWithAttachments(
+    String channelId,
+    Map<String, dynamic> data,
+    List<Map<String, dynamic>> files,
+  ) async {
+    final form = MultipartForm();
+    form.addJson('payload_json', data);
+    for (var i = 0; i < files.length; i++) {
+      final file = files[i];
+      final name = 'files[$i]';
+      final filename = (file['filename'] ?? 'attachment').toString();
+      final content = (file['content'] ?? Uint8List(0)) as List<int>;
+      final ct =
+          (file['content_type'] ?? 'application/octet-stream').toString();
+      form.addFile(name, filename, content, contentType: ct);
+    }
+    final result = await rest.makeMultipartRequest(
+        'POST', '/channels/$channelId/messages/upload', form);
+    return result.deserialize(AccordMessage.fromJson);
+  }
+
+  /// Edits an existing message.
+  Future<RestResult> edit(
+      String channelId, String messageId, Map<String, dynamic> data) async {
+    final result = await rest.makeRequest(
+        'PATCH', '/channels/$channelId/messages/$messageId',
+        body: data);
+    return result.deserialize(AccordMessage.fromJson);
+  }
+
+  /// Deletes a single message.
+  Future<RestResult> delete(String channelId, String messageId) {
+    return rest.makeRequest(
+        'DELETE', '/channels/$channelId/messages/$messageId');
+  }
+
+  /// Bulk-deletes 2–100 messages. Messages older than 14 days are rejected.
+  Future<RestResult> bulkDelete(String channelId, List<String> messageIds) {
+    return rest.makeRequest(
+      'POST',
+      '/channels/$channelId/messages/bulk-delete',
+      body: {'messages': messageIds},
+    );
+  }
+
+  /// Lists all pinned messages in a channel.
+  Future<RestResult> listPins(String channelId) async {
+    final result = await rest.makeRequest('GET', '/channels/$channelId/pins');
+    return result.deserializeArray(AccordMessage.fromJson);
+  }
+
+  /// Pins a message (max 50 per channel).
+  Future<RestResult> pin(String channelId, String messageId) {
+    return rest.makeRequest('PUT', '/channels/$channelId/pins/$messageId');
+  }
+
+  /// Unpins a message.
+  Future<RestResult> unpin(String channelId, String messageId) {
+    return rest.makeRequest('DELETE', '/channels/$channelId/pins/$messageId');
+  }
+
+  /// Searches messages within a space.
+  Future<RestResult> search(String spaceId, String queryStr,
+      {Map<String, dynamic> query = const {}}) async {
+    final q = Map<String, dynamic>.from(query)..['query'] = queryStr;
+    final result = await rest
+        .makeRequest('GET', '/spaces/$spaceId/messages/search', query: q);
+    return result.deserializeArray(AccordMessage.fromJson);
+  }
+
+  /// Lists thread replies for a parent message.
+  Future<RestResult> listThread(String channelId, String parentMessageId,
+      {Map<String, dynamic> query = const {}}) {
+    final q = Map<String, dynamic>.from(query)..['thread_id'] = parentMessageId;
+    return list(channelId, query: q);
+  }
+
+  /// Fetches thread metadata for a parent message.
+  Future<RestResult> getThreadInfo(String channelId, String messageId) {
+    return rest.makeRequest(
+        'GET', '/channels/$channelId/messages/$messageId/threads');
+  }
+
+  /// Lists all active threads in a channel.
+  Future<RestResult> listActiveThreads(String channelId) async {
+    final result =
+        await rest.makeRequest('GET', '/channels/$channelId/threads');
+    return result.deserializeArray(AccordMessage.fromJson);
+  }
+
+  /// Lists top-level posts in a forum channel.
+  Future<RestResult> listPosts(String channelId,
+      {Map<String, dynamic> query = const {}}) {
+    final q = Map<String, dynamic>.from(query)..['top_level'] = 'true';
+    return list(channelId, query: q);
+  }
+
+  /// Triggers the typing indicator (lasts ~10s).
+  Future<RestResult> typing(String channelId, {String threadId = ''}) {
+    final data = <String, dynamic>{};
+    if (threadId.isNotEmpty) data['thread_id'] = threadId;
+    return rest.makeRequest('POST', '/channels/$channelId/typing', body: data);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/plugins_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/plugins_api.dart
@@ -1,0 +1,139 @@
+import 'dart:typed_data';
+
+import '../../models/plugin_manifest.dart';
+import '../endpoint_base.dart';
+import '../multipart_form.dart';
+import '../rest_result.dart';
+
+/// Server plugin management: list, install, delete, downloads, sessions,
+/// roles, action dispatch, and leaderboards.
+class PluginsApi extends EndpointBase {
+  PluginsApi(super.rest);
+
+  /// Lists installed plugins for a space, optionally filtered by [type].
+  Future<RestResult> listPlugins(String spaceId, {String type = ''}) async {
+    final query = <String, dynamic>{};
+    if (type.isNotEmpty) query['type'] = type;
+    final result =
+        await rest.makeRequest('GET', '/spaces/$spaceId/plugins', query: query);
+    return result.deserializeArray(AccordPluginManifest.fromJson);
+  }
+
+  /// Installs a plugin by uploading a manifest and optional bundle (admin).
+  Future<RestResult> installPlugin(
+    String spaceId,
+    Map<String, dynamic> manifest, {
+    Uint8List? bundleData,
+    String filename = 'plugin.daccord-plugin',
+  }) async {
+    final form = MultipartForm();
+    form.addJson('manifest', manifest);
+    if (bundleData != null && bundleData.isNotEmpty) {
+      form.addFile('bundle', filename, bundleData,
+          contentType: 'application/zip');
+    }
+    final result = await rest.makeMultipartRequest(
+        'POST', '/spaces/$spaceId/plugins', form);
+    return result.deserialize(AccordPluginManifest.fromJson);
+  }
+
+  /// Uninstalls a plugin (admin).
+  Future<RestResult> deletePlugin(String spaceId, String pluginId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/plugins/$pluginId');
+  }
+
+  /// Downloads the Lua source for a scripted plugin (raw bytes).
+  Future<RestResult> getSource(String pluginId) {
+    return rest.makeRawRequest('/plugins/$pluginId/source');
+  }
+
+  /// Downloads the full plugin bundle ZIP for a native plugin (raw bytes).
+  Future<RestResult> getBundle(String pluginId) {
+    return rest.makeRawRequest('/plugins/$pluginId/bundle');
+  }
+
+  /// Returns active sessions for a channel.
+  Future<RestResult> getChannelSessions(String channelId) {
+    return rest.makeRequest('GET', '/channels/$channelId/sessions/active');
+  }
+
+  /// Returns active sessions across all channels in a space.
+  Future<RestResult> getSpaceSessions(String spaceId) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/sessions/active');
+  }
+
+  /// Creates an activity session in a voice channel.
+  Future<RestResult> createSession(String pluginId, String channelId) {
+    return rest.makeRequest('POST', '/plugins/$pluginId/sessions',
+        body: {'channel_id': channelId});
+  }
+
+  /// Ends an activity session.
+  Future<RestResult> deleteSession(String pluginId, String sessionId) {
+    return rest.makeRequest('DELETE', '/plugins/$pluginId/sessions/$sessionId');
+  }
+
+  /// Transitions session state (host only). [state] is "running" or "ended".
+  Future<RestResult> updateSessionState(
+      String pluginId, String sessionId, String state) {
+    return rest.makeRequest('PATCH', '/plugins/$pluginId/sessions/$sessionId',
+        body: {'state': state});
+  }
+
+  /// Leaves an activity session (non-host).
+  Future<RestResult> leaveSession(String pluginId, String sessionId) {
+    return rest.makeRequest(
+        'POST', '/plugins/$pluginId/sessions/$sessionId/leave');
+  }
+
+  /// Assigns a participant role. [role] is "player" or "spectator".
+  Future<RestResult> assignRole(
+      String pluginId, String sessionId, String userId, String role) {
+    return rest.makeRequest(
+        'POST', '/plugins/$pluginId/sessions/$sessionId/roles',
+        body: {'user_id': userId, 'role': role});
+  }
+
+  /// Sends a plugin action (e.g. game move) for scripted plugins.
+  Future<RestResult> sendAction(
+      String pluginId, String sessionId, Map<String, dynamic> data) {
+    return rest.makeRequest(
+        'POST', '/plugins/$pluginId/sessions/$sessionId/actions',
+        body: data);
+  }
+
+  // ── Leaderboards ───────────────────────────────────────────────────────
+
+  /// Submits a score to a leaderboard.
+  Future<RestResult> leaderboardSubmit(
+      String pluginId, String boardId, double score,
+      {Map<String, dynamic> metadata = const {}}) {
+    final body = <String, dynamic>{'score': score};
+    if (metadata.isNotEmpty) body['metadata'] = metadata;
+    return rest.makeRequest(
+        'POST', '/plugins/$pluginId/leaderboards/$boardId/submit',
+        body: body);
+  }
+
+  /// Returns the top entries for a leaderboard.
+  Future<RestResult> leaderboardGet(String pluginId, String boardId,
+      {int limit = 50}) {
+    return rest.makeRequest('GET', '/plugins/$pluginId/leaderboards/$boardId',
+        query: {'limit': limit.toString()});
+  }
+
+  /// Returns leaderboard entries around the current user's rank.
+  Future<RestResult> leaderboardAround(String pluginId, String boardId,
+      {int limit = 10}) {
+    return rest.makeRequest(
+        'GET', '/plugins/$pluginId/leaderboards/$boardId/around',
+        query: {'limit': limit.toString()});
+  }
+
+  /// Returns a specific user's leaderboard entry.
+  Future<RestResult> leaderboardGetUser(
+      String pluginId, String boardId, String userId) {
+    return rest.makeRequest(
+        'GET', '/plugins/$pluginId/leaderboards/$boardId/user/$userId');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/reactions_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/reactions_api.dart
@@ -1,0 +1,60 @@
+import '../../models/user.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Message reaction operations: add, remove, list, and clear.
+class ReactionsApi extends EndpointBase {
+  ReactionsApi(super.rest);
+
+  String _encode(String emoji) => Uri.encodeComponent(emoji);
+
+  /// Adds the current user's reaction. [emoji] is a unicode emoji or
+  /// `name:id` for custom emoji.
+  Future<RestResult> add(String channelId, String messageId, String emoji) {
+    final e = _encode(emoji);
+    return rest.makeRequest(
+        'PUT', '/channels/$channelId/messages/$messageId/reactions/$e/@me');
+  }
+
+  /// Removes the current user's reaction.
+  Future<RestResult> removeOwn(
+      String channelId, String messageId, String emoji) {
+    final e = _encode(emoji);
+    return rest.makeRequest(
+        'DELETE', '/channels/$channelId/messages/$messageId/reactions/$e/@me');
+  }
+
+  /// Removes another user's reaction (requires manage_messages).
+  Future<RestResult> removeUser(
+      String channelId, String messageId, String emoji, String userId) {
+    final e = _encode(emoji);
+    return rest.makeRequest('DELETE',
+        '/channels/$channelId/messages/$messageId/reactions/$e/$userId');
+  }
+
+  /// Lists users who reacted with [emoji]. Supports `after`/`limit`.
+  Future<RestResult> listUsers(String channelId, String messageId, String emoji,
+      {Map<String, dynamic> query = const {}}) async {
+    final e = _encode(emoji);
+    final result = await rest.makeRequest(
+      'GET',
+      '/channels/$channelId/messages/$messageId/reactions/$e',
+      query: query,
+    );
+    return result.deserializeArray(AccordUser.fromJson);
+  }
+
+  /// Removes all reactions (requires manage_messages).
+  Future<RestResult> removeAll(String channelId, String messageId) {
+    return rest.makeRequest(
+        'DELETE', '/channels/$channelId/messages/$messageId/reactions');
+  }
+
+  /// Removes all reactions of a specific emoji (requires manage_messages).
+  Future<RestResult> removeEmoji(
+      String channelId, String messageId, String emoji) {
+    final e = _encode(emoji);
+    return rest.makeRequest(
+        'DELETE', '/channels/$channelId/messages/$messageId/reactions/$e');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/reports_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/reports_api.dart
@@ -1,0 +1,32 @@
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Report management within a space: create, list, fetch, resolve.
+class ReportsApi extends EndpointBase {
+  ReportsApi(super.rest);
+
+  /// Creates a report. [data] should include `target_type`, `target_id`,
+  /// `category`, and optionally `channel_id`/`description`.
+  Future<RestResult> create(String spaceId, Map<String, dynamic> data) {
+    return rest.makeRequest('POST', '/spaces/$spaceId/reports', body: data);
+  }
+
+  /// Lists reports. Supports `status`/`limit`/`before`.
+  Future<RestResult> list(String spaceId,
+      {Map<String, dynamic> query = const {}}) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/reports', query: query);
+  }
+
+  /// Fetches a single report by ID.
+  Future<RestResult> fetch(String spaceId, String reportId) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/reports/$reportId');
+  }
+
+  /// Resolves a report. [data] should include `status` and optionally
+  /// `action_taken`.
+  Future<RestResult> resolve(
+      String spaceId, String reportId, Map<String, dynamic> data) {
+    return rest.makeRequest('PATCH', '/spaces/$spaceId/reports/$reportId',
+        body: data);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/roles_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/roles_api.dart
@@ -1,0 +1,41 @@
+import '../../models/role.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Role management within a space: list, create, update, delete, reorder.
+class RolesApi extends EndpointBase {
+  RolesApi(super.rest);
+
+  /// Lists all roles in a space.
+  Future<RestResult> list(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId/roles');
+    return result.deserializeArray(AccordRole.fromJson);
+  }
+
+  /// Creates a new role.
+  Future<RestResult> create(String spaceId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('POST', '/spaces/$spaceId/roles', body: data);
+    return result.deserialize(AccordRole.fromJson);
+  }
+
+  /// Updates an existing role.
+  Future<RestResult> update(
+      String spaceId, String roleId, Map<String, dynamic> data) async {
+    final result = await rest
+        .makeRequest('PATCH', '/spaces/$spaceId/roles/$roleId', body: data);
+    return result.deserialize(AccordRole.fromJson);
+  }
+
+  /// Permanently deletes a role.
+  Future<RestResult> delete(String spaceId, String roleId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/roles/$roleId');
+  }
+
+  /// Reorders roles. [data] entries have `id` and `position` keys.
+  Future<RestResult> reorder(String spaceId, List<dynamic> data) async {
+    final result =
+        await rest.makeRequest('PATCH', '/spaces/$spaceId/roles', body: data);
+    return result.deserializeArray(AccordRole.fromJson);
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/soundboard_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/soundboard_api.dart
@@ -1,0 +1,50 @@
+import '../../models/sound.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Soundboard management within a space: list, fetch, create, update, delete,
+/// and trigger playback.
+class SoundboardApi extends EndpointBase {
+  SoundboardApi(super.rest);
+
+  /// Lists all sounds in a space's soundboard.
+  Future<RestResult> list(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId/soundboard');
+    return result.deserializeArray(AccordSound.fromJson);
+  }
+
+  /// Fetches a single sound by ID.
+  Future<RestResult> fetch(String spaceId, String soundId) async {
+    final result =
+        await rest.makeRequest('GET', '/spaces/$spaceId/soundboard/$soundId');
+    return result.deserialize(AccordSound.fromJson);
+  }
+
+  /// Creates a sound. [data] should include `name` and `audio` (data URI),
+  /// optionally `volume`.
+  Future<RestResult> create(String spaceId, Map<String, dynamic> data) async {
+    final result = await rest.makeRequest('POST', '/spaces/$spaceId/soundboard',
+        body: data);
+    return result.deserialize(AccordSound.fromJson);
+  }
+
+  /// Updates a sound's name or volume.
+  Future<RestResult> update(
+      String spaceId, String soundId, Map<String, dynamic> data) async {
+    final result = await rest.makeRequest(
+        'PATCH', '/spaces/$spaceId/soundboard/$soundId',
+        body: data);
+    return result.deserialize(AccordSound.fromJson);
+  }
+
+  /// Deletes a sound.
+  Future<RestResult> delete(String spaceId, String soundId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId/soundboard/$soundId');
+  }
+
+  /// Triggers playback of a sound.
+  Future<RestResult> play(String spaceId, String soundId) {
+    return rest.makeRequest(
+        'POST', '/spaces/$spaceId/soundboard/$soundId/play');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/spaces_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/spaces_api.dart
@@ -1,0 +1,62 @@
+import '../../models/channel.dart';
+import '../../models/space.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Space (guild) management routes.
+class SpacesApi extends EndpointBase {
+  SpacesApi(super.rest);
+
+  /// Creates a new space.
+  Future<RestResult> create(Map<String, dynamic> data) async {
+    final result = await rest.makeRequest('POST', '/spaces', body: data);
+    return result.deserialize(AccordSpace.fromJson);
+  }
+
+  /// Fetches a space by snowflake ID.
+  Future<RestResult> fetch(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId');
+    return result.deserialize(AccordSpace.fromJson);
+  }
+
+  /// Updates a space's settings.
+  Future<RestResult> update(String spaceId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('PATCH', '/spaces/$spaceId', body: data);
+    return result.deserialize(AccordSpace.fromJson);
+  }
+
+  /// Permanently deletes a space (owner only).
+  Future<RestResult> delete(String spaceId) {
+    return rest.makeRequest('DELETE', '/spaces/$spaceId');
+  }
+
+  /// Lists all channels in a space.
+  Future<RestResult> listChannels(String spaceId) async {
+    final result = await rest.makeRequest('GET', '/spaces/$spaceId/channels');
+    return result.deserializeArray(AccordChannel.fromJson);
+  }
+
+  /// Creates a new channel in a space.
+  Future<RestResult> createChannel(
+      String spaceId, Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('POST', '/spaces/$spaceId/channels', body: data);
+    return result.deserialize(AccordChannel.fromJson);
+  }
+
+  /// Reorders channels. [data] entries have `id` and `position` keys.
+  Future<RestResult> reorderChannels(String spaceId, List<dynamic> data) {
+    return rest.makeRequest('PATCH', '/spaces/$spaceId/channels', body: data);
+  }
+
+  /// Joins a public space without an invite.
+  Future<RestResult> join(String spaceId) {
+    return rest.makeRequest('POST', '/spaces/$spaceId/join');
+  }
+
+  /// Fetches the current anonymous (guest) viewer count for a space.
+  Future<RestResult> anonymousCount(String spaceId) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/anonymous-count');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/users_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/users_api.dart
@@ -1,0 +1,109 @@
+import '../../models/accord_relationship.dart';
+import '../../models/channel.dart';
+import '../../models/space.dart';
+import '../../models/user.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// User-related routes: the current user, lookups, DMs, relationships, and
+/// GDPR data export.
+class UsersApi extends EndpointBase {
+  UsersApi(super.rest);
+
+  /// Fetches the currently authenticated user.
+  Future<RestResult> getMe() async {
+    final result = await rest.makeRequest('GET', '/users/@me');
+    return result.deserialize(AccordUser.fromJson);
+  }
+
+  /// Updates the current user's profile.
+  Future<RestResult> updateMe(Map<String, dynamic> data) async {
+    final result = await rest.makeRequest('PATCH', '/users/@me', body: data);
+    return result.deserialize(AccordUser.fromJson);
+  }
+
+  /// Fetches a user by snowflake ID.
+  Future<RestResult> fetch(String userId) async {
+    final result = await rest.makeRequest('GET', '/users/$userId');
+    return result.deserialize(AccordUser.fromJson);
+  }
+
+  /// Lists all spaces the current user belongs to.
+  Future<RestResult> listSpaces() async {
+    final result = await rest.makeRequest('GET', '/users/@me/spaces');
+    return result.deserializeArray(AccordSpace.fromJson);
+  }
+
+  /// Lists all DM channels for the current user.
+  Future<RestResult> listChannels() async {
+    final result = await rest.makeRequest('GET', '/users/@me/channels');
+    return result.deserializeArray(AccordChannel.fromJson);
+  }
+
+  /// Creates a DM channel with the specified user(s).
+  Future<RestResult> createDm(Map<String, dynamic> data) async {
+    final result =
+        await rest.makeRequest('POST', '/users/@me/channels', body: data);
+    return result.deserialize(AccordChannel.fromJson);
+  }
+
+  /// Deletes the current user's account.
+  Future<RestResult> deleteMe([Map<String, dynamic> data = const {}]) {
+    return rest.makeRequest('DELETE', '/users/@me', body: data);
+  }
+
+  /// Lists all connections linked to the current user's account.
+  Future<RestResult> listConnections() {
+    return rest.makeRequest('GET', '/users/@me/connections');
+  }
+
+  /// Lists all muted channel IDs for the current user.
+  Future<RestResult> listMutes() {
+    return rest.makeRequest('GET', '/users/@me/mutes');
+  }
+
+  /// Lists channels with unread messages for the current user.
+  Future<RestResult> listUnread() {
+    return rest.makeRequest('GET', '/users/@me/read-states');
+  }
+
+  /// Returns mutual friends between the current user and [userId].
+  Future<RestResult> getMutualFriends(String userId) async {
+    final result =
+        await rest.makeRequest('GET', '/users/$userId/mutual-friends');
+    return result.deserializeArray(AccordUser.fromJson);
+  }
+
+  /// Searches for users by username or display name.
+  Future<RestResult> searchUsers(String query, {int limit = 25}) async {
+    final result = await rest.makeRequest(
+      'GET',
+      '/users/search',
+      query: {'query': query, 'limit': limit},
+    );
+    return result.deserializeArray(AccordUser.fromJson);
+  }
+
+  /// Lists all relationships for the current user.
+  Future<RestResult> listRelationships() async {
+    final result = await rest.makeRequest('GET', '/users/@me/relationships');
+    return result.deserializeArray(AccordRelationship.fromJson);
+  }
+
+  /// Creates or updates a relationship with another user.
+  /// [data] should contain `{"type": int}` (1 = friend request, 2 = block).
+  Future<RestResult> putRelationship(String userId, Map<String, dynamic> data) {
+    return rest.makeRequest('PUT', '/users/@me/relationships/$userId',
+        body: data);
+  }
+
+  /// Removes a relationship (unfriend, decline, cancel, or unblock).
+  Future<RestResult> deleteRelationship(String userId) {
+    return rest.makeRequest('DELETE', '/users/@me/relationships/$userId');
+  }
+
+  /// Requests a full export of the current user's personal data (GDPR).
+  Future<RestResult> requestDataExport() {
+    return rest.makeRequest('GET', '/users/@me/data-export');
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/voice_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/voice_api.dart
@@ -1,0 +1,51 @@
+import '../../models/voice_server_update.dart';
+import '../../models/voice_state.dart';
+import '../endpoint_base.dart';
+import '../rest_result.dart';
+
+/// Voice routes: backend info, join/leave, regions, and channel status.
+class VoiceApi extends EndpointBase {
+  VoiceApi(super.rest);
+
+  /// Returns the server's voice backend configuration.
+  Future<RestResult> getInfo() {
+    return rest.makeRequest('GET', '/voice/info');
+  }
+
+  /// Joins a voice channel. On success [RestResult.data] is an
+  /// [AccordVoiceServerUpdate] with backend connection details.
+  Future<RestResult> join(String channelId,
+      {bool selfMute = false, bool selfDeaf = false}) async {
+    final result = await rest.makeRequest(
+      'POST',
+      '/channels/$channelId/voice/join',
+      body: {'self_mute': selfMute, 'self_deaf': selfDeaf},
+    );
+    return result.deserialize(AccordVoiceServerUpdate.fromJson);
+  }
+
+  /// Leaves the current voice channel.
+  Future<RestResult> leave(String channelId) {
+    return rest.makeRequest('DELETE', '/channels/$channelId/voice/leave');
+  }
+
+  /// Lists available voice regions for a space.
+  Future<RestResult> listRegions(String spaceId) {
+    return rest.makeRequest('GET', '/spaces/$spaceId/voice-regions');
+  }
+
+  /// Fetches the current voice status for a channel. On success
+  /// [RestResult.data] is a `List<AccordVoiceState>`.
+  Future<RestResult> getStatus(String channelId) async {
+    final result =
+        await rest.makeRequest('GET', '/channels/$channelId/voice-status');
+    final d = result.data;
+    if (result.ok && d is List) {
+      result.data = [
+        for (final item in d)
+          if (item is Map<String, dynamic>) AccordVoiceState.fromJson(item),
+      ];
+    }
+    return result;
+  }
+}

--- a/packages/accordkit/lib/src/rest/multipart_form.dart
+++ b/packages/accordkit/lib/src/rest/multipart_form.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+/// Builds `multipart/form-data` request bodies for file uploads and mixed
+/// payloads. Add parts with [addField]/[addJson]/[addFile], then [build] the
+/// final byte body and send it with [contentType].
+class MultipartForm {
+  final String _boundary;
+  final List<Uint8List> _parts = [];
+
+  MultipartForm({String? boundary})
+      : _boundary = boundary ?? '----AccordForm${Random().nextInt(1 << 31)}';
+
+  static const List<int> _crlf = [13, 10]; // "\r\n"
+
+  /// Adds a plain text field.
+  void addField(String name, String value) {
+    final header =
+        '--$_boundary\r\nContent-Disposition: form-data; name="$name"\r\n\r\n';
+    final part = BytesBuilder()
+      ..add(utf8.encode(header))
+      ..add(utf8.encode(value))
+      ..add(_crlf);
+    _parts.add(part.toBytes());
+  }
+
+  /// Adds a JSON field. [data] is encoded with [jsonEncode].
+  void addJson(String name, Object? data) {
+    final jsonStr = jsonEncode(data);
+    final header = '--$_boundary\r\nContent-Disposition: form-data; '
+        'name="$name"\r\nContent-Type: application/json\r\n\r\n';
+    final part = BytesBuilder()
+      ..add(utf8.encode(header))
+      ..add(utf8.encode(jsonStr))
+      ..add(_crlf);
+    _parts.add(part.toBytes());
+  }
+
+  /// Adds a binary file part.
+  void addFile(
+    String name,
+    String filename,
+    List<int> content, {
+    String contentType = 'application/octet-stream',
+  }) {
+    final header = '--$_boundary\r\nContent-Disposition: form-data; '
+        'name="$name"; filename="$filename"\r\nContent-Type: $contentType\r\n\r\n';
+    final part = BytesBuilder()
+      ..add(utf8.encode(header))
+      ..add(content)
+      ..add(_crlf);
+    _parts.add(part.toBytes());
+  }
+
+  /// The `Content-Type` header value, including the boundary.
+  String contentType() => 'multipart/form-data; boundary=$_boundary';
+
+  /// Assembles all parts plus the closing boundary into the final body.
+  Uint8List build() {
+    final result = BytesBuilder();
+    for (final part in _parts) {
+      result.add(part);
+    }
+    result.add(utf8.encode('--$_boundary--\r\n'));
+    return result.toBytes();
+  }
+}

--- a/packages/accordkit/lib/src/rest/paginator.dart
+++ b/packages/accordkit/lib/src/rest/paginator.dart
@@ -1,0 +1,59 @@
+import 'accord_rest.dart';
+import 'rest_result.dart';
+
+/// Cursor-based pagination helper wrapping a single page of items. Call [next]
+/// to fetch the following page using the same path, query, and model class.
+class AccordPaginator {
+  List<dynamic> items;
+  bool hasMore = false;
+  String _after = '';
+
+  final AccordRest _rest;
+  final String _path;
+  final Map<String, dynamic> _query;
+  final Object Function(Map<String, dynamic>)? _fromJson;
+
+  AccordPaginator._(
+    this._rest,
+    this._path,
+    this._query,
+    this._fromJson, {
+    List<dynamic>? items,
+  }) : items = items ?? [];
+
+  /// Builds a paginator from a [RestResult]. When [fromJson] is provided, Map
+  /// items are deserialized into model instances.
+  static AccordPaginator fromResult(
+    RestResult result,
+    AccordRest rest,
+    String path,
+    Map<String, dynamic> query, {
+    Object Function(Map<String, dynamic>)? fromJson,
+  }) {
+    final p = AccordPaginator._(
+        rest, path, Map<String, dynamic>.from(query), fromJson);
+    if (result.ok) {
+      final data = result.data;
+      if (data is List) {
+        if (fromJson != null) {
+          p.items = [
+            for (final item in data)
+              if (item is Map<String, dynamic>) fromJson(item) else item,
+          ];
+        } else {
+          p.items = data;
+        }
+      }
+      p.hasMore = result.hasMore;
+      p._after = (result.cursor['after'] ?? '').toString();
+    }
+    return p;
+  }
+
+  /// Fetches the next page using the stored cursor, returning a new paginator.
+  Future<AccordPaginator> next() async {
+    final query = Map<String, dynamic>.from(_query)..['after'] = _after;
+    final result = await _rest.makeRequest('GET', _path, query: query);
+    return fromResult(result, _rest, _path, query, fromJson: _fromJson);
+  }
+}

--- a/packages/accordkit/lib/src/rest/rest_result.dart
+++ b/packages/accordkit/lib/src/rest/rest_result.dart
@@ -1,0 +1,66 @@
+import 'accord_error.dart';
+
+/// The outcome of a REST call: either parsed [data] on success or an [error]
+/// on failure. [cursor] carries pagination state for cursor-based endpoints.
+class RestResult {
+  bool ok;
+  int statusCode;
+
+  /// A typed model, a list of models, raw bytes, a Map, or null.
+  Object? data;
+  AccordError? error;
+
+  /// Pagination info, e.g. `{ "after": "id", "has_more": bool }`.
+  Map<String, dynamic> cursor;
+
+  RestResult({
+    this.ok = false,
+    this.statusCode = 0,
+    this.data,
+    this.error,
+    Map<String, dynamic>? cursor,
+  }) : cursor = cursor ?? {};
+
+  /// Whether the endpoint reported another page is available.
+  bool get hasMore => cursor['has_more'] == true;
+
+  static RestResult success(
+    int status,
+    Object? data, [
+    Map<String, dynamic> cursor = const {},
+  ]) {
+    return RestResult(
+      ok: true,
+      statusCode: status,
+      data: data,
+      cursor: Map<String, dynamic>.from(cursor),
+    );
+  }
+
+  static RestResult failure(int status, AccordError? err) {
+    return RestResult(ok: false, statusCode: status, error: err);
+  }
+
+  /// Deserializes a successful Map response using [fromJson], replacing [data]
+  /// with the model. No-op for non-Map or failed results.
+  RestResult deserialize(Object Function(Map<String, dynamic>) fromJson) {
+    final d = data;
+    if (ok && d is Map<String, dynamic>) {
+      data = fromJson(d);
+    }
+    return this;
+  }
+
+  /// Deserializes a successful List response, mapping each Map element through
+  /// [fromJson]. No-op for non-List or failed results.
+  RestResult deserializeArray(Object Function(Map<String, dynamic>) fromJson) {
+    final d = data;
+    if (ok && d is List) {
+      data = [
+        for (final item in d)
+          if (item is Map<String, dynamic>) fromJson(item) else item,
+      ];
+    }
+    return this;
+  }
+}

--- a/packages/accordkit/lib/src/utils/cdn.dart
+++ b/packages/accordkit/lib/src/utils/cdn.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../core/accord_config.dart';
+
+/// Builds CDN URLs for avatars, icons, banners, emojis, attachments, and
+/// sounds, and resolves server-returned relative CDN paths to absolute URLs.
+class AccordCDN {
+  /// Fallback CDN base used when a per-call [cdnUrl] is not provided.
+  static String baseUrl = AccordConfig.defaultCdnUrl;
+
+  static String _resolve(String cdnUrl) => cdnUrl.isNotEmpty ? cdnUrl : baseUrl;
+
+  static String avatar(
+    String userId,
+    String hash, {
+    String format = 'png',
+    String cdnUrl = '',
+  }) {
+    return '${_resolve(cdnUrl)}/avatars/$userId/$hash.$format';
+  }
+
+  static String defaultAvatar(int index, {String cdnUrl = ''}) {
+    return '${_resolve(cdnUrl)}/embed/avatars/$index.png';
+  }
+
+  static String spaceIcon(
+    String spaceId,
+    String hash, {
+    String format = 'png',
+    String cdnUrl = '',
+  }) {
+    return '${_resolve(cdnUrl)}/space-icons/$spaceId/$hash.$format';
+  }
+
+  static String spaceBanner(
+    String spaceId,
+    String hash, {
+    String format = 'png',
+    String cdnUrl = '',
+  }) {
+    return '${_resolve(cdnUrl)}/banners/$spaceId/$hash.$format';
+  }
+
+  static String emoji(
+    String emojiId, {
+    String format = 'png',
+    String cdnUrl = '',
+  }) {
+    return '${_resolve(cdnUrl)}/emojis/$emojiId.$format';
+  }
+
+  static String attachment(
+    String channelId,
+    String attachmentId,
+    String filename, {
+    String cdnUrl = '',
+  }) {
+    return '${_resolve(cdnUrl)}/attachments/$channelId/$attachmentId/$filename';
+  }
+
+  static String sound(String audioUrl, {String cdnUrl = ''}) {
+    return resolvePath(audioUrl, cdnUrl: cdnUrl);
+  }
+
+  /// Resolves a server-returned CDN path (e.g. "/cdn/avatars/123.png") to a
+  /// full URL. Absolute URLs are returned unchanged.
+  static String resolvePath(String path, {String cdnUrl = ''}) {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+    if (path.startsWith('/cdn/')) {
+      return _resolve(cdnUrl) + path.substring(4);
+    }
+    if (path.startsWith('/')) {
+      return _resolve(cdnUrl) + path;
+    }
+    return '${_resolve(cdnUrl)}/$path';
+  }
+
+  /// Builds a `data:` URI from raw file [bytes], inferring the MIME type from
+  /// [filePath]'s extension. Suitable for avatar/icon/banner upload fields.
+  static String buildDataUri(Uint8List bytes, String filePath) {
+    final dotIndex = filePath.lastIndexOf('.');
+    final ext =
+        dotIndex >= 0 ? filePath.substring(dotIndex + 1).toLowerCase() : '';
+    final String mime;
+    switch (ext) {
+      case 'jpg':
+      case 'jpeg':
+        mime = 'image/jpeg';
+        break;
+      case 'webp':
+        mime = 'image/webp';
+        break;
+      case 'gif':
+        mime = 'image/gif';
+        break;
+      default:
+        mime = 'image/png';
+    }
+    return 'data:$mime;base64,${base64Encode(bytes)}';
+  }
+
+  /// Whether the given asset hash denotes an animated asset (`a_` prefix).
+  static bool isAnimated(String hash) => hash.startsWith('a_');
+
+  /// Picks `gif` for animated hashes, otherwise `png`.
+  static String autoFormat(String hash) => isAnimated(hash) ? 'gif' : 'png';
+}

--- a/packages/accordkit/lib/src/utils/json_utils.dart
+++ b/packages/accordkit/lib/src/utils/json_utils.dart
@@ -1,0 +1,61 @@
+/// Internal coercion helpers mirroring the lenient parsing the GDScript
+/// reference client performs (snowflakes may arrive as ints or strings,
+/// numbers may be ints or doubles, etc.).
+library;
+
+/// Coerces [value] to a [String]. Returns [fallback] when null.
+String asString(Object? value, [String fallback = '']) {
+  if (value == null) return fallback;
+  if (value is String) return value;
+  return value.toString();
+}
+
+/// Coerces [value] to a [String], or null when the value is absent/null.
+String? asStringOrNull(Object? value) {
+  if (value == null) return null;
+  if (value is String) return value;
+  return value.toString();
+}
+
+/// Coerces [value] to an [int]. Accepts ints, doubles, and numeric strings.
+int asInt(Object? value, [int fallback = 0]) {
+  if (value == null) return fallback;
+  if (value is int) return value;
+  if (value is double) return value.toInt();
+  if (value is bool) return value ? 1 : 0;
+  if (value is String) return int.tryParse(value) ?? fallback;
+  return fallback;
+}
+
+/// Coerces [value] to a [double]. Accepts ints, doubles, and numeric strings.
+double asDouble(Object? value, [double fallback = 0.0]) {
+  if (value == null) return fallback;
+  if (value is double) return value;
+  if (value is int) return value.toDouble();
+  if (value is String) return double.tryParse(value) ?? fallback;
+  return fallback;
+}
+
+/// Coerces [value] to a [bool], defaulting to [fallback].
+bool asBool(Object? value, [bool fallback = false]) {
+  if (value is bool) return value;
+  return fallback;
+}
+
+/// Returns [value] as a `Map<String, dynamic>` when it is one, else null.
+Map<String, dynamic>? asMap(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) return value.cast<String, dynamic>();
+  return null;
+}
+
+/// Returns [value] as a [List] when it is one, else null.
+List<dynamic>? asList(Object? value) {
+  if (value is List) return value;
+  return null;
+}
+
+/// Converts a list of model objects exposing `toJson()` into a list of maps.
+List<Map<String, dynamic>> toJsonList(Iterable<dynamic> items) {
+  return items.map((e) => e.toJson() as Map<String, dynamic>).toList();
+}

--- a/packages/accordkit/lib/src/utils/snowflake.dart
+++ b/packages/accordkit/lib/src/utils/snowflake.dart
@@ -1,0 +1,47 @@
+import 'dart:math';
+
+/// Helpers for decoding and generating Accord snowflake IDs. Snowflakes embed
+/// a millisecond timestamp (relative to the Accord epoch) in their high bits.
+class AccordSnowflake {
+  /// Accord epoch: 2024-01-01T00:00:00Z in milliseconds.
+  static const int epochMs = 1704067200000;
+
+  static final Random _random = Random();
+
+  /// Decodes the embedded creation timestamp (ms since Unix epoch). Returns 0
+  /// for an empty or non-numeric snowflake.
+  static int decodeTimestampMs(String snowflake) {
+    if (snowflake.isEmpty) return 0;
+    final id = int.tryParse(snowflake) ?? 0;
+    return (id >> 22) + epochMs;
+  }
+
+  /// Decodes the embedded creation timestamp in seconds (fractional).
+  static double decodeTimestamp(String snowflake) {
+    return decodeTimestampMs(snowflake) / 1000.0;
+  }
+
+  /// Decodes the snowflake to a UTC [DateTime].
+  static DateTime decodeToDateTime(String snowflake) {
+    return DateTime.fromMillisecondsSinceEpoch(
+      decodeTimestampMs(snowflake),
+      isUtc: true,
+    );
+  }
+
+  /// Builds a snowflake whose timestamp component matches [timestampMs].
+  /// The lower 22 bits are zero.
+  static String fromTimestampMs(int timestampMs) {
+    final id = (timestampMs - epochMs) << 22;
+    return id.toString();
+  }
+
+  /// Generates a unique-enough nonce snowflake for the current time, with the
+  /// low 22 bits randomised. Suitable for optimistic message nonces.
+  static String generateNonce() {
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final id =
+        ((nowMs - epochMs) << 22) | (_random.nextInt(0x400000) & 0x3FFFFF);
+    return id.toString();
+  }
+}

--- a/packages/accordkit/lib/src/voice/voice_manager.dart
+++ b/packages/accordkit/lib/src/voice/voice_manager.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import '../gateway/gateway_socket.dart';
+import '../models/voice_server_update.dart';
+import '../models/voice_state.dart';
+import '../rest/endpoints/voice_api.dart';
+import '../rest/rest_result.dart';
+
+/// High-level voice helper that ties the voice REST endpoints to gateway voice
+/// events, tracking the currently-joined channel and surfacing connect,
+/// disconnect, and error events as streams.
+class VoiceManager {
+  final VoiceApi _voiceApi;
+  String _currentChannelId = '';
+  AccordVoiceState? _currentVoiceState;
+
+  late final StreamSubscription<AccordVoiceState> _stateSub;
+  late final StreamSubscription<AccordVoiceServerUpdate> _serverSub;
+
+  final _connected = StreamController<AccordVoiceServerUpdate>.broadcast();
+  final _disconnected = StreamController<String>.broadcast();
+  final _stateChanged = StreamController<AccordVoiceState>.broadcast();
+  final _serverUpdated = StreamController<AccordVoiceServerUpdate>.broadcast();
+  final _error = StreamController<String>.broadcast();
+
+  /// Fires when a voice channel has been joined.
+  Stream<AccordVoiceServerUpdate> get onVoiceConnected => _connected.stream;
+
+  /// Fires with the channel ID when voice is left or force-disconnected.
+  Stream<String> get onVoiceDisconnected => _disconnected.stream;
+
+  /// Fires on any voice state update relayed by the gateway.
+  Stream<AccordVoiceState> get onVoiceStateChanged => _stateChanged.stream;
+
+  /// Fires on a voice server update relayed by the gateway.
+  Stream<AccordVoiceServerUpdate> get onVoiceServerUpdated =>
+      _serverUpdated.stream;
+
+  /// Fires with a message when a voice operation fails.
+  Stream<String> get onVoiceError => _error.stream;
+
+  VoiceManager(this._voiceApi, GatewaySocket gateway) {
+    _stateSub = gateway.onVoiceStateUpdate.listen(_onVoiceStateUpdate);
+    _serverSub = gateway.onVoiceServerUpdate.listen(_onVoiceServerUpdate);
+  }
+
+  /// Joins [channelId]. On success emits [onVoiceConnected]; on failure emits
+  /// [onVoiceError]. Returns the underlying [RestResult].
+  Future<RestResult> join(String channelId,
+      {bool selfMute = false, bool selfDeaf = false}) async {
+    final result =
+        await _voiceApi.join(channelId, selfMute: selfMute, selfDeaf: selfDeaf);
+    final data = result.data;
+    if (result.ok && data is AccordVoiceServerUpdate) {
+      _currentChannelId = channelId;
+      _currentVoiceState = data.voiceState;
+      _connected.add(data);
+    } else {
+      _error.add(result.error?.message ?? 'Failed to join voice channel');
+    }
+    return result;
+  }
+
+  /// Leaves the current voice channel, if any.
+  Future<RestResult> leave() async {
+    final channelId = _currentChannelId;
+    if (channelId.isEmpty) {
+      return RestResult.failure(0, null);
+    }
+    final result = await _voiceApi.leave(channelId);
+    if (result.ok) {
+      _currentChannelId = '';
+      _currentVoiceState = null;
+      _disconnected.add(channelId);
+    }
+    return result;
+  }
+
+  /// Whether currently connected to a voice channel.
+  bool isConnectedToVoice() => _currentChannelId.isNotEmpty;
+
+  /// The current voice channel ID, or empty when not connected.
+  String getCurrentChannel() => _currentChannelId;
+
+  /// The current voice state, or null when not connected.
+  AccordVoiceState? getCurrentVoiceState() => _currentVoiceState;
+
+  /// Cancels gateway subscriptions and closes streams.
+  Future<void> dispose() async {
+    await _stateSub.cancel();
+    await _serverSub.cancel();
+    await _connected.close();
+    await _disconnected.close();
+    await _stateChanged.close();
+    await _serverUpdated.close();
+    await _error.close();
+  }
+
+  void _onVoiceStateUpdate(AccordVoiceState state) {
+    _stateChanged.add(state);
+    // Detect a forced disconnection: our user's channel_id became null.
+    final current = _currentVoiceState;
+    if (current != null && state.userId == current.userId) {
+      _currentVoiceState = state;
+      if (state.channelId == null && _currentChannelId.isNotEmpty) {
+        final oldChannel = _currentChannelId;
+        _currentChannelId = '';
+        _currentVoiceState = null;
+        _disconnected.add(oldChannel);
+      }
+    }
+  }
+
+  void _onVoiceServerUpdate(AccordVoiceServerUpdate info) {
+    _serverUpdated.add(info);
+  }
+}

--- a/packages/accordkit/pubspec.yaml
+++ b/packages/accordkit/pubspec.yaml
@@ -1,0 +1,16 @@
+name: accordkit
+description: Accord protocol client for Dart — REST, Gateway WebSocket, and data models for Daccord servers.
+version: 2.0.0
+repository: https://github.com/DaccordProject/accordkit-dart
+homepage: https://daccord.gg
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  http: ^1.2.0
+  web_socket_channel: ^3.0.0
+
+dev_dependencies:
+  lints: ^4.0.0
+  test: ^1.25.0

--- a/packages/accordkit/test/accord_client_test.dart
+++ b/packages/accordkit/test/accord_client_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_gateway_connection.dart';
+
+Future<void> pump([int times = 2]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  test('wires config, endpoint APIs, and applies token to REST', () {
+    final client = AccordClient(
+      token: 'abc',
+      tokenType: 'Bearer',
+      baseUrl: 'https://srv',
+      intents: ['messages'],
+    );
+    expect(client.config.apiUrl(), 'https://srv/api/v1');
+    expect(client.rest.token, 'abc');
+    expect(client.rest.tokenType, 'Bearer');
+    expect(client.users, isA<UsersApi>());
+    expect(client.directory, isA<DirectoryApi>());
+    expect(client.voiceManager, isA<VoiceManager>());
+  });
+
+  test('forwards gateway events through the client', () async {
+    final factory = FakeConnectionFactory();
+    final client = AccordClient(
+      token: 'tok',
+      connectionFactory: factory.call,
+      sleep: (_) async {},
+    );
+    final messages = <AccordMessage>[];
+    client.onMessageCreate.listen(messages.add);
+
+    client.login();
+    await pump();
+    factory.last.receive(jsonEncode({
+      'op': GatewayOpcodes.event,
+      'type': 'message.create',
+      'data': {'id': '1', 'channel_id': '5', 'content': 'yo'},
+    }));
+    await pump();
+
+    expect(messages.single.content, 'yo');
+    await client.dispose();
+  });
+
+  test('REST endpoints work through the client with a mock http client',
+      () async {
+    final mock = MockClient((req) async {
+      return http.Response(
+        jsonEncode({
+          'data': {'id': '1', 'username': 'me'}
+        }),
+        200,
+      );
+    });
+    final client = AccordClient(token: 'tok', httpClient: mock);
+    final result = await client.users.getMe();
+    expect((result.data as AccordUser).username, 'me');
+    await client.dispose();
+  });
+}

--- a/packages/accordkit/test/endpoints_test.dart
+++ b/packages/accordkit/test/endpoints_test.dart
@@ -1,0 +1,279 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'support/test_helpers.dart';
+
+late List<CapturedRequest> log;
+late AccordRest rest;
+
+CapturedRequest get req => log.single;
+
+void main() {
+  setUp(() {
+    log = <CapturedRequest>[];
+  });
+
+  group('UsersApi', () {
+    test('getMe deserializes user', () async {
+      rest = mockRest(
+          log: log, responder: (_) => jsonData({'id': '1', 'username': 'me'}));
+      final result = await UsersApi(rest).getMe();
+      expect(req.url.path, '/api/v1/users/@me');
+      expect((result.data as AccordUser).username, 'me');
+    });
+
+    test('searchUsers passes query params', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await UsersApi(rest).searchUsers('alice', limit: 5);
+      expect(req.url.path, '/api/v1/users/search');
+      expect(req.url.queryParameters['query'], 'alice');
+      expect(req.url.queryParameters['limit'], '5');
+    });
+
+    test('listRelationships deserializes array', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData([
+                {
+                  'id': '1',
+                  'type': 1,
+                  'user': {'id': '2', 'username': 'x'}
+                },
+              ]));
+      final result = await UsersApi(rest).listRelationships();
+      expect((result.data as List).single, isA<AccordRelationship>());
+    });
+  });
+
+  group('SpacesApi', () {
+    test('create posts body and deserializes', () async {
+      rest = mockRest(
+          log: log, responder: (_) => jsonData({'id': '9', 'name': 'New'}));
+      final result = await SpacesApi(rest).create({'name': 'New'});
+      expect(req.method, 'POST');
+      expect(req.url.path, '/api/v1/spaces');
+      expect(req.jsonBody, {'name': 'New'});
+      expect((result.data as AccordSpace).name, 'New');
+    });
+
+    test('listChannels deserializes array', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData([
+                {'id': '1', 'type': 'text'},
+              ]));
+      final result = await SpacesApi(rest).listChannels('7');
+      expect(req.url.path, '/api/v1/spaces/7/channels');
+      expect((result.data as List).single, isA<AccordChannel>());
+    });
+
+    test('anonymousCount path', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData({'count': 3}));
+      await SpacesApi(rest).anonymousCount('7');
+      expect(req.url.path, '/api/v1/spaces/7/anonymous-count');
+    });
+  });
+
+  group('MessagesApi', () {
+    test('create message', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) =>
+              jsonData({'id': '1', 'channel_id': '5', 'content': 'hi'}));
+      final result = await MessagesApi(rest).create('5', {'content': 'hi'});
+      expect(req.method, 'POST');
+      expect(req.url.path, '/api/v1/channels/5/messages');
+      expect((result.data as AccordMessage).content, 'hi');
+    });
+
+    test('bulkDelete posts messages array', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await MessagesApi(rest).bulkDelete('5', ['1', '2']);
+      expect(req.url.path, '/api/v1/channels/5/messages/bulk-delete');
+      expect(req.jsonBody!['messages'], ['1', '2']);
+    });
+
+    test('listPosts injects top_level query', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await MessagesApi(rest).listPosts('5');
+      expect(req.url.queryParameters['top_level'], 'true');
+    });
+
+    test('listThread injects thread_id', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await MessagesApi(rest).listThread('5', '99');
+      expect(req.url.queryParameters['thread_id'], '99');
+    });
+
+    test('createWithAttachments uses multipart upload path', () async {
+      rest = mockRest(
+          log: log, responder: (_) => jsonData({'id': '1', 'channel_id': '5'}));
+      await MessagesApi(rest).createWithAttachments(
+        '5',
+        {'content': 'hi'},
+        [
+          {
+            'filename': 'a.bin',
+            'content': Uint8List.fromList([1, 2]),
+            'content_type': 'application/octet-stream',
+          }
+        ],
+      );
+      expect(req.url.path, '/api/v1/channels/5/messages/upload');
+      final body = utf8.decode(req.bodyBytes);
+      expect(body, contains('filename="a.bin"'));
+      expect(body, contains('name="payload_json"'));
+    });
+  });
+
+  group('ReactionsApi', () {
+    test('add encodes emoji into path', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await ReactionsApi(rest).add('5', '10', '👍');
+      expect(req.method, 'PUT');
+      expect(req.url.path,
+          '/api/v1/channels/5/messages/10/reactions/${Uri.encodeComponent('👍')}/@me');
+    });
+  });
+
+  group('MembersApi', () {
+    test('leaveMe with deleteData sets query', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await MembersApi(rest).leaveMe('7', deleteData: true);
+      expect(req.method, 'DELETE');
+      expect(req.url.path, '/api/v1/spaces/7/members/@me');
+      expect(req.url.queryParameters['delete_data'], 'true');
+    });
+
+    test('addRole path', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await MembersApi(rest).addRole('7', '2', '3');
+      expect(req.url.path, '/api/v1/spaces/7/members/2/roles/3');
+      expect(req.method, 'PUT');
+    });
+  });
+
+  group('AuthApi', () {
+    test('register parses auth response into user + token', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData({
+                'user': {'id': '1', 'username': 'a'},
+                'token': 'abc',
+              }));
+      final result = await AuthApi(rest).register({'username': 'a'});
+      final data = result.data as Map<String, dynamic>;
+      expect((data['user'] as AccordUser).username, 'a');
+      expect(data['token'], 'abc');
+    });
+
+    test('login keeps mfa_required envelope unparsed', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData({'mfa_required': true, 'ticket': 'tkt'}));
+      final result = await AuthApi(rest).login({'username': 'a'});
+      final data = result.data as Map<String, dynamic>;
+      expect(data['mfa_required'], isTrue);
+      expect(data['ticket'], 'tkt');
+    });
+  });
+
+  group('VoiceApi', () {
+    test('join deserializes server update', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData({
+                'space_id': '7',
+                'channel_id': '5',
+                'backend': 'livekit',
+                'url': 'wss://lk',
+                'token': 't',
+              }));
+      final result = await VoiceApi(rest).join('5', selfMute: true);
+      expect(req.url.path, '/api/v1/channels/5/voice/join');
+      expect(req.jsonBody, {'self_mute': true, 'self_deaf': false});
+      expect((result.data as AccordVoiceServerUpdate).livekitUrl, 'wss://lk');
+    });
+
+    test('getStatus deserializes voice state list', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData([
+                {'user_id': '1', 'channel_id': '5'},
+              ]));
+      final result = await VoiceApi(rest).getStatus('5');
+      expect((result.data as List).single, isA<AccordVoiceState>());
+    });
+  });
+
+  group('PluginsApi', () {
+    test('listPlugins filters by type', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await PluginsApi(rest).listPlugins('7', type: 'activity');
+      expect(req.url.queryParameters['type'], 'activity');
+    });
+
+    test('getSource uses raw request', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => http.Response.bytes(utf8.encode('-- lua'), 200));
+      final result = await PluginsApi(rest).getSource('1');
+      expect(req.url.path, '/api/v1/plugins/1/source');
+      expect(utf8.decode(result.data as Uint8List), '-- lua');
+    });
+
+    test('leaderboardSubmit posts score', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await PluginsApi(rest)
+          .leaderboardSubmit('1', 'board', 42.0, metadata: {'k': 'v'});
+      expect(req.url.path, '/api/v1/plugins/1/leaderboards/board/submit');
+      expect(req.jsonBody!['score'], 42.0);
+      expect(req.jsonBody!['metadata'], {'k': 'v'});
+    });
+  });
+
+  group('DirectoryApi', () {
+    test('browse builds master-server path with params', () async {
+      // DirectoryApi targets the master server, so its rest base URL is the
+      // master root (without the /api/v1 instance prefix).
+      rest = mockRest(
+          log: log,
+          baseUrl: 'https://master.test',
+          responder: (_) => jsonData({'spaces': []}));
+      await DirectoryApi(rest).browse(query: 'fun', tag: 'games', page: 2);
+      expect(req.url.path, '/api/v1/directory');
+      expect(req.url.queryParameters['q'], 'fun');
+      expect(req.url.queryParameters['tag'], 'games');
+      expect(req.url.queryParameters['page'], '2');
+    });
+  });
+
+  group('AdminApi', () {
+    test('listUsers deserializes array', () async {
+      rest = mockRest(
+          log: log,
+          responder: (_) => jsonData([
+                {'id': '1', 'username': 'a'},
+              ]));
+      final result = await AdminApi(rest).listUsers();
+      expect(req.url.path, '/api/v1/admin/users');
+      expect((result.data as List).single, isA<AccordUser>());
+    });
+  });
+
+  group('RolesApi', () {
+    test('reorder sends array body', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await RolesApi(rest).reorder('7', [
+        {'id': '1', 'position': 0},
+      ]);
+      expect(req.method, 'PATCH');
+      expect(req.url.path, '/api/v1/spaces/7/roles');
+      expect(req.jsonArrayBody!.single['id'], '1');
+    });
+  });
+}

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -1,0 +1,260 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_gateway_connection.dart';
+
+/// Yields to the microtask/event queue so stream events and `.then` callbacks
+/// run.
+Future<void> pump([int times = 2]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+GatewaySocket makeSocket(FakeConnectionFactory factory) {
+  final s = GatewaySocket(
+    connectionFactory: factory.call,
+    sleep: (_) async {},
+    random: () => 0.0,
+    token: 'tok',
+    tokenType: 'Bot',
+  );
+  s.setup(AccordConfig(), 'tok', tknType: 'Bot', intentList: ['messages']);
+  return s;
+}
+
+Map<String, dynamic> lastSent(FakeGatewayConnection c) =>
+    jsonDecode(c.sent.last) as Map<String, dynamic>;
+
+void main() {
+  group('handshake', () {
+    test('emits connected when the socket becomes ready', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      final connected = <void>[];
+      socket.onConnected.listen(connected.add);
+
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      expect(socket.state, GatewayState.connected);
+      expect(connected, hasLength(1));
+      await socket.dispose();
+    });
+
+    test('HELLO triggers IDENTIFY with token and intents', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 60000},
+      }));
+      await pump();
+
+      final sent = lastSent(factory.last);
+      expect(sent['op'], GatewayOpcodes.identify);
+      expect(sent['data']['token'], 'Bot tok');
+      expect(sent['data']['intents'], ['messages']);
+      await socket.dispose();
+    });
+  });
+
+  group('heartbeat', () {
+    test('server HEARTBEAT op prompts an immediate heartbeat with sequence',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      // Deliver an event carrying a sequence number.
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'typing.start',
+        'seq': 7,
+        'data': {'channel_id': '1'},
+      }));
+      // Server asks us to heartbeat.
+      factory.last.receive(jsonEncode({'op': GatewayOpcodes.heartbeat}));
+      await pump();
+
+      final sent = lastSent(factory.last);
+      expect(sent['op'], GatewayOpcodes.heartbeat);
+      expect(sent['data'], 7);
+      await socket.dispose();
+    });
+  });
+
+  group('dispatch', () {
+    test('message.create emits a typed AccordMessage and a raw event',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      final messages = <AccordMessage>[];
+      final raw = <RawGatewayEvent>[];
+      socket.onMessageCreate.listen(messages.add);
+      socket.onRawEvent.listen(raw.add);
+
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'message.create',
+        'data': {'id': '1', 'channel_id': '5', 'content': 'hi'},
+      }));
+      await pump();
+
+      expect(messages.single.content, 'hi');
+      expect(raw.single.type, 'message.create');
+      await socket.dispose();
+    });
+
+    test('ready event records the session id', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'data': {'session_id': 'SESSION'},
+      }));
+      await pump();
+
+      expect(socket.sessionId, 'SESSION');
+      await socket.dispose();
+    });
+  });
+
+  group('outbound helpers', () {
+    test('updatePresence / updateVoiceState / requestMembers / voiceSignal',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      final conn = factory.last;
+
+      socket.updatePresence('online', activity: {'name': 'g'});
+      expect(lastSent(conn)['op'], GatewayOpcodes.presenceUpdate);
+      expect(lastSent(conn)['data']['activity'], {'name': 'g'});
+
+      socket.updateVoiceState('7', '5', selfMute: true);
+      expect(lastSent(conn)['op'], GatewayOpcodes.voiceStateUpdate);
+      expect(lastSent(conn)['data']['channel_id'], '5');
+      expect(lastSent(conn)['data']['self_mute'], true);
+
+      socket.updateVoiceState('7', null);
+      expect(lastSent(conn)['data']['channel_id'], isNull);
+
+      socket.requestMembers('7', query: 'al', limit: 5);
+      expect(lastSent(conn)['op'], GatewayOpcodes.requestMembers);
+      expect(lastSent(conn)['data']['limit'], 5);
+
+      socket.sendVoiceSignal('7', '5', 'offer', {'sdp': 'x'});
+      expect(lastSent(conn)['op'], GatewayOpcodes.voiceSignal);
+      expect(lastSent(conn)['data']['type'], 'offer');
+
+      await socket.dispose();
+    });
+  });
+
+  group('reconnect', () {
+    test('resumes after an unexpected close once a session exists', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      // Establish a session.
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'data': {'session_id': 'S1'},
+      }));
+      await pump();
+
+      // Unexpected drop.
+      factory.last.simulateClose(1006);
+      await pump();
+
+      expect(factory.connections.length, 2,
+          reason: 'a reconnect connection should be created');
+
+      // New connection gets HELLO → should RESUME (not IDENTIFY).
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 60000},
+      }));
+      await pump();
+
+      final sent = lastSent(factory.last);
+      expect(sent['op'], GatewayOpcodes.resume);
+      expect(sent['data']['session_id'], 'S1');
+      await socket.dispose();
+    });
+
+    test('does not reconnect on a fatal close code', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      factory.last.simulateClose(4004); // authentication failed
+      await pump();
+
+      expect(factory.connections.length, 1);
+      expect(socket.state, GatewayState.disconnected);
+      await socket.dispose();
+    });
+
+    test('disconnectFromGateway emits disconnected and suppresses reconnect',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      final disconnects = <DisconnectInfo>[];
+      socket.onDisconnected.listen(disconnects.add);
+
+      socket.connectToGateway('ws://x');
+      await pump();
+      await socket.disconnectFromGateway(1000, 'bye');
+      await pump();
+
+      expect(disconnects.single.reason, 'bye');
+      expect(factory.connections.length, 1);
+      expect(socket.state, GatewayState.disconnected);
+      await socket.dispose();
+    });
+
+    test('non-resumable INVALID_SESSION clears session and reconnects',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'data': {'session_id': 'S1'},
+      }));
+      await pump();
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.invalidSession,
+        'data': false,
+      }));
+      await pump();
+
+      expect(socket.sessionId, '');
+      expect(factory.connections.length, 2);
+      await socket.dispose();
+    });
+  });
+}

--- a/packages/accordkit/test/models_test.dart
+++ b/packages/accordkit/test/models_test.dart
@@ -1,0 +1,349 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccordUser', () {
+    test('parses fields and coerces int id to string', () {
+      final u = AccordUser.fromJson({
+        'id': 123,
+        'username': 'alice',
+        'display_name': 'Alice',
+        'bot': true,
+        'flags': 5,
+        'is_admin': true,
+      });
+      expect(u.id, '123');
+      expect(u.username, 'alice');
+      expect(u.displayName, 'Alice');
+      expect(u.bot, isTrue);
+      expect(u.flags, 5);
+      expect(u.isAdmin, isTrue);
+    });
+
+    test('toJson omits null optionals', () {
+      final u = AccordUser(id: '1', username: 'bob');
+      final j = u.toJson();
+      expect(j['id'], '1');
+      expect(j.containsKey('display_name'), isFalse);
+      expect(j.containsKey('avatar'), isFalse);
+    });
+  });
+
+  group('AccordApplication', () {
+    test('reads owner.id over owner_id', () {
+      final a = AccordApplication.fromJson({
+        'id': '1',
+        'owner': {'id': '99'},
+      });
+      expect(a.ownerId, '99');
+    });
+
+    test('falls back to owner_id', () {
+      final a = AccordApplication.fromJson({'id': '1', 'owner_id': '42'});
+      expect(a.ownerId, '42');
+    });
+  });
+
+  group('AccordChannel', () {
+    test('parses space_id from guild_id alias and overwrites', () {
+      final c = AccordChannel.fromJson({
+        'id': '1',
+        'guild_id': '7',
+        'rate_limit_per_user': 5,
+        'permission_overwrites': [
+          {'id': '3', 'type': 'member', 'allow': [], 'deny': []},
+        ],
+      });
+      expect(c.spaceId, '7');
+      expect(c.rateLimit, 5);
+      expect(c.permissionOverwrites.single.type, 'user');
+    });
+
+    test('roundtrips recipients', () {
+      final c = AccordChannel.fromJson({
+        'id': '1',
+        'type': 'group_dm',
+        'recipients': [
+          {'id': '2', 'username': 'x'},
+        ],
+      });
+      expect(c.recipients!.single.username, 'x');
+      final j = c.toJson();
+      expect((j['recipients'] as List).single['username'], 'x');
+    });
+  });
+
+  group('AccordMessage', () {
+    test('parses author, mentions, attachments, embeds, reply_to', () {
+      final m = AccordMessage.fromJson({
+        'id': '10',
+        'channel_id': '5',
+        'guild_id': '7',
+        'author': {'id': '2'},
+        'content': 'hello',
+        'mentions': [
+          {'id': '3'},
+          '4',
+        ],
+        'mention_roles': [9],
+        'attachments': [
+          {'id': '1', 'filename': 'a.png', 'size': 10, 'url': 'u'},
+        ],
+        'embeds': [
+          {'title': 'T'},
+        ],
+        'message_reference': {'message_id': '99'},
+        'reactions': [
+          {'emoji': '👍', 'count': 2, 'me': true},
+        ],
+      });
+      expect(m.spaceId, '7');
+      expect(m.authorId, '2');
+      expect(m.mentions, ['3', '4']);
+      expect(m.mentionRoles, ['9']);
+      expect(m.attachments.single.filename, 'a.png');
+      expect(m.embeds.single.title, 'T');
+      expect(m.replyTo, '99');
+      expect(m.reactions!.single.count, 2);
+      expect(m.reactions!.single.includesMe, isTrue);
+    });
+
+    test('toJson includes attachments/embeds and omits empty extras', () {
+      final m = AccordMessage(id: '1', channelId: '2', content: 'hi');
+      final j = m.toJson();
+      expect(j['attachments'], isEmpty);
+      expect(j['embeds'], isEmpty);
+      expect(j.containsKey('reply_count'), isFalse);
+      expect(j.containsKey('thread_participants'), isFalse);
+    });
+  });
+
+  group('AccordMember', () {
+    test('reads nested user and nick alias', () {
+      final m = AccordMember.fromJson({
+        'user': {'id': '2', 'username': 'x'},
+        'guild_id': '7',
+        'nick': 'Nicky',
+        'roles': [1, 2],
+        'communication_disabled_until': 'soon',
+      });
+      expect(m.userId, '2');
+      expect(m.user!.username, 'x');
+      expect(m.spaceId, '7');
+      expect(m.nickname, 'Nicky');
+      expect(m.roles, ['1', '2']);
+      expect(m.timedOutUntil, 'soon');
+    });
+  });
+
+  group('AccordEmbed builder', () {
+    test('chains setters and serialises', () {
+      final e = AccordEmbed.build()
+          .setTitle('Title')
+          .setDescription('Desc')
+          .setColor(0xFF0000)
+          .addField('k', 'v', inline: true)
+          .setFooter('foot', iconUrl: 'icon')
+          .setAuthor('auth');
+      final j = e.toJson();
+      expect(j['title'], 'Title');
+      expect(j['color'], 0xFF0000);
+      expect((j['fields'] as List).single['inline'], isTrue);
+      expect((j['footer'] as Map)['icon_url'], 'icon');
+      expect((j['author'] as Map)['name'], 'auth');
+    });
+  });
+
+  group('AccordEmoji', () {
+    test('null id stays null, roles aliased', () {
+      final e = AccordEmoji.fromJson({
+        'name': 'smile',
+        'roles': [1, 2],
+      });
+      expect(e.id, isNull);
+      expect(e.roleIds, ['1', '2']);
+      expect(e.toJson().containsKey('id'), isFalse);
+    });
+  });
+
+  group('AccordReaction', () {
+    test('string emoji shorthand', () {
+      final r = AccordReaction.fromJson({'emoji': '🔥', 'count': 1});
+      expect(r.emoji['id'], isNull);
+      expect(r.emoji['name'], '🔥');
+    });
+
+    test('splits custom emoji token name:id', () {
+      final r = AccordReaction.fromJson(
+          {'emoji': 'cube2:323038910819074048', 'count': 1});
+      expect(r.emoji['id'], '323038910819074048');
+      expect(r.emoji['name'], 'cube2');
+    });
+
+    test('non-numeric tail after colon stays part of the name', () {
+      final r = AccordReaction.fromJson({'emoji': ':hamburger:', 'count': 1});
+      expect(r.emoji['id'], isNull);
+      expect(r.emoji['name'], ':hamburger:');
+    });
+
+    test('map emoji keeps explicit id and name', () {
+      final r = AccordReaction.fromJson({
+        'emoji': {'id': '42', 'name': 'cube2'},
+        'count': 1,
+      });
+      expect(r.emoji['id'], '42');
+      expect(r.emoji['name'], 'cube2');
+    });
+  });
+
+  group('AccordSpace', () {
+    test('parses roles and emojis', () {
+      final s = AccordSpace.fromJson({
+        'id': '1',
+        'name': 'Space',
+        'roles': [
+          {'id': '1', 'name': 'admin'},
+        ],
+        'emojis': [
+          {'id': '2', 'name': 'e'},
+        ],
+        'member_count': 3,
+      });
+      expect(s.roles.single.name, 'admin');
+      expect(s.emojis.single.name, 'e');
+      expect(s.memberCount, 3);
+    });
+  });
+
+  group('AccordVoiceServerUpdate', () {
+    test('aliases url/endpoint and nested voice_state', () {
+      final v = AccordVoiceServerUpdate.fromJson({
+        'space_id': '1',
+        'channel_id': '2',
+        'backend': 'livekit',
+        'url': 'wss://lk',
+        'endpoint': 'sfu',
+        'voice_state': {'user_id': '9', 'channel_id': '2'},
+      });
+      expect(v.livekitUrl, 'wss://lk');
+      expect(v.sfuEndpoint, 'sfu');
+      expect(v.voiceState!.userId, '9');
+    });
+  });
+
+  group('AccordVoiceState', () {
+    test('nullable channel_id', () {
+      final v = AccordVoiceState.fromJson({'user_id': '1'});
+      expect(v.channelId, isNull);
+      expect(v.toJson().containsKey('channel_id'), isFalse);
+    });
+  });
+
+  group('AccordRelationship', () {
+    test('extracts user status/activities', () {
+      final r = AccordRelationship.fromJson({
+        'id': '1',
+        'type': 1,
+        'user': {
+          'id': '2',
+          'username': 'x',
+          'status': 'online',
+          'activities': [
+            {'name': 'game'},
+          ],
+        },
+      });
+      expect(r.type, 1);
+      expect(r.user!.id, '2');
+      expect(r.userStatus, 'online');
+      expect(r.userActivities, hasLength(1));
+    });
+  });
+
+  group('AccordPluginManifest', () {
+    test('canvas_size array and defaults', () {
+      final m = AccordPluginManifest.fromJson({
+        'id': '1',
+        'name': 'p',
+        'canvas_size': [800, 600],
+        'max_spectators': -1,
+      });
+      expect(m.canvasSize, [800, 600]);
+      expect(m.maxSpectators, -1);
+    });
+
+    test('canvas_width/height fallback', () {
+      final m = AccordPluginManifest.fromJson({
+        'id': '1',
+        'canvas_width': 320,
+        'canvas_height': 240,
+      });
+      expect(m.canvasSize, [320, 240]);
+    });
+  });
+
+  group('AccordInvite', () {
+    test('inviter object and guild_id alias', () {
+      final i = AccordInvite.fromJson({
+        'code': 'abc',
+        'guild_id': '7',
+        'channel_id': '5',
+        'inviter': {'id': '2'},
+      });
+      expect(i.spaceId, '7');
+      expect(i.inviterId, '2');
+    });
+  });
+
+  group('AccordInteraction', () {
+    test('member.user.id and message', () {
+      final it = AccordInteraction.fromJson({
+        'id': '1',
+        'application_id': '9',
+        'member': {
+          'user': {'id': '2'},
+        },
+        'message': {'id': '10', 'channel_id': '5'},
+      });
+      expect(it.memberId, '2');
+      expect(it.message!.id, '10');
+    });
+  });
+
+  group('AccordActivity', () {
+    test('roundtrip', () {
+      final a = AccordActivity.fromJson({'name': 'g', 'type': 'streaming'});
+      expect(a.toJson()['type'], 'streaming');
+    });
+  });
+
+  group('AccordAuditLogEntry / AccordCommand / AccordRole / AccordSound', () {
+    test('audit log entry', () {
+      final e = AccordAuditLogEntry.fromJson({
+        'id': '1',
+        'user_id': '2',
+        'action_type': 'ban',
+      });
+      expect(e.toJson()['action_type'], 'ban');
+    });
+
+    test('command guild_id alias', () {
+      final c = AccordCommand.fromJson({'id': '1', 'guild_id': '7'});
+      expect(c.spaceId, '7');
+    });
+
+    test('role permissions list', () {
+      final r = AccordRole.fromJson({
+        'id': '1',
+        'name': 'r',
+        'permissions': ['administrator'],
+      });
+      expect(r.permissions, ['administrator']);
+    });
+
+    test('sound volume coercion', () {
+      final s = AccordSound.fromJson({'name': 's', 'volume': 1});
+      expect(s.volume, 1.0);
+    });
+  });
+}

--- a/packages/accordkit/test/paginator_test.dart
+++ b/packages/accordkit/test/paginator_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'support/test_helpers.dart';
+
+void main() {
+  group('AccordPaginator', () {
+    test('fromResult deserializes items and tracks cursor', () async {
+      final rest = mockRest(log: [], responder: (_) => jsonData([]));
+      final result = RestResult.success(
+        200,
+        [
+          {'id': '1', 'username': 'a'},
+        ],
+        {'after': '1', 'has_more': true},
+      );
+      final p = AccordPaginator.fromResult(result, rest, '/users', {},
+          fromJson: AccordUser.fromJson);
+      expect(p.items.single, isA<AccordUser>());
+      expect(p.hasMore, isTrue);
+    });
+
+    test('next fetches following page with after cursor', () async {
+      final log = <CapturedRequest>[];
+      final rest = mockRest(
+        log: log,
+        responder: (_) => http.Response(
+          jsonEncode({
+            'data': [
+              {'id': '2', 'username': 'b'},
+            ],
+            'cursor': {'after': '', 'has_more': false},
+          }),
+          200,
+        ),
+      );
+      final first = RestResult.success(
+        200,
+        [
+          {'id': '1', 'username': 'a'},
+        ],
+        {'after': '1', 'has_more': true},
+      );
+      final p = AccordPaginator.fromResult(first, rest, '/users', {},
+          fromJson: AccordUser.fromJson);
+      final next = await p.next();
+      expect(log.single.url.queryParameters['after'], '1');
+      expect((next.items.single as AccordUser).id, '2');
+      expect(next.hasMore, isFalse);
+    });
+  });
+}

--- a/packages/accordkit/test/rest_test.dart
+++ b/packages/accordkit/test/rest_test.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'support/test_helpers.dart';
+
+void main() {
+  group('RestResult', () {
+    test('success/failure factories and hasMore', () {
+      final ok = RestResult.success(200, {'a': 1}, {'has_more': true});
+      expect(ok.ok, isTrue);
+      expect(ok.hasMore, isTrue);
+      final err = RestResult.failure(400, AccordError(message: 'x'));
+      expect(err.ok, isFalse);
+      expect(err.error!.message, 'x');
+    });
+
+    test('deserialize and deserializeArray', () {
+      final r = RestResult.success(200, {'id': '1', 'username': 'a'});
+      r.deserialize(AccordUser.fromJson);
+      expect((r.data as AccordUser).username, 'a');
+
+      final arr = RestResult.success(200, [
+        {'id': '1', 'username': 'a'},
+        {'id': '2', 'username': 'b'},
+      ]);
+      arr.deserializeArray(AccordUser.fromJson);
+      expect((arr.data as List).map((u) => (u as AccordUser).id), ['1', '2']);
+    });
+  });
+
+  group('AccordError', () {
+    test('fromJson', () {
+      final e = AccordError.fromJson({
+        'code': 'BAD',
+        'message': 'nope',
+        'details': {'k': 'v'}
+      });
+      expect(e.code, 'BAD');
+      expect(e.details['k'], 'v');
+    });
+  });
+
+  group('AccordRest.makeRequest', () {
+    test('builds URL, encodes query, sets auth headers', () async {
+      final log = <CapturedRequest>[];
+      final rest = mockRest(
+        log: log,
+        responder: (_) => jsonData({'ok': true}),
+      );
+      await rest.makeRequest('GET', '/users/@me',
+          query: {'limit': 10, 'q': 'a b', 'skip': null});
+
+      final req = log.single;
+      expect(req.method, 'GET');
+      expect(req.url.path, '/api/v1/users/@me');
+      expect(req.url.queryParameters['limit'], '10');
+      expect(req.url.queryParameters['q'], 'a b');
+      expect(req.url.queryParameters.containsKey('skip'), isFalse);
+      expect(req.headers['authorization'], 'Bot test-token');
+      expect(req.headers['user-agent'], contains('AccordKit'));
+    });
+
+    test('encodes JSON body for POST', () async {
+      final log = <CapturedRequest>[];
+      final rest = mockRest(log: log, responder: (_) => jsonData(null));
+      await rest.makeRequest('POST', '/x', body: {'a': 1});
+      expect(log.single.jsonBody, {'a': 1});
+    });
+
+    test('parses data envelope with cursor normalisation', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => http.Response(
+          jsonEncode({
+            'data': [
+              {'id': '1'}
+            ],
+            'cursor': {'after': '99'},
+          }),
+          200,
+        ),
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(result.ok, isTrue);
+      expect(result.hasMore, isTrue); // derived from non-empty after
+      expect(result.cursor['after'], '99');
+    });
+
+    test('parses error envelope', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonError('FORBIDDEN', 'no', status: 403),
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(result.ok, isFalse);
+      expect(result.statusCode, 403);
+      expect(result.error!.code, 'FORBIDDEN');
+    });
+
+    test('plain dict (no envelope) returned as map on success', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonRaw({'hello': 'world'}),
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(result.ok, isTrue);
+      expect((result.data as Map)['hello'], 'world');
+    });
+
+    test('empty success body yields null data', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => http.Response('', 204),
+      );
+      final result = await rest.makeRequest('DELETE', '/x');
+      expect(result.ok, isTrue);
+      expect(result.data, isNull);
+    });
+
+    test('retries on 429 then succeeds', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) {
+          calls++;
+          if (calls == 1) {
+            return http.Response('{"retry_after":0.01}', 429,
+                headers: {'retry-after': '0.01'});
+          }
+          return jsonData({'ok': true});
+        },
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(calls, 2);
+      expect(result.ok, isTrue);
+    });
+
+    test('gives up after max retries on persistent 429', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) {
+          calls++;
+          return http.Response('', 429, headers: {'retry-after': '0'});
+        },
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(calls, AccordRest.maxRetries);
+      expect(result.ok, isFalse);
+      expect(result.statusCode, 429);
+    });
+
+    test('transport exception becomes INTERNAL error', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => throw Exception('boom'),
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(result.ok, isFalse);
+      expect(result.error!.code, 'INTERNAL');
+    });
+  });
+
+  group('AccordRest.makeRawRequest', () {
+    test('returns raw bytes on success', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => http.Response.bytes([1, 2, 3], 200),
+      );
+      final result = await rest.makeRawRequest('/plugins/1/bundle');
+      expect(result.ok, isTrue);
+      expect(result.data, isA<Uint8List>());
+      expect(result.data as Uint8List, [1, 2, 3]);
+    });
+
+    test('non-2xx becomes failure', () async {
+      final rest = mockRest(
+        log: [],
+        responder: (_) => http.Response.bytes([], 404),
+      );
+      final result = await rest.makeRawRequest('/x');
+      expect(result.ok, isFalse);
+      expect(result.statusCode, 404);
+    });
+  });
+
+  group('AccordRest.makeMultipartRequest', () {
+    test('sends multipart body and parses response', () async {
+      final log = <CapturedRequest>[];
+      final rest = mockRest(
+        log: log,
+        responder: (_) => jsonData({'id': '1', 'channel_id': '2'}),
+      );
+      final form = MultipartForm(boundary: 'BOUND')
+        ..addJson('payload_json', {'content': 'hi'})
+        ..addFile('files[0]', 'a.txt', utf8.encode('hello'),
+            contentType: 'text/plain');
+      final result = await rest.makeMultipartRequest('POST', '/upload', form);
+      expect(result.ok, isTrue);
+
+      final body = utf8.decode(log.single.bodyBytes);
+      expect(log.single.headers['content-type'], contains('boundary=BOUND'));
+      expect(body, contains('name="payload_json"'));
+      expect(body, contains('filename="a.txt"'));
+      expect(body, contains('hello'));
+      expect(body.trimRight().endsWith('--BOUND--'), isTrue);
+    });
+  });
+
+  group('MultipartForm', () {
+    test('builds well-formed parts', () {
+      final form = MultipartForm(boundary: 'X')..addField('a', 'b');
+      final out = utf8.decode(form.build());
+      expect(out, contains('--X\r\nContent-Disposition: form-data; name="a"'));
+      expect(out, contains('\r\nb\r\n'));
+      expect(out.endsWith('--X--\r\n'), isTrue);
+    });
+  });
+}

--- a/packages/accordkit/test/support/fake_gateway_connection.dart
+++ b/packages/accordkit/test/support/fake_gateway_connection.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+
+import 'package:accordkit/accordkit.dart';
+
+/// A [GatewayConnection] driven by tests: push inbound frames with [receive],
+/// inspect outbound frames via [sent], and simulate closure with [simulateClose].
+class FakeGatewayConnection implements GatewayConnection {
+  final String url;
+  final _messages = StreamController<String>();
+  final Completer<void> _ready = Completer<void>();
+
+  /// JSON strings sent by the socket.
+  final List<String> sent = [];
+
+  @override
+  int? closeCode;
+  @override
+  String? closeReason;
+
+  bool readyImmediately;
+
+  FakeGatewayConnection(this.url, {this.readyImmediately = true}) {
+    if (readyImmediately && !_ready.isCompleted) {
+      _ready.complete();
+    }
+  }
+
+  /// Completes the [ready] future (when [readyImmediately] was false).
+  void markReady() {
+    if (!_ready.isCompleted) _ready.complete();
+  }
+
+  /// Pushes an inbound frame to the socket.
+  void receive(String text) => _messages.add(text);
+
+  /// Simulates the connection closing with the given code/reason.
+  void simulateClose(int code, [String reason = '']) {
+    closeCode = code;
+    closeReason = reason;
+    if (!_messages.isClosed) _messages.close();
+  }
+
+  @override
+  Future<void> get ready => _ready.future;
+
+  @override
+  Stream<String> get messages => _messages.stream;
+
+  @override
+  void sendText(String text) => sent.add(text);
+
+  @override
+  Future<void> close([int? code, String? reason]) async {
+    if (code != null) closeCode = code;
+    if (reason != null) closeReason = reason;
+    if (!_messages.isClosed) await _messages.close();
+  }
+}
+
+/// Creates a connection factory that hands out [FakeGatewayConnection]s and
+/// records each one created (so tests can drive reconnect scenarios).
+class FakeConnectionFactory {
+  final List<FakeGatewayConnection> connections = [];
+  bool readyImmediately;
+
+  FakeConnectionFactory({this.readyImmediately = true});
+
+  FakeGatewayConnection get last => connections.last;
+
+  GatewayConnection call(String url) {
+    final conn = FakeGatewayConnection(url, readyImmediately: readyImmediately);
+    connections.add(conn);
+    return conn;
+  }
+}

--- a/packages/accordkit/test/support/test_helpers.dart
+++ b/packages/accordkit/test/support/test_helpers.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// A captured outbound HTTP request, for assertions.
+class CapturedRequest {
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final String body;
+  final List<int> bodyBytes;
+
+  CapturedRequest(
+      this.method, this.url, this.headers, this.body, this.bodyBytes);
+
+  Map<String, dynamic>? get jsonBody {
+    if (body.isEmpty) return null;
+    final decoded = jsonDecode(body);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
+
+  List<dynamic>? get jsonArrayBody {
+    if (body.isEmpty) return null;
+    final decoded = jsonDecode(body);
+    return decoded is List ? decoded : null;
+  }
+}
+
+/// Builds an [AccordRest] backed by a [MockClient]. Every request is recorded
+/// into [log]; the [responder] decides each response. Rate-limit sleeps are
+/// instant.
+AccordRest mockRest({
+  required List<CapturedRequest> log,
+  required FutureOr<http.Response> Function(CapturedRequest req) responder,
+  String token = 'test-token',
+  String tokenType = 'Bot',
+  String baseUrl = 'https://example.test/api/v1',
+}) {
+  final client = MockClient((request) async {
+    final captured = CapturedRequest(
+      request.method,
+      request.url,
+      request.headers,
+      request.body,
+      request.bodyBytes,
+    );
+    log.add(captured);
+    return responder(captured);
+  });
+  return AccordRest(
+    baseUrl,
+    token: token,
+    tokenType: tokenType,
+    client: client,
+    sleep: (_) async {},
+  );
+}
+
+/// A JSON `{ "data": ... }` success envelope response.
+http.Response jsonData(Object? data, {int status = 200}) {
+  return http.Response(jsonEncode({'data': data}), status,
+      headers: {'content-type': 'application/json'});
+}
+
+/// A raw JSON body response (no envelope).
+http.Response jsonRaw(Object? body, {int status = 200}) {
+  return http.Response(jsonEncode(body), status,
+      headers: {'content-type': 'application/json'});
+}
+
+/// A JSON `{ "error": {...} }` failure envelope response.
+http.Response jsonError(
+  String code,
+  String message, {
+  int status = 400,
+}) {
+  return http.Response(
+    jsonEncode({
+      'error': {'code': code, 'message': message}
+    }),
+    status,
+    headers: {'content-type': 'application/json'},
+  );
+}

--- a/packages/accordkit/test/utils_test.dart
+++ b/packages/accordkit/test/utils_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccordSnowflake', () {
+    test('decodeTimestampMs of zero-low-bits id', () {
+      final sf =
+          AccordSnowflake.fromTimestampMs(AccordSnowflake.epochMs + 1000);
+      expect(AccordSnowflake.decodeTimestampMs(sf),
+          AccordSnowflake.epochMs + 1000);
+    });
+
+    test('decodeTimestamp returns seconds', () {
+      final sf =
+          AccordSnowflake.fromTimestampMs(AccordSnowflake.epochMs + 2000);
+      expect(AccordSnowflake.decodeTimestamp(sf),
+          (AccordSnowflake.epochMs + 2000) / 1000.0);
+    });
+
+    test('empty snowflake decodes to 0', () {
+      expect(AccordSnowflake.decodeTimestampMs(''), 0);
+    });
+
+    test('decodeToDateTime is UTC', () {
+      final sf = AccordSnowflake.fromTimestampMs(AccordSnowflake.epochMs);
+      final dt = AccordSnowflake.decodeToDateTime(sf);
+      expect(dt.isUtc, isTrue);
+      expect(dt.millisecondsSinceEpoch, AccordSnowflake.epochMs);
+    });
+
+    test('generateNonce is numeric and unique-ish', () {
+      final a = AccordSnowflake.generateNonce();
+      expect(int.tryParse(a), isNotNull);
+    });
+  });
+
+  group('AccordCDN', () {
+    test('avatar url', () {
+      expect(
+        AccordCDN.avatar('1', 'hash', cdnUrl: 'https://cdn'),
+        'https://cdn/avatars/1/hash.png',
+      );
+    });
+
+    test('animated detection and auto format', () {
+      expect(AccordCDN.isAnimated('a_123'), isTrue);
+      expect(AccordCDN.autoFormat('a_123'), 'gif');
+      expect(AccordCDN.autoFormat('123'), 'png');
+    });
+
+    test('resolvePath handles absolute, /cdn/, /, and bare', () {
+      expect(AccordCDN.resolvePath('https://x/y'), 'https://x/y');
+      expect(AccordCDN.resolvePath('/cdn/a.png', cdnUrl: 'https://cdn'),
+          'https://cdn/a.png');
+      expect(AccordCDN.resolvePath('/a.png', cdnUrl: 'https://cdn'),
+          'https://cdn/a.png');
+      expect(AccordCDN.resolvePath('a.png', cdnUrl: 'https://cdn'),
+          'https://cdn/a.png');
+    });
+
+    test('buildDataUri infers mime from extension', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final uri = AccordCDN.buildDataUri(bytes, 'pic.jpeg');
+      expect(uri.startsWith('data:image/jpeg;base64,'), isTrue);
+      expect(uri.endsWith(base64Encode(bytes)), isTrue);
+    });
+
+    test('default avatar and emoji', () {
+      expect(AccordCDN.defaultAvatar(3, cdnUrl: 'https://cdn'),
+          'https://cdn/embed/avatars/3.png');
+      expect(AccordCDN.emoji('9', cdnUrl: 'https://cdn'),
+          'https://cdn/emojis/9.png');
+    });
+  });
+
+  group('GatewayIntents', () {
+    test('all is union of privileged and unprivileged', () {
+      expect(GatewayIntents.all().toSet(),
+          {...GatewayIntents.unprivileged(), ...GatewayIntents.privileged()});
+    });
+
+    test('defaults and guest sets', () {
+      expect(GatewayIntents.defaults(), contains(GatewayIntents.messages));
+      expect(GatewayIntents.guest(), contains(GatewayIntents.members));
+    });
+  });
+
+  group('AccordPermission', () {
+    test('has respects administrator', () {
+      expect(AccordPermission.has(['administrator'], 'ban_members'), isTrue);
+      expect(AccordPermission.has(['send_messages'], 'ban_members'), isFalse);
+      expect(AccordPermission.has(['ban_members'], 'ban_members'), isTrue);
+    });
+
+    test('all contains 40 entries and descriptions exist', () {
+      expect(AccordPermission.all(), hasLength(40));
+      expect(AccordPermission.description('administrator'), isNotEmpty);
+      expect(AccordPermission.description('not_a_perm'), isEmpty);
+    });
+  });
+}

--- a/packages/accordkit/test/voice_manager_test.dart
+++ b/packages/accordkit/test/voice_manager_test.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_gateway_connection.dart';
+import 'support/test_helpers.dart';
+
+Future<void> pump([int times = 2]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  late FakeConnectionFactory factory;
+  late GatewaySocket gateway;
+
+  Future<void> connectGateway() async {
+    gateway = GatewaySocket(
+      connectionFactory: factory.call,
+      sleep: (_) async {},
+      random: () => 0.0,
+    );
+    gateway.setup(AccordConfig(), 'tok');
+    gateway.connectToGateway('ws://x');
+    await pump();
+  }
+
+  setUp(() {
+    factory = FakeConnectionFactory();
+  });
+
+  test('join success emits onVoiceConnected and tracks channel', () async {
+    await connectGateway();
+    final voiceApi = VoiceApi(mockRest(
+      log: [],
+      responder: (_) => jsonData({
+        'space_id': '7',
+        'channel_id': '5',
+        'backend': 'livekit',
+        'url': 'wss://lk',
+        'token': 't',
+        'voice_state': {'user_id': '9', 'channel_id': '5'},
+      }),
+    ));
+    final manager = VoiceManager(voiceApi, gateway);
+    final connected = <AccordVoiceServerUpdate>[];
+    manager.onVoiceConnected.listen(connected.add);
+
+    final result = await manager.join('5', selfMute: true);
+    await pump();
+
+    expect(result.ok, isTrue);
+    expect(manager.isConnectedToVoice(), isTrue);
+    expect(manager.getCurrentChannel(), '5');
+    expect(connected.single.livekitUrl, 'wss://lk');
+    await manager.dispose();
+    await gateway.dispose();
+  });
+
+  test('join failure emits onVoiceError', () async {
+    await connectGateway();
+    final voiceApi = VoiceApi(mockRest(
+      log: [],
+      responder: (_) => jsonError('FORBIDDEN', 'no voice', status: 403),
+    ));
+    final manager = VoiceManager(voiceApi, gateway);
+    final errors = <String>[];
+    manager.onVoiceError.listen(errors.add);
+
+    final result = await manager.join('5');
+    await pump();
+
+    expect(result.ok, isFalse);
+    expect(errors.single, 'no voice');
+    expect(manager.isConnectedToVoice(), isFalse);
+    await manager.dispose();
+    await gateway.dispose();
+  });
+
+  test('leave without a channel returns a failure', () async {
+    await connectGateway();
+    final voiceApi =
+        VoiceApi(mockRest(log: [], responder: (_) => jsonData(null)));
+    final manager = VoiceManager(voiceApi, gateway);
+    final result = await manager.leave();
+    expect(result.ok, isFalse);
+    await manager.dispose();
+    await gateway.dispose();
+  });
+
+  test('forced disconnect via voice.state_update with null channel', () async {
+    await connectGateway();
+    final voiceApi = VoiceApi(mockRest(
+      log: [],
+      responder: (_) => jsonData({
+        'space_id': '7',
+        'channel_id': '5',
+        'backend': 'custom',
+        'voice_state': {'user_id': '9', 'channel_id': '5'},
+      }),
+    ));
+    final manager = VoiceManager(voiceApi, gateway);
+    final disconnects = <String>[];
+    manager.onVoiceDisconnected.listen(disconnects.add);
+
+    await manager.join('5');
+    await pump();
+
+    // Gateway relays a state update removing us from the channel.
+    factory.last.receive(jsonEncode({
+      'op': GatewayOpcodes.event,
+      'type': 'voice.state_update',
+      'data': {'user_id': '9', 'channel_id': null},
+    }));
+    await pump();
+
+    expect(disconnects, contains('5'));
+    expect(manager.isConnectedToVoice(), isFalse);
+    await manager.dispose();
+    await gateway.dispose();
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,11 +12,9 @@ packages:
   accordkit:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "285e7b4263f875be3eadd0c3c6217932ae3e24b8"
-      url: "https://github.com/DaccordProject/accordkit-dart"
-    source: git
+      path: "packages/accordkit"
+      relative: true
+    source: path
     version: "2.0.0"
   after_layout:
     dependency: transitive
@@ -254,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -986,18 +984,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -1069,10 +1067,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1738,26 +1736,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   thumbhash:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
     path: packages/markdown_viewer
 
   # Accord protocol SDK — the networking layer that replaced firebridge.
+  # Vendored in-tree (packages/accordkit) and maintained here.
   accordkit:
-    git:
-      url: https://github.com/DaccordProject/accordkit-dart
+    path: packages/accordkit
 
   google_fonts: ^6.2.1
   flutter_riverpod: ^3.0.3


### PR DESCRIPTION
## Summary

- Move the Accord protocol SDK from the GitHub git dependency (`DaccordProject/accordkit-dart`) into the repo at `packages/accordkit`, so it can be maintained alongside the client.
- Switch `pubspec.yaml` from the `git:` source to `path: packages/accordkit`; `flutter pub get` re-resolved cleanly (reflected in `pubspec.lock`).
- Update `CLAUDE.md` references (networking note, `packages/` layout, setup snippet, "when in doubt" pointer) to reflect the in-tree location.

## Why

We're consolidating maintenance of the SDK into this repo. The upstream `accordkit-dart` repo has been **archived** (read-only); this tree is now canonical.

## Notes for reviewer

- The SDK source was vendored as a plain copy (no `.git`), matching the existing `packages/livekit_client` and `packages/markdown_viewer` pattern — copied at upstream commit `7e05060`.
- Build artifacts (`.dart_tool`, `build`, `pubspec.lock`, IDE dirs) were excluded from the copy.
- Dependency resolution verified via `flutter pub get`; a full `flutter analyze` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)