### PR TITLE
fix(messaging): render markdown and tappable mention/channel chips together

### DIFF
--- a/lib/features/messaging/components/box/accord_markdown_box.dart
+++ b/lib/features/messaging/components/box/accord_markdown_box.dart
@@ -1,5 +1,6 @@
 import 'package:bonfire/shared/utils/platform.dart';
 import 'package:bonfire/shared/utils/style/markdown/stylesheet.dart';
+import 'package:dart_markdown/dart_markdown.dart' as md;
 import 'package:flutter/material.dart';
 import 'package:flutter_prism/flutter_prism.dart';
 import 'package:markdown_viewer/markdown_viewer.dart';
@@ -7,13 +8,24 @@ import 'package:url_launcher/url_launcher.dart';
 
 /// Renders Accord message content as markdown, reusing Bonfire's
 /// `markdown_viewer` stack (stylesheet + Prism code highlighting + external
-/// link launching). It takes a plain content string; Accord carries mentions as
-/// message metadata (`mentions` / `mentionRoles` / `mentionEveryone`) rather
-/// than inline markup, so there is no `<@id>` / `<#id>` substitution to do here.
+/// link launching).
+///
+/// Callers that render inside a space (see `AccordMessageContent`) inject
+/// [syntaxExtensions] + [elementBuilders] for Accord's inline tokens — `@user`
+/// / `@role` / `@everyone` / `#channel` chips, custom `:emoji:`, `||spoiler||`
+/// and `__underline__` — so those render *alongside* standard markdown rather
+/// than replacing it. Callers without that context (e.g. embeds) pass nothing.
 class AccordMarkdownBox extends StatelessWidget {
-  const AccordMarkdownBox({super.key, required this.content});
+  const AccordMarkdownBox({
+    super.key,
+    required this.content,
+    this.syntaxExtensions = const [],
+    this.elementBuilders = const [],
+  });
 
   final String content;
+  final List<md.Syntax> syntaxExtensions;
+  final List<MarkdownElementBuilder> elementBuilders;
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +38,8 @@ class AccordMarkdownBox extends StatelessWidget {
       enableImageSize: false,
       selectable: shouldUseDesktopLayout(context),
       enableKbd: false,
+      syntaxExtensions: syntaxExtensions,
+      elementBuilders: elementBuilders,
       styleSheet: getMarkdownStyleSheet(context),
       highlightBuilder: (text, language, infoString) {
         final prism = Prism(

--- a/lib/features/messaging/components/box/accord_message_content.dart
+++ b/lib/features/messaging/components/box/accord_message_content.dart
@@ -2,408 +2,144 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
+import 'package:bonfire/features/channels/controllers/open_tabs.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/models/open_tab.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
-import 'package:bonfire/features/member/utils/member_display.dart';
+import 'package:bonfire/features/member/views/accord_member_popout.dart';
 import 'package:bonfire/features/messaging/components/box/accord_markdown_box.dart';
+import 'package:bonfire/features/messaging/components/box/accord_message_markup.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
-import 'package:bonfire/theme/theme.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Renders message content with `||spoiler||` reveal-on-tap markup and inline
-/// chips for `@user`, `@role`, `@everyone`/`@here`, and `#channel` references.
+/// Renders Accord message content as markdown, with inline chips for `@user`,
+/// `@role`, `@everyone`/`@here`, and `#channel` references, custom `:emoji:`,
+/// `||spoiler||` reveals, and `__underline__`.
 ///
-/// When the content has no spoilers and no chip-eligible references it defers
-/// to [AccordMarkdownBox] so the full markdown stack (bold/italic/code/links)
-/// is preserved. When either is present it falls back to an inline span
-/// renderer: plain text segments are rendered verbatim, spoilers as tappable
-/// reveal boxes, and mentions/channels as styled chips. (Markdown formatting
-/// inside a chip-containing message is not applied — matching the existing
-/// spoiler behaviour, and the reference client which renders these as inline
-/// pills, not formatted markup.)
+/// All of these are layered onto the standard markdown stack ([AccordMarkdownBox])
+/// as syntax extensions, so a single message renders markdown *and* Accord
+/// tokens together. Mention/channel chips are tappable: a user mention opens the
+/// member popout, a channel mention opens (or focuses) that channel's tab.
 ///
-/// Pass [spaceId] when rendering inside a space so user/role/channel handles
-/// resolve against the space's caches; without it, only `@everyone`/`@here`
-/// chip up (suitable for DMs).
+/// Pass [spaceId] when rendering inside a space so handles resolve against the
+/// space's caches and taps can navigate; without it (DMs) only the
+/// protocol-agnostic tokens (`@everyone`/`@here`, spoiler, underline, markdown)
+/// apply.
 class AccordMessageContent extends ConsumerWidget {
   const AccordMessageContent({super.key, required this.content, this.spaceId});
 
   final String content;
   final String? spaceId;
 
-  static final _spoiler = RegExp(r'\|\|(.+?)\|\|', dotAll: true);
-
-  /// Matches `@everyone`, `@here`, `@<word>`, or `#<word-or-hyphen>`. The
-  /// capture groups distinguish the kind, and `\B@` would over-match inside
-  /// words like `email@host`, so we require the previous character (if any) to
-  /// be a non-word char via a manual check at match time.
-  static final _chip = RegExp(r'@(everyone|here)\b|@(\w+)|#([A-Za-z0-9_\-]+)');
-
-  /// Daccord underline: `__text__` (the reference maps this to `[u]…[/u]`,
-  /// unlike standard markdown which treats `__` as bold). Non-greedy so the
-  /// shortest run wins; requires at least one char between the delimiters.
-  static final _underline = RegExp(r'__(.+?)__', dotAll: true);
-
-  /// A custom-emoji shortcode `:name:` (matches the reference's
-  /// `:([a-z0-9_]+):`, case-insensitively).
-  static final _emoji = RegExp(r':([A-Za-z0-9_]+):');
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final members = spaceId == null
-        ? null
-        : ref.watch(accordMembersControllerProvider(spaceId!));
-    final space = spaceId == null
-        ? null
-        : ref.watch(
-            spacesControllerProvider.select(
-              (s) => s?.firstWhereOrNull((sp) => sp.id == spaceId),
-            ),
-          );
-    final channels = spaceId == null
-        ? null
-        : ref.watch(accordChannelsControllerProvider(spaceId!));
-    final roles = space?.roles ?? const <AccordRole>[];
     final cdnUrl = ref.watch(
       accordAuthProvider.select(
         (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
       ),
     );
 
-    // Custom space emoji, keyed by lowercase name for `:name:` resolution.
-    final emojiList = spaceId == null
-        ? null
-        : ref.watch(accordEmojisControllerProvider(spaceId!));
+    final id = spaceId;
+    if (id == null) {
+      // DM / no-space context: still resolve broadcasts, spoilers, underline,
+      // and markdown — just nothing that needs space caches or navigation.
+      final markup = buildAccordMarkup(AccordMarkupContext(cdnUrl: cdnUrl));
+      return AccordMarkdownBox(
+        content: content,
+        syntaxExtensions: markup.syntaxes,
+        elementBuilders: markup.builders,
+      );
+    }
+
+    final members = ref.watch(accordMembersControllerProvider(id));
+    final space = ref.watch(
+      spacesControllerProvider.select(
+        (s) => s?.firstWhereOrNull((sp) => sp.id == id),
+      ),
+    );
+    final channels = ref.watch(accordChannelsControllerProvider(id));
+    final emojiList = ref.watch(accordEmojisControllerProvider(id));
+
+    final userByHandle = <String, AccordMember>{};
+    if (members != null) {
+      for (final member in members.values) {
+        final username = member.user?.username;
+        if (username != null && username.isNotEmpty) {
+          userByHandle.putIfAbsent(username.toLowerCase(), () => member);
+        }
+        final display = member.user?.displayName;
+        if (display != null && display.isNotEmpty) {
+          userByHandle.putIfAbsent(display.toLowerCase(), () => member);
+        }
+      }
+    }
+
+    final roleByName = <String, AccordRole>{
+      for (final role in (space?.roles ?? const <AccordRole>[]))
+        if (role.mentionable && role.name.isNotEmpty)
+          role.name.toLowerCase(): role,
+    };
+
+    final channelByName = <String, AccordChannel>{};
+    for (final channel in (channels ?? const <AccordChannel>[])) {
+      final name = channel.name;
+      if (name != null && name.isNotEmpty && channel.type != 'category') {
+        channelByName.putIfAbsent(name.toLowerCase(), () => channel);
+      }
+    }
+
     final emojiByName = <String, AccordEmoji>{
       for (final e in (emojiList ?? const <AccordEmoji>[]))
         if (e.name.isNotEmpty) e.name.toLowerCase(): e,
     };
 
-    final hasSpoiler = content.contains('||') && _spoiler.hasMatch(content);
-    final hasChip = _chip.hasMatch(content);
-    final hasUnderline = _underline.hasMatch(content);
-    final hasEmoji =
-        emojiByName.isNotEmpty &&
-        _emoji
-            .allMatches(content)
-            .any((m) => emojiByName.containsKey(m.group(1)!.toLowerCase()));
-    // Nothing custom to render → defer to the full markdown stack.
-    if (!hasSpoiler && !hasChip && !hasUnderline && !hasEmoji) {
-      return AccordMarkdownBox(content: content);
-    }
-
-    final baseStyle = Theme.of(context).textTheme.bodyLarge;
-    final spans = <InlineSpan>[];
-
-    // First split by spoiler matches so the other inline handlers run only over
-    // plain segments — content inside spoilers stays opaque under the reveal box.
-    int cursor = 0;
-    for (final spoiler in _spoiler.allMatches(content)) {
-      if (spoiler.start > cursor) {
-        _appendInline(
-          context: context,
-          text: content.substring(cursor, spoiler.start),
-          baseStyle: baseStyle,
-          spans: spans,
-          members: members,
-          roles: roles,
-          channels: channels,
-          emojiByName: emojiByName,
-          cdnUrl: cdnUrl,
-        );
-      }
-      spans.add(
-        WidgetSpan(
-          alignment: PlaceholderAlignment.middle,
-          child: _Spoiler(text: spoiler.group(1) ?? '', style: baseStyle),
-        ),
-      );
-      cursor = spoiler.end;
-    }
-    if (cursor < content.length) {
-      _appendInline(
-        context: context,
-        text: content.substring(cursor),
-        baseStyle: baseStyle,
-        spans: spans,
-        members: members,
-        roles: roles,
-        channels: channels,
+    final markup = buildAccordMarkup(
+      AccordMarkupContext(
+        userByHandle: userByHandle,
+        roleByName: roleByName,
+        channelByName: channelByName,
         emojiByName: emojiByName,
         cdnUrl: cdnUrl,
-      );
-    }
-    return Text.rich(TextSpan(children: spans));
+        onTapUser: (userId) =>
+            showAccordMemberPopout(context, spaceId: id, userId: userId),
+        onTapChannel: (channelId) => _openChannel(ref, id, channelId),
+      ),
+    );
+
+    return AccordMarkdownBox(
+      content: content,
+      syntaxExtensions: markup.syntaxes,
+      elementBuilders: markup.builders,
+    );
   }
 
-  /// Appends [text] to [spans], substituting inline tokens — custom `:emoji:`,
-  /// `__underline__`, and `@user`/`@role`/`#channel` chips — with rich spans.
-  /// A forward scan picks the matching token at each position (emoji, then
-  /// underline, then chip); anything else falls through as plain text. Chips
-  /// only render when they resolve to a real member/role/channel (or are
-  /// `@everyone`/`@here`); `:emoji:` only when it resolves to a space emoji.
-  void _appendInline({
-    required BuildContext context,
-    required String text,
-    required TextStyle? baseStyle,
-    required List<InlineSpan> spans,
-    required Map<String, AccordMember>? members,
-    required List<AccordRole> roles,
-    required List<AccordChannel>? channels,
-    required Map<String, AccordEmoji> emojiByName,
-    required String? cdnUrl,
-  }) {
-    int cursor = 0;
-    void flushPlain(int upTo) {
-      if (upTo > cursor) {
-        spans.add(
-          TextSpan(text: text.substring(cursor, upTo), style: baseStyle),
-        );
-      }
-    }
-
-    var pos = 0;
-    while (pos < text.length) {
-      // Custom emoji `:name:` (only when it resolves to a space emoji).
-      final emojiM = _emoji.matchAsPrefix(text, pos);
-      if (emojiM != null) {
-        final emoji = emojiByName[emojiM.group(1)!.toLowerCase()];
-        if (emoji != null) {
-          flushPlain(pos);
-          final url = _emojiImageUrl(emoji, cdnUrl);
-          spans.add(
-            WidgetSpan(
-              alignment: PlaceholderAlignment.middle,
-              child: _EmojiImage(url: url, name: emojiM.group(1)!),
-            ),
-          );
-          pos = emojiM.end;
-          cursor = pos;
-          continue;
-        }
-      }
-
-      // Daccord underline `__text__`.
-      final underlineM = _underline.matchAsPrefix(text, pos);
-      if (underlineM != null) {
-        flushPlain(pos);
-        spans.add(
-          TextSpan(
-            text: underlineM.group(1),
-            style: (baseStyle ?? const TextStyle()).copyWith(
-              decoration: TextDecoration.underline,
-            ),
+  /// Opens (or switches to) the tab for [channelId] on the active server,
+  /// mirroring the sidebar's channel selection. The NSFW gate and voice-join
+  /// behaviour stay with the message pane / channel list; a mention tap just
+  /// surfaces the channel.
+  void _openChannel(WidgetRef ref, String spaceId, String channelId) {
+    final activeKey = ref.read(connectionsControllerProvider).activeKey;
+    if (activeKey == null) return;
+    final channel = ref
+        .read(accordChannelsControllerProvider(spaceId))
+        ?.firstWhereOrNull((c) => c.id == channelId);
+    ref.read(openTabsControllerProvider.notifier).open(
+          OpenTab(
+            channelId: channelId,
+            spaceId: spaceId,
+            serverKey: activeKey,
+            name: channel?.name ?? channelId,
           ),
         );
-        pos = underlineM.end;
-        cursor = pos;
-        continue;
-      }
-
-      // Mention / channel chip.
-      final chipM = _chip.matchAsPrefix(text, pos) as RegExpMatch?;
-      if (chipM != null) {
-        final atBoundary = pos == 0 || !_isWordChar(text[pos - 1]);
-        final chip = atBoundary
-            ? _resolveChip(chipM, members, roles, channels)
-            : null;
-        if (chip != null) {
-          flushPlain(pos);
-          spans.add(
-            WidgetSpan(
-              alignment: PlaceholderAlignment.middle,
-              child: _Chip(label: chip.label, color: chip.color),
-            ),
-          );
-          pos = chipM.end;
-          cursor = pos;
-          continue;
-        }
-      }
-
-      pos++;
-    }
-    flushPlain(text.length);
-  }
-
-  /// Resolves [emoji] to an absolute image URL (mirrors the emoji picker):
-  /// an explicit `imageUrl` wins, else the CDN path by id. Null when neither.
-  String? _emojiImageUrl(AccordEmoji emoji, String? cdnUrl) {
-    if (emoji.imageUrl.isNotEmpty) {
-      return AccordCDN.resolvePath(emoji.imageUrl, cdnUrl: cdnUrl ?? '');
-    }
-    final id = emoji.id;
-    if (id == null) return null;
-    return AccordCDN.emoji(
-      id,
-      format: emoji.animated ? 'gif' : 'png',
-      cdnUrl: cdnUrl ?? '',
-    );
-  }
-
-  _ChipData? _resolveChip(
-    RegExpMatch match,
-    Map<String, AccordMember>? members,
-    List<AccordRole> roles,
-    List<AccordChannel>? channels,
-  ) {
-    final broadcast = match.group(1);
-    if (broadcast != null) {
-      // `@everyone`/`@here`: always chip up.
-      return _ChipData(label: '@$broadcast', color: _broadcastColor);
-    }
-    final userHandle = match.group(2);
-    if (userHandle != null) {
-      final lower = userHandle.toLowerCase();
-      // Try role first (more specific) then member username/display.
-      final role = roles.firstWhereOrNull(
-        (r) => r.mentionable && r.name.toLowerCase() == lower,
-      );
-      if (role != null) {
-        return _ChipData(
-          label: '@${role.name}',
-          color: accordRoleColor(role.color) ?? _mentionColor,
+    ref.read(readStateControllerProvider.notifier).markRead(channelId);
+    ref.read(settingsControllerProvider.notifier).setLastSelection(
+          spaceId,
+          channelId,
         );
-      }
-      if (members != null) {
-        final member = members.values.firstWhereOrNull((m) {
-          final u = m.user?.username;
-          if (u != null && u.toLowerCase() == lower) return true;
-          final d = m.user?.displayName;
-          return d != null && d.toLowerCase() == lower;
-        });
-        if (member != null) {
-          final name = accordMemberName(member, fallback: userHandle);
-          return _ChipData(label: '@$name', color: _mentionColor);
-        }
-      }
-      return null;
-    }
-    final channelName = match.group(3);
-    if (channelName != null && channels != null) {
-      final lower = channelName.toLowerCase();
-      final channel = channels.firstWhereOrNull((c) {
-        final name = c.name;
-        return name != null &&
-            name.toLowerCase() == lower &&
-            c.type != 'category';
-      });
-      if (channel != null) {
-        return _ChipData(label: '#${channel.name}', color: _mentionColor);
-      }
-    }
-    return null;
-  }
-
-  static bool _isWordChar(String ch) {
-    if (ch.isEmpty) return false;
-    final c = ch.codeUnitAt(0);
-    if (c >= 0x30 && c <= 0x39) return true;
-    if (c >= 0x41 && c <= 0x5A) return true;
-    if (c >= 0x61 && c <= 0x7A) return true;
-    if (c == 0x5F) return true;
-    return c > 0x7F;
-  }
-
-  static const _mentionColor = Color(0xFF5865F2);
-  static const _broadcastColor = Color(0xFFFAA61A);
-}
-
-class _ChipData {
-  const _ChipData({required this.label, required this.color});
-  final String label;
-  final Color color;
-}
-
-/// An inline custom-emoji image (~20px). Falls back to the literal `:name:`
-/// text when there's no URL or the image fails to load.
-class _EmojiImage extends StatelessWidget {
-  const _EmojiImage({required this.url, required this.name});
-
-  final String? url;
-  final String name;
-
-  @override
-  Widget build(BuildContext context) {
-    if (url == null || url!.isEmpty) {
-      return Text(':$name:', style: Theme.of(context).textTheme.bodyLarge);
-    }
-    return Tooltip(
-      message: ':$name:',
-      child: CachedNetworkImage(
-        imageUrl: url!,
-        width: 20,
-        height: 20,
-        fit: BoxFit.contain,
-        errorWidget: (context, _, _) =>
-            Text(':$name:', style: Theme.of(context).textTheme.bodyLarge),
-      ),
-    );
-  }
-}
-
-class _Chip extends StatelessWidget {
-  const _Chip({required this.label, required this.color});
-
-  final String label;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.18),
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-          color: color,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-class _Spoiler extends StatefulWidget {
-  const _Spoiler({required this.text, this.style});
-
-  final String text;
-  final TextStyle? style;
-
-  @override
-  State<_Spoiler> createState() => _SpoilerState();
-}
-
-class _SpoilerState extends State<_Spoiler> {
-  bool _revealed = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    return GestureDetector(
-      onTap: _revealed ? null : () => setState(() => _revealed = true),
-      child: MouseRegion(
-        cursor: _revealed ? MouseCursor.defer : SystemMouseCursors.click,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          decoration: BoxDecoration(
-            color: _revealed ? Colors.transparent : colors.background,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: Text(
-            widget.text,
-            style: (widget.style ?? const TextStyle()).copyWith(
-              color: _revealed ? null : Colors.transparent,
-            ),
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/features/messaging/components/box/accord_message_markup.dart
+++ b/lib/features/messaging/components/box/accord_message_markup.dart
@@ -1,0 +1,464 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/member/utils/member_display.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:dart_markdown/dart_markdown.dart' as md;
+import 'package:flutter/material.dart';
+import 'package:markdown_viewer/markdown_viewer.dart';
+
+/// Resolved lookup tables + tap callbacks for rendering Accord's inline tokens
+/// (`@user` / `@role` / `@everyone` / `#channel` chips, custom `:emoji:`,
+/// `||spoiler||`, `__underline__`) as markdown syntax extensions.
+///
+/// All maps are keyed by the **lowercased** handle/name so resolution is
+/// case-insensitive. Anything not present here simply renders as plain text —
+/// an unresolved `#channel` or `@user` is left verbatim rather than chipped.
+/// Pass empty maps (the default) in contexts without a space (e.g. DMs); the
+/// protocol-agnostic tokens (`@everyone`/`@here`, spoiler, underline, markdown)
+/// still apply.
+class AccordMarkupContext {
+  const AccordMarkupContext({
+    this.userByHandle = const {},
+    this.roleByName = const {},
+    this.channelByName = const {},
+    this.emojiByName = const {},
+    this.cdnUrl,
+    this.onTapUser,
+    this.onTapChannel,
+  });
+
+  final Map<String, AccordMember> userByHandle;
+  final Map<String, AccordRole> roleByName;
+  final Map<String, AccordChannel> channelByName;
+  final Map<String, AccordEmoji> emojiByName;
+  final String? cdnUrl;
+  final void Function(String userId)? onTapUser;
+  final void Function(String channelId)? onTapChannel;
+}
+
+/// Builds the syntax extensions + element builders that teach
+/// [AccordMarkdownBox]'s `markdown_viewer` stack to render Accord's inline
+/// tokens *alongside* standard markdown (rather than replacing it).
+///
+/// Custom inline syntaxes are evaluated before the built-in emphasis syntaxes,
+/// so `__text__` becomes an underline (matching the reference client) instead
+/// of bold, and `:emoji:` / `@mention` / `#channel` chip up when they resolve.
+({List<md.Syntax> syntaxes, List<MarkdownElementBuilder> builders})
+buildAccordMarkup(AccordMarkupContext ctx) {
+  return (
+    syntaxes: <md.Syntax>[
+      _SpoilerSyntax(),
+      _UnderlineSyntax(),
+      _EmojiSyntax(ctx),
+      _MentionSyntax(ctx),
+      _ChannelSyntax(ctx),
+    ],
+    builders: <MarkdownElementBuilder>[
+      _SpoilerBuilder(),
+      _UnderlineBuilder(),
+      _EmojiBuilder(),
+      _MentionBuilder(ctx.onTapUser),
+      _ChannelBuilder(ctx.onTapChannel),
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Syntaxes
+// ---------------------------------------------------------------------------
+
+/// `||text||` → an `accordSpoiler` element carrying the hidden text.
+class _SpoilerSyntax extends md.InlineSyntax {
+  _SpoilerSyntax() : super(RegExp(r'\|\|(.+?)\|\|', dotAll: true));
+
+  @override
+  md.InlineObject? parse(md.InlineParser parser, Match match) {
+    final markers = parser.consumeBy(match[0]!.length);
+    return md.InlineElement(
+      'accordSpoiler',
+      markers: markers,
+      attributes: {'text': match[1] ?? ''},
+      start: markers.first.start,
+      end: markers.last.end,
+    );
+  }
+}
+
+/// `__text__` → an `accordUnderline` element. Unlike standard markdown (which
+/// treats `__` as bold) the reference client maps this to an underline. The
+/// inner text is preserved as a child [md.Text] so it renders with the parent
+/// style merged.
+class _UnderlineSyntax extends md.InlineSyntax {
+  _UnderlineSyntax() : super(RegExp(r'__(.+?)__', dotAll: true));
+
+  @override
+  md.InlineObject? parse(md.InlineParser parser, Match match) {
+    final start = parser.position;
+    final full = match[0]!;
+    final innerSpans = parser.subspan(start + 2, start + full.length - 2);
+    final markers = parser.consumeBy(full.length);
+    return md.InlineElement(
+      'accordUnderline',
+      markers: markers,
+      children: innerSpans
+          .map<md.InlineObject>((span) => md.Text.fromSpan(span))
+          .toList(),
+      start: markers.first.start,
+      end: markers.last.end,
+    );
+  }
+}
+
+/// `:name:` → an `accordEmoji` element, but only when the name resolves to a
+/// space emoji. Otherwise it regrets the match (returns `null` without
+/// consuming) so the literal `:name:` is left for other syntaxes / plain text.
+class _EmojiSyntax extends md.InlineSyntax {
+  _EmojiSyntax(this.ctx) : super(RegExp(r':([A-Za-z0-9_]+):'));
+
+  final AccordMarkupContext ctx;
+
+  @override
+  md.InlineObject? parse(md.InlineParser parser, Match match) {
+    final emoji = ctx.emojiByName[match[1]!.toLowerCase()];
+    if (emoji == null) return null;
+    final url = _emojiUrl(emoji, ctx.cdnUrl);
+    final markers = parser.consumeBy(match[0]!.length);
+    return md.InlineElement(
+      'accordEmoji',
+      markers: markers,
+      attributes: {'name': match[1]!, if (url != null) 'url': url},
+      start: markers.first.start,
+      end: markers.last.end,
+    );
+  }
+}
+
+/// `@everyone` / `@here` / `@handle` → an `accordMention` chip. `@everyone` and
+/// `@here` always chip up; a `@handle` chips only when it resolves to a
+/// mentionable role or a member (else it regrets). A leading word character
+/// (e.g. the `@` in `email@host`) suppresses the match.
+class _MentionSyntax extends md.InlineSyntax {
+  _MentionSyntax(this.ctx) : super(RegExp(r'@(everyone|here)\b|@(\w+)'));
+
+  final AccordMarkupContext ctx;
+
+  @override
+  md.InlineObject? parse(md.InlineParser parser, Match match) {
+    final pos = parser.position;
+    if (pos > 0 && _isWordCharCode(parser.charAt(pos - 1))) return null;
+
+    String label;
+    Color color;
+    String? userId;
+
+    final broadcast = match[1];
+    if (broadcast != null) {
+      label = '@$broadcast';
+      color = _broadcastColor;
+    } else {
+      final handle = match[2]!;
+      final lower = handle.toLowerCase();
+      final role = ctx.roleByName[lower];
+      if (role != null) {
+        label = '@${role.name}';
+        color = accordRoleColor(role.color) ?? _mentionColor;
+      } else {
+        final member = ctx.userByHandle[lower];
+        if (member == null) return null;
+        label = '@${_memberLabel(member, handle)}';
+        color = _mentionColor;
+        userId = member.user?.id;
+      }
+    }
+
+    final markers = parser.consumeBy(match[0]!.length);
+    return md.InlineElement(
+      'accordMention',
+      markers: markers,
+      attributes: {
+        'label': label,
+        'color': _encodeColor(color),
+        if (userId != null) 'userId': userId,
+      },
+      start: markers.first.start,
+      end: markers.last.end,
+    );
+  }
+}
+
+/// `#name` → an `accordChannel` chip, only when it resolves to a real channel
+/// (else it regrets). A leading word character suppresses the match.
+class _ChannelSyntax extends md.InlineSyntax {
+  _ChannelSyntax(this.ctx) : super(RegExp(r'#([A-Za-z0-9_\-]+)'));
+
+  final AccordMarkupContext ctx;
+
+  @override
+  md.InlineObject? parse(md.InlineParser parser, Match match) {
+    final pos = parser.position;
+    if (pos > 0 && _isWordCharCode(parser.charAt(pos - 1))) return null;
+
+    final channel = ctx.channelByName[match[1]!.toLowerCase()];
+    if (channel == null) return null;
+
+    final markers = parser.consumeBy(match[0]!.length);
+    return md.InlineElement(
+      'accordChannel',
+      markers: markers,
+      attributes: {
+        'label': '#${channel.name}',
+        'color': _encodeColor(_mentionColor),
+        'channelId': channel.id,
+      },
+      start: markers.first.start,
+      end: markers.last.end,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+class _MentionBuilder extends MarkdownElementBuilder {
+  _MentionBuilder(this.onTapUser);
+
+  final void Function(String userId)? onTapUser;
+
+  @override
+  List<String> get matchTypes => const ['accordMention'];
+
+  @override
+  bool isBlock(element) => false;
+
+  @override
+  Widget? buildWidget(element, parent) {
+    final a = element.attributes;
+    final userId = a['userId'];
+    final tap = (userId != null && onTapUser != null)
+        ? () => onTapUser!(userId)
+        : null;
+    return _inlineWidget(
+      _Chip(label: a['label'] ?? '', color: _decodeColor(a['color']), onTap: tap),
+    );
+  }
+}
+
+class _ChannelBuilder extends MarkdownElementBuilder {
+  _ChannelBuilder(this.onTapChannel);
+
+  final void Function(String channelId)? onTapChannel;
+
+  @override
+  List<String> get matchTypes => const ['accordChannel'];
+
+  @override
+  bool isBlock(element) => false;
+
+  @override
+  Widget? buildWidget(element, parent) {
+    final a = element.attributes;
+    final channelId = a['channelId'];
+    final tap = (channelId != null && onTapChannel != null)
+        ? () => onTapChannel!(channelId)
+        : null;
+    return _inlineWidget(
+      _Chip(label: a['label'] ?? '', color: _decodeColor(a['color']), onTap: tap),
+    );
+  }
+}
+
+class _EmojiBuilder extends MarkdownElementBuilder {
+  @override
+  List<String> get matchTypes => const ['accordEmoji'];
+
+  @override
+  bool isBlock(element) => false;
+
+  @override
+  Widget? buildWidget(element, parent) {
+    final a = element.attributes;
+    return _inlineWidget(_EmojiImage(url: a['url'], name: a['name'] ?? ''));
+  }
+}
+
+class _SpoilerBuilder extends MarkdownElementBuilder {
+  @override
+  List<String> get matchTypes => const ['accordSpoiler'];
+
+  @override
+  bool isBlock(element) => false;
+
+  @override
+  Widget? buildWidget(element, parent) {
+    return _inlineWidget(_Spoiler(text: element.attributes['text'] ?? ''));
+  }
+}
+
+/// Underline relies on the default (children-merging) [buildWidget]; supplying
+/// a [textStyle] with an underline decoration is enough.
+class _UnderlineBuilder extends MarkdownElementBuilder {
+  _UnderlineBuilder()
+      : super(textStyle: const TextStyle(decoration: TextDecoration.underline));
+
+  @override
+  List<String> get matchTypes => const ['accordUnderline'];
+}
+
+// ---------------------------------------------------------------------------
+// Widgets
+// ---------------------------------------------------------------------------
+
+/// Wraps an arbitrary [child] widget into a [RichText] whose root span is a
+/// [WidgetSpan]. The renderer only permits `RichText`/`Text`/`DefaultTextStyle`
+/// /`Consumer` from an inline `buildWidget`; returning the widget *inside* a
+/// `RichText` (with a `WidgetSpan` root) keeps it a discrete inline item — the
+/// merge pass detects the `WidgetSpan` and lays these out in a `Wrap` rather
+/// than trying to cast it into a `List<TextSpan>` (which would throw).
+Widget _inlineWidget(Widget child) => RichText(
+      text: WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: child,
+      ),
+    );
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label, required this.color, this.onTap});
+
+  final String label;
+  final Color color;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+      ),
+    );
+    if (onTap == null) return chip;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(onTap: onTap, child: chip),
+    );
+  }
+}
+
+/// An inline custom-emoji image (~20px). Falls back to the literal `:name:`
+/// text when there's no URL or the image fails to load.
+class _EmojiImage extends StatelessWidget {
+  const _EmojiImage({required this.url, required this.name});
+
+  final String? url;
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    if (url == null || url!.isEmpty) {
+      return Text(':$name:', style: Theme.of(context).textTheme.bodyLarge);
+    }
+    return Tooltip(
+      message: ':$name:',
+      child: CachedNetworkImage(
+        imageUrl: url!,
+        width: 20,
+        height: 20,
+        fit: BoxFit.contain,
+        errorWidget: (context, _, _) =>
+            Text(':$name:', style: Theme.of(context).textTheme.bodyLarge),
+      ),
+    );
+  }
+}
+
+class _Spoiler extends StatefulWidget {
+  const _Spoiler({required this.text});
+
+  final String text;
+
+  @override
+  State<_Spoiler> createState() => _SpoilerState();
+}
+
+class _SpoilerState extends State<_Spoiler> {
+  bool _revealed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    final style = Theme.of(context).textTheme.bodyLarge;
+    return GestureDetector(
+      onTap: _revealed ? null : () => setState(() => _revealed = true),
+      child: MouseRegion(
+        cursor: _revealed ? MouseCursor.defer : SystemMouseCursors.click,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          decoration: BoxDecoration(
+            color: _revealed ? Colors.transparent : colors.background,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            widget.text,
+            style: (style ?? const TextStyle()).copyWith(
+              color: _revealed ? null : Colors.transparent,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _mentionColor = Color(0xFF5865F2);
+const _broadcastColor = Color(0xFFFAA61A);
+
+String _encodeColor(Color color) => color.toARGB32().toString();
+
+Color _decodeColor(String? encoded) {
+  if (encoded == null) return _mentionColor;
+  return Color(int.tryParse(encoded) ?? _mentionColor.toARGB32());
+}
+
+String _memberLabel(AccordMember member, String fallback) {
+  final display = member.user?.displayName;
+  if (display != null && display.isNotEmpty) return display;
+  final username = member.user?.username;
+  if (username != null && username.isNotEmpty) return username;
+  return fallback;
+}
+
+/// Resolves [emoji] to an absolute image URL (mirrors the emoji picker): an
+/// explicit `imageUrl` wins, else the CDN path by id. Null when neither.
+String? _emojiUrl(AccordEmoji emoji, String? cdnUrl) {
+  if (emoji.imageUrl.isNotEmpty) {
+    return AccordCDN.resolvePath(emoji.imageUrl, cdnUrl: cdnUrl ?? '');
+  }
+  final id = emoji.id;
+  if (id == null) return null;
+  return AccordCDN.emoji(
+    id,
+    format: emoji.animated ? 'gif' : 'png',
+    cdnUrl: cdnUrl ?? '',
+  );
+}
+
+bool _isWordCharCode(int c) {
+  if (c >= 0x30 && c <= 0x39) return true; // 0-9
+  if (c >= 0x41 && c <= 0x5A) return true; // A-Z
+  if (c >= 0x61 && c <= 0x7A) return true; // a-z
+  if (c == 0x5F) return true; // _
+  return c > 0x7F; // non-ASCII (treat as word char)
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,10 +254,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -419,7 +419,7 @@ packages:
     source: hosted
     version: "4.6.1"
   dart_markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dart_markdown
       sha256: b9b7e13733dd418bc83e6f4e68d79caebab6cd3a8b301e91d1bfd6ef5ef8e993
@@ -986,18 +986,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -1069,10 +1069,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1623,7 +1623,7 @@ packages:
     source: hosted
     version: "0.10.13"
   source_span:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: source_span
       sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
@@ -1738,26 +1738,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   thumbhash:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,11 @@ dependencies:
   markdown_viewer:
     path: packages/markdown_viewer
 
+  # Promoted from transitive (pulled in by markdown_viewer) so message rendering
+  # can define custom inline markdown syntaxes for Accord mentions/channels/emoji.
+  dart_markdown: 3.1.7
+  source_span: ^1.10.1
+
   # Accord protocol SDK — the networking layer that replaced firebridge.
   accordkit:
     git:

--- a/test/features/messaging/accord_message_markup_test.dart
+++ b/test/features/messaging/accord_message_markup_test.dart
@@ -1,0 +1,101 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/components/box/accord_markdown_box.dart';
+import 'package:bonfire/features/messaging/components/box/accord_message_markup.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Joins the plain text of every [RichText] paragraph on screen (skipping the
+/// chip RichTexts, whose root span is a [WidgetSpan]).
+String _paragraphText(WidgetTester tester) {
+  final buffer = StringBuffer();
+  for (final element in find.byType(RichText).evaluate()) {
+    final span = (element.widget as RichText).text;
+    if (span is WidgetSpan) continue;
+    buffer.write(span.toPlainText());
+  }
+  return buffer.toString();
+}
+
+Widget _host(Widget child) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  testWidgets(
+    'renders markdown and a channel chip together; chip is tappable',
+    (tester) async {
+      String? tapped;
+      final markup = buildAccordMarkup(
+        AccordMarkupContext(
+          channelByName: {
+            'general': AccordChannel(id: 'c1', name: 'general', type: 'text'),
+          },
+          onTapChannel: (id) => tapped = id,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _host(
+          AccordMarkdownBox(
+            content: 'see **bold** in #general now',
+            syntaxExtensions: markup.syntaxes,
+            elementBuilders: markup.builders,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Markdown was applied (asterisks stripped), not shown verbatim.
+      final text = _paragraphText(tester);
+      expect(text, contains('bold'));
+      expect(text, isNot(contains('*')));
+
+      // The channel rendered as a chip pill, and tapping it fires the callback.
+      expect(find.text('#general'), findsOneWidget);
+      await tester.tap(find.text('#general'));
+      await tester.pump();
+      expect(tapped, 'c1');
+    },
+  );
+
+  testWidgets(
+    'chips @everyone but leaves email-like @ handles as plain text',
+    (tester) async {
+      final markup = buildAccordMarkup(const AccordMarkupContext());
+
+      await tester.pumpWidget(
+        _host(
+          AccordMarkdownBox(
+            content: 'mail me at email@host then ping @everyone',
+            syntaxExtensions: markup.syntaxes,
+            elementBuilders: markup.builders,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('@everyone'), findsOneWidget);
+      expect(_paragraphText(tester), contains('email@host'));
+    },
+  );
+
+  testWidgets('unresolved #channel stays plain text (no chip)', (tester) async {
+    final markup = buildAccordMarkup(const AccordMarkupContext());
+
+    await tester.pumpWidget(
+      _host(
+        AccordMarkdownBox(
+          content: 'look at #nowhere please',
+          syntaxExtensions: markup.syntaxes,
+          elementBuilders: markup.builders,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('#nowhere'), findsNothing);
+    expect(_paragraphText(tester), contains('#nowhere'));
+  });
+}


### PR DESCRIPTION
## Summary
- Message content previously fell back to an inline-span renderer whenever a chip-eligible token was present, which silently dropped **all markdown** (so `**bold**` showed literal asterisks) and rendered mention/channel pills that **weren't tappable**.
- Re-implements Accord's inline tokens (`@user`/`@role`/`@everyone`/`#channel` chips, custom `:emoji:`, `||spoiler||`, `__underline__`) as `markdown_viewer` syntax extensions + element builders, so they render *alongside* the standard markdown stack instead of replacing it.
- Mention/channel chips are now wired up: tapping a user mention opens the member popout, tapping a channel mention opens (or focuses) that channel's tab.

## Changes
- **`pubspec.yaml`** — promote `dart_markdown` + `source_span` from transitive to direct deps so message rendering can define custom inline syntaxes.
- **`accord_message_markup.dart`** (new) — `AccordMarkupContext` + `buildAccordMarkup()`: five inline syntaxes/builders plus the tappable chip / emoji-image / spoiler widgets. Unresolved `#channel` / `@handle` tokens (and email-like `email@host`) stay plain text.
- **`accord_markdown_box.dart`** — forward `syntaxExtensions` / `elementBuilders` through to `MarkdownViewer`.
- **`accord_message_content.dart`** — rewritten to *always* use the markdown box, resolving handles against the space's member/role/channel/emoji caches and wiring the tap callbacks.

## Notes
- Channel-mention taps open/focus the channel tab but intentionally skip the NSFW gate and voice auto-join (those stay with the sidebar / message pane to keep this change focused).

## Test plan
- [x] `flutter analyze --no-fatal-infos` — clean (only pre-existing infos in unrelated files)
- [x] `flutter test` — 132/132 pass, including 3 new widget tests in `test/features/messaging/accord_message_markup_test.dart`:
  - [x] markdown + a `#channel` chip render together; the chip is tappable
  - [x] `@everyone` chips while `email@host` stays plain text
  - [x] unresolved `#channel` stays plain text (no chip)
- [ ] Manual smoke test in the running app against a live Accord server (verified via widget tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)