### PR TITLE
feat(channels): inline sidebar drag-reorder & text-type switching

### DIFF
--- a/lib/features/channels/components/channel_management.dart
+++ b/lib/features/channels/components/channel_management.dart
@@ -17,6 +17,12 @@ const _channelTypes = <({String value, String label, IconData icon})>[
   (value: 'category', label: 'Category', icon: Icons.folder),
 ];
 
+/// Channel types whose stored messages and rendering are identical, so an
+/// existing channel may be switched between them retroactively without losing
+/// data. Mirrors accordserver's `is_non_destructive_type_change`; the type
+/// selector in edit mode is limited to this set.
+const _textLikeTypes = <String>{'text', 'announcement'};
+
 /// Slowmode (rate-limit per user) presets in seconds (0 = off). Mirrors the
 /// reference client's channel edit dialog.
 const _slowmodePresets = <({String label, int seconds})>[
@@ -172,6 +178,10 @@ class _ChannelEditorDialogState extends ConsumerState<_ChannelEditorDialog> {
       final data = <String, dynamic>{
         'name': name,
         'topic': topic.isEmpty ? null : topic,
+        if (_textLikeTypes.contains(widget.channel!.type) &&
+            _textLikeTypes.contains(_type) &&
+            _type != widget.channel!.type)
+          'type': _type,
         if (supportsModeration) 'nsfw': _nsfw,
         if (supportsModeration) 'rate_limit': _rateLimit,
       };
@@ -318,6 +328,39 @@ class _ChannelEditorDialogState extends ConsumerState<_ChannelEditorDialog> {
                   ),
                 if (_type != 'category' && categories.isNotEmpty)
                   const SizedBox(height: 12),
+              ],
+              // Edit mode: allow switching between non-destructive (text-like)
+              // types only. Voice/category/forum channels show no selector since
+              // no safe conversion exists.
+              if (_isEdit && _textLikeTypes.contains(widget.channel!.type)) ...[
+                DropdownButtonFormField<String>(
+                  initialValue:
+                      _textLikeTypes.contains(_type) ? _type : widget.channel!.type,
+                  decoration: const InputDecoration(
+                    labelText: 'Type',
+                    isDense: true,
+                    border: OutlineInputBorder(),
+                  ),
+                  items: [
+                    for (final t in _channelTypes)
+                      if (_textLikeTypes.contains(t.value))
+                        DropdownMenuItem(
+                          value: t.value,
+                          child: Row(
+                            children: [
+                              Icon(t.icon, size: 16, color: colors.dirtyWhite),
+                              const SizedBox(width: 8),
+                              Text(t.label),
+                            ],
+                          ),
+                        ),
+                  ],
+                  onChanged: _busy
+                      ? null
+                      : (v) => setState(
+                          () => _type = v ?? widget.channel!.type),
+                ),
+                const SizedBox(height: 12),
               ],
               if (_type != 'category')
                 TextField(

--- a/lib/features/channels/utils/channel_sort.dart
+++ b/lib/features/channels/utils/channel_sort.dart
@@ -1,0 +1,19 @@
+import 'package:accordkit/accordkit.dart';
+
+/// Reads [AccordChannel.position] as an int. Missing/non-numeric values → 0.
+int parseChannelPosition(AccordChannel c) {
+  final raw = c.position;
+  if (raw is int) return raw;
+  if (raw is num) return raw.toInt();
+  if (raw is String) return int.tryParse(raw) ?? 0;
+  return 0;
+}
+
+/// A stable change-detection key for a channel list based on (id, parentId, position).
+/// Sorting the parts ensures the signature is order-independent.
+String channelListSignature(List<AccordChannel> channels) {
+  final parts = [
+    for (final c in channels) '${c.id}:${c.parentId}:${parseChannelPosition(c)}',
+  ]..sort();
+  return parts.join(',');
+}

--- a/lib/features/spaces/views/accord_channel_reorder.dart
+++ b/lib/features/spaces/views/accord_channel_reorder.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/utils/channel_sort.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
@@ -54,21 +55,10 @@ class _ChannelReorderState extends ConsumerState<_ChannelReorder> {
     _items = _flatten(widget.channels);
   }
 
-  /// Builds the flat list shown in the reorderable view: each category
-  /// followed by its children, then uncategorized channels at the end (in a
-  /// synthetic "Uncategorized" group). Order within each group follows the
-  /// channel's current `position`.
-  /// AccordChannel.position is loosely-typed (`Object?`) so any sort/compare
-  /// goes through this helper. Treats missing/non-numeric values as 0 — the
-  /// reference client does the same.
-  static int _pos(AccordChannel c) {
-    final raw = c.position;
-    if (raw is int) return raw;
-    if (raw is num) return raw.toInt();
-    if (raw is String) return int.tryParse(raw) ?? 0;
-    return 0;
-  }
+  static int _pos(AccordChannel c) => parseChannelPosition(c);
 
+  /// Builds the flat list: each category followed by its children, then
+  /// uncategorized channels at the end. Order within each group follows `position`.
   static List<_Entry> _flatten(List<AccordChannel> channels) {
     final sorted = [...channels]..sort((a, b) => _pos(a).compareTo(_pos(b)));
     final categories = sorted.where((c) => c.type == 'category').toList();

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -11,6 +11,7 @@ import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/channels/controllers/open_tabs.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/channels/models/open_tab.dart';
+import 'package:bonfire/features/channels/utils/channel_sort.dart';
 import 'package:bonfire/features/developer/services/mcp_home_bridge.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';

--- a/lib/features/spaces/views/accord_home_channels.dart
+++ b/lib/features/spaces/views/accord_home_channels.dart
@@ -178,8 +178,6 @@ class _ChannelListState extends ConsumerState<_ChannelList> {
             child: channels == null
                 ? const Center(child: CircularProgressIndicator())
                 : (canManageChannels && id != null)
-                    // Managers get inline drag-and-drop: long-press a channel or
-                    // category to reorder it or move it between categories.
                     ? _ChannelDragList(
                         spaceId: id,
                         channels: channels,
@@ -619,13 +617,7 @@ class _MentionBadge extends StatelessWidget {
   }
 }
 
-/// The channel sidebar for users who can manage channels: a [ReorderableListView]
-/// that lets them long-press to drag channels and categories into a new order,
-/// or drop a channel under a different category. Mirrors the modal reorder
-/// dialog's persistence (per-bucket `position`, plus `parent_id` when a channel
-/// crosses a category boundary) but inline in the sidebar. Collapsed categories
-/// keep their (hidden) children adjacent in the working model so they stay
-/// correctly parented even though they aren't shown.
+/// Sidebar channel list with inline long-press drag-to-reorder for space managers.
 class _ChannelDragList extends ConsumerStatefulWidget {
   const _ChannelDragList({
     required this.spaceId,
@@ -651,6 +643,7 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
   late List<_DragEntry> _items;
   late String _signature;
   bool _persisting = false;
+  bool _pendingPersist = false;
 
   @override
   void initState() {
@@ -676,22 +669,10 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
     });
   }
 
-  /// Channel `position` is loosely typed (`Object?`); funnel every read through
-  /// here. Missing/non-numeric values sort as 0, matching the reorder dialog.
-  static int _pos(AccordChannel c) {
-    final raw = c.position;
-    if (raw is int) return raw;
-    if (raw is num) return raw.toInt();
-    if (raw is String) return int.tryParse(raw) ?? 0;
-    return 0;
-  }
+  static int _pos(AccordChannel c) => parseChannelPosition(c);
 
-  static String _signatureOf(List<AccordChannel> channels) {
-    final parts = [
-      for (final c in channels) '${c.id}:${c.parentId}:${_pos(c)}',
-    ]..sort();
-    return parts.join(',');
-  }
+  static String _signatureOf(List<AccordChannel> channels) =>
+      channelListSignature(channels);
 
   /// Categories (each followed by their children) then uncategorized channels,
   /// each group ordered by `position`. Children carry their parent's id.
@@ -722,15 +703,18 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
       .where((e) => e.isCategory || !widget.collapsed.contains(e.parentId))
       .toList();
 
-  void _recomputeParents() {
-    String? current;
+  void _recomputeParents(_DragEntry moved) {
+    if (moved.isCategory) return;
+    String? newParent;
     for (final e in _items) {
       if (e.isCategory) {
-        current = e.channel.id;
-      } else {
-        e.parentId = current;
+        newParent = e.channel.id;
+      } else if (identical(e, moved)) {
+        moved.parentId = newParent;
+        return;
       }
     }
+    moved.parentId = null;
   }
 
   // [newIndex] is already adjusted for the item removed at [oldIndex]
@@ -760,9 +744,17 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
       _items.removeWhere(block.contains);
       final insertAt = before == null ? _items.length : _items.indexOf(before);
       _items.insertAll(insertAt < 0 ? _items.length : insertAt, block);
-      _recomputeParents();
+      _recomputeParents(moved);
     });
-    _persist();
+    _schedulePersist();
+  }
+
+  void _schedulePersist() {
+    if (_persisting) {
+      _pendingPersist = true;
+    } else {
+      _persist();
+    }
   }
 
   /// Walks the new ordering and PATCHes any channel whose (parent, position)
@@ -812,7 +804,12 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
       }
     } finally {
       _persisting = false;
-      if (mounted) _resync();
+      if (_pendingPersist && mounted) {
+        _pendingPersist = false;
+        _persist();
+      } else if (mounted) {
+        _resync();
+      }
     }
   }
 
@@ -863,9 +860,7 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
   }
 }
 
-/// One row in the inline reorder model: a category header or a channel tile.
-/// [parentId] tracks the category a channel currently sits under (null when
-/// uncategorized); it is recomputed as items are dragged.
+/// One row in the drag model: a category header or a channel tile.
 class _DragEntry {
   _DragEntry.category(this.channel)
       : isCategory = true,
@@ -878,8 +873,7 @@ class _DragEntry {
   String? parentId;
 }
 
-/// A pending PATCH computed from a reorder: a channel's new [position] and,
-/// when it crossed a category boundary, its new [parentId].
+/// A pending PATCH from a reorder: channel's new position and optional new parent.
 class _DragUpdate {
   const _DragUpdate(
     this.channelId, {

--- a/lib/features/spaces/views/accord_home_channels.dart
+++ b/lib/features/spaces/views/accord_home_channels.dart
@@ -177,19 +177,30 @@ class _ChannelListState extends ConsumerState<_ChannelList> {
           Expanded(
             child: channels == null
                 ? const Center(child: CircularProgressIndicator())
-                : ListView(
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    children: _buildChannelEntries(
-                      context,
-                      spaceId: id,
-                      channels: channels,
-                      selectedChannelId: selectedChannelId,
-                      onSelect: onSelect,
-                      canManageChannels: canManageChannels,
-                      collapsed: collapsed,
-                      onToggleCollapsed: _toggleCollapsed,
-                    ),
-                  ),
+                : (canManageChannels && id != null)
+                    // Managers get inline drag-and-drop: long-press a channel or
+                    // category to reorder it or move it between categories.
+                    ? _ChannelDragList(
+                        spaceId: id,
+                        channels: channels,
+                        selectedChannelId: selectedChannelId,
+                        onSelect: onSelect,
+                        collapsed: collapsed,
+                        onToggleCollapsed: _toggleCollapsed,
+                      )
+                    : ListView(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        children: _buildChannelEntries(
+                          context,
+                          spaceId: id,
+                          channels: channels,
+                          selectedChannelId: selectedChannelId,
+                          onSelect: onSelect,
+                          canManageChannels: canManageChannels,
+                          collapsed: collapsed,
+                          onToggleCollapsed: _toggleCollapsed,
+                        ),
+                      ),
           ),
           VoiceBar(
             onTapStatus: () {
@@ -606,4 +617,279 @@ class _MentionBadge extends StatelessWidget {
       ),
     );
   }
+}
+
+/// The channel sidebar for users who can manage channels: a [ReorderableListView]
+/// that lets them long-press to drag channels and categories into a new order,
+/// or drop a channel under a different category. Mirrors the modal reorder
+/// dialog's persistence (per-bucket `position`, plus `parent_id` when a channel
+/// crosses a category boundary) but inline in the sidebar. Collapsed categories
+/// keep their (hidden) children adjacent in the working model so they stay
+/// correctly parented even though they aren't shown.
+class _ChannelDragList extends ConsumerStatefulWidget {
+  const _ChannelDragList({
+    required this.spaceId,
+    required this.channels,
+    required this.selectedChannelId,
+    required this.onSelect,
+    required this.collapsed,
+    required this.onToggleCollapsed,
+  });
+
+  final String spaceId;
+  final List<AccordChannel> channels;
+  final String? selectedChannelId;
+  final ValueChanged<String> onSelect;
+  final Set<String> collapsed;
+  final ValueChanged<String> onToggleCollapsed;
+
+  @override
+  ConsumerState<_ChannelDragList> createState() => _ChannelDragListState();
+}
+
+class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
+  late List<_DragEntry> _items;
+  late String _signature;
+  bool _persisting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _items = _flatten(widget.channels);
+    _signature = _signatureOf(widget.channels);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ChannelDragList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Ignore incoming list churn while our own optimistic PATCHes are landing;
+    // we reconcile once at the end of [_persist].
+    if (_persisting) return;
+    final sig = _signatureOf(widget.channels);
+    if (sig != _signature) _resync();
+  }
+
+  void _resync() {
+    setState(() {
+      _items = _flatten(widget.channels);
+      _signature = _signatureOf(widget.channels);
+    });
+  }
+
+  /// Channel `position` is loosely typed (`Object?`); funnel every read through
+  /// here. Missing/non-numeric values sort as 0, matching the reorder dialog.
+  static int _pos(AccordChannel c) {
+    final raw = c.position;
+    if (raw is int) return raw;
+    if (raw is num) return raw.toInt();
+    if (raw is String) return int.tryParse(raw) ?? 0;
+    return 0;
+  }
+
+  static String _signatureOf(List<AccordChannel> channels) {
+    final parts = [
+      for (final c in channels) '${c.id}:${c.parentId}:${_pos(c)}',
+    ]..sort();
+    return parts.join(',');
+  }
+
+  /// Categories (each followed by their children) then uncategorized channels,
+  /// each group ordered by `position`. Children carry their parent's id.
+  static List<_DragEntry> _flatten(List<AccordChannel> channels) {
+    final sorted = [...channels]..sort((a, b) => _pos(a).compareTo(_pos(b)));
+    final categories = sorted.where((c) => c.type == 'category').toList();
+    final leaves = sorted.where((c) => c.type != 'category').toList();
+    final byParent = <String?, List<AccordChannel>>{};
+    for (final c in leaves) {
+      byParent.putIfAbsent(c.parentId, () => []).add(c);
+    }
+    final out = <_DragEntry>[];
+    for (final c in byParent[null] ?? const <AccordChannel>[]) {
+      out.add(_DragEntry.channel(c, parentId: null));
+    }
+    for (final category in categories) {
+      out.add(_DragEntry.category(category));
+      for (final child in byParent[category.id] ?? const <AccordChannel>[]) {
+        out.add(_DragEntry.channel(child, parentId: category.id));
+      }
+    }
+    return out;
+  }
+
+  /// The items actually shown: every category, plus the children of categories
+  /// that aren't collapsed (uncategorized channels are always shown).
+  List<_DragEntry> get _visible => _items
+      .where((e) => e.isCategory || !widget.collapsed.contains(e.parentId))
+      .toList();
+
+  void _recomputeParents() {
+    String? current;
+    for (final e in _items) {
+      if (e.isCategory) {
+        current = e.channel.id;
+      } else {
+        e.parentId = current;
+      }
+    }
+  }
+
+  // [newIndex] is already adjusted for the item removed at [oldIndex]
+  // (ReorderableListView.onReorderItem semantics): it's the target index within
+  // the post-removal list, so no manual decrement is needed.
+  void _onReorder(int oldIndex, int newIndex) {
+    final visible = _visible;
+    final moved = visible[oldIndex];
+    final newVisible = [...visible]..removeAt(oldIndex);
+    final _DragEntry? before =
+        newIndex < newVisible.length ? newVisible[newIndex] : null;
+
+    // A dragged category carries its contiguous children with it.
+    final List<_DragEntry> block;
+    if (moved.isCategory) {
+      final start = _items.indexOf(moved);
+      var end = start + 1;
+      while (end < _items.length && !_items[end].isCategory) {
+        end++;
+      }
+      block = _items.sublist(start, end);
+    } else {
+      block = [moved];
+    }
+
+    setState(() {
+      _items.removeWhere(block.contains);
+      final insertAt = before == null ? _items.length : _items.indexOf(before);
+      _items.insertAll(insertAt < 0 ? _items.length : insertAt, block);
+      _recomputeParents();
+    });
+    _persist();
+  }
+
+  /// Walks the new ordering and PATCHes any channel whose (parent, position)
+  /// changed. Positions count within each bucket (categories share one bucket;
+  /// each category's children share another) so siblings stay coherent.
+  Future<void> _persist() async {
+    final client = ref.read(accordAuthProvider
+        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    if (client == null) return;
+    final notifier =
+        ref.read(accordChannelsControllerProvider(widget.spaceId).notifier);
+
+    final updates = <_DragUpdate>[];
+    var categoryPos = 0;
+    final childPos = <String?, int>{};
+    for (final entry in _items) {
+      final ch = entry.channel;
+      if (entry.isCategory) {
+        if (_pos(ch) != categoryPos) {
+          updates.add(_DragUpdate(ch.id, position: categoryPos));
+        }
+        categoryPos++;
+      } else {
+        final pos = childPos[entry.parentId] ?? 0;
+        childPos[entry.parentId] = pos + 1;
+        final parentChanged = ch.parentId != entry.parentId;
+        final positionChanged = _pos(ch) != pos;
+        if (parentChanged || positionChanged) {
+          updates.add(_DragUpdate(
+            ch.id,
+            position: pos,
+            parentId: parentChanged ? entry.parentId : null,
+            includeParent: parentChanged,
+          ));
+        }
+      }
+    }
+
+    if (updates.isEmpty) return;
+
+    _persisting = true;
+    try {
+      for (final u in updates) {
+        final body = <String, dynamic>{'position': u.position};
+        if (u.includeParent) body['parent_id'] = u.parentId;
+        await notifier.updateChannel(client, u.channelId, body);
+      }
+    } finally {
+      _persisting = false;
+      if (mounted) _resync();
+    }
+  }
+
+  Widget _buildItem(BuildContext context, _DragEntry entry) {
+    if (entry.isCategory) {
+      final cat = entry.channel;
+      return _CategoryHeader(
+        category: cat,
+        spaceId: widget.spaceId,
+        canManageChannels: true,
+        collapsed: widget.collapsed.contains(cat.id),
+        onToggle: () => widget.onToggleCollapsed(cat.id),
+        onAdd: () => showCreateChannelDialog(context,
+            spaceId: widget.spaceId, parentId: cat.id),
+        onEdit: () => showEditChannelDialog(context,
+            spaceId: widget.spaceId, channel: cat),
+      );
+    }
+    final ch = entry.channel;
+    return _ChannelTile(
+      channel: ch,
+      spaceId: widget.spaceId,
+      selected: ch.id == widget.selectedChannelId,
+      canManageChannels: true,
+      onTap: () => widget.onSelect(ch.id),
+      onEdit: () =>
+          showEditChannelDialog(context, spaceId: widget.spaceId, channel: ch),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = _visible;
+    return ReorderableListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      buildDefaultDragHandles: false,
+      itemCount: visible.length,
+      onReorderItem: _onReorder,
+      itemBuilder: (context, index) {
+        final entry = visible[index];
+        return ReorderableDelayedDragStartListener(
+          key: ValueKey(entry.channel.id),
+          index: index,
+          child: _buildItem(context, entry),
+        );
+      },
+    );
+  }
+}
+
+/// One row in the inline reorder model: a category header or a channel tile.
+/// [parentId] tracks the category a channel currently sits under (null when
+/// uncategorized); it is recomputed as items are dragged.
+class _DragEntry {
+  _DragEntry.category(this.channel)
+      : isCategory = true,
+        parentId = null;
+  _DragEntry.channel(this.channel, {required this.parentId})
+      : isCategory = false;
+
+  final AccordChannel channel;
+  final bool isCategory;
+  String? parentId;
+}
+
+/// A pending PATCH computed from a reorder: a channel's new [position] and,
+/// when it crossed a category boundary, its new [parentId].
+class _DragUpdate {
+  const _DragUpdate(
+    this.channelId, {
+    required this.position,
+    this.parentId,
+    this.includeParent = false,
+  });
+
+  final String channelId;
+  final int position;
+  final String? parentId;
+  final bool includeParent;
 }

--- a/test/features/channels/channel_sort_test.dart
+++ b/test/features/channels/channel_sort_test.dart
@@ -1,0 +1,62 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/utils/channel_sort.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Minimal stub so tests don't need a real AccordChannel constructor.
+AccordChannel _ch(String id, {Object? position, String? parentId}) {
+  return AccordChannel(
+    id: id,
+    name: '#$id',
+    type: 'text',
+    position: position,
+    parentId: parentId,
+  );
+}
+
+void main() {
+  group('parseChannelPosition', () {
+    test('int value returned as-is', () {
+      expect(parseChannelPosition(_ch('a', position: 3)), 3);
+    });
+
+    test('double coerced to int', () {
+      expect(parseChannelPosition(_ch('a', position: 2.9)), 2);
+    });
+
+    test('string parsed', () {
+      expect(parseChannelPosition(_ch('a', position: '7')), 7);
+    });
+
+    test('null returns 0', () {
+      expect(parseChannelPosition(_ch('a', position: null)), 0);
+    });
+
+    test('non-numeric string returns 0', () {
+      expect(parseChannelPosition(_ch('a', position: 'bad')), 0);
+    });
+  });
+
+  group('channelListSignature', () {
+    test('empty list gives empty signature', () {
+      expect(channelListSignature([]), '');
+    });
+
+    test('same channels in different order give same signature', () {
+      final a = _ch('1', position: 0);
+      final b = _ch('2', position: 1);
+      expect(channelListSignature([a, b]), channelListSignature([b, a]));
+    });
+
+    test('different position makes signature differ', () {
+      final before = [_ch('1', position: 0)];
+      final after = [_ch('1', position: 1)];
+      expect(channelListSignature(before), isNot(channelListSignature(after)));
+    });
+
+    test('different parentId makes signature differ', () {
+      final before = [_ch('1', position: 0, parentId: null)];
+      final after = [_ch('1', position: 0, parentId: 'cat1')];
+      expect(channelListSignature(before), isNot(channelListSignature(after)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Inline channel drag-reorder**: managers (manage-channels permission) get a `ReorderableListView` sidebar — long-press to drag channels and categories into a new order, or move a channel under a different category. Dragging a category carries its children as a contiguous block. Changes persist via per-bucket `position` (plus `parent_id` when a channel crosses a category boundary) with optimistic PATCH and end-of-run reconciliation. Non-managers keep the plain `ListView`.
- **Channel type switching**: the channel edit dialog gains a Type selector limited to non-destructive `text` ↔ `announcement` conversions (mirrors accordserver's `is_non_destructive_type_change`). Voice/category/forum show no selector since no safe conversion exists.

This is an *inline* alternative to PR #100's modal reorder dialog — reordering happens directly in the sidebar.

## Test plan
- [ ] As a manager, long-press-drag a channel within a category and confirm order persists after refresh
- [ ] Drag a channel from one category to another; confirm `parent_id` updates
- [ ] Drag a whole category (with children) to a new position
- [ ] Collapsed categories keep their children correctly parented
- [ ] As a non-manager, sidebar is the plain non-draggable list
- [ ] Edit a text channel → switch type to announcement (and back); confirm no data loss
- [ ] Voice/category/forum edit dialogs show no Type selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)