### PR TITLE
Add opt-in error reporting via GlitchTip (Sentry-compatible)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,15 +189,22 @@ jobs:
         # intermittently 504 or arrive corrupted and fail the whole release.
         # Retry the build a few times with backoff so a transient fetch failure
         # doesn't sink a tagged release; a cached archive also short-circuits it.
+        env:
+          # GlitchTip DSN baked into release builds (reporting stays opt-in at
+          # runtime). When the secret is unset the empty define falls back to
+          # the in-repo dev DSN (see
+          # lib/features/error_reporting/controllers/error_reporting.dart).
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           set -uo pipefail
+          DEFINES=(--dart-define=SENTRY_DSN="${SENTRY_DSN:-}")
           build_once() {
             case "${{ matrix.platform }}" in
-              web)     flutter build web     --no-tree-shake-icons --release ;;
-              android) flutter build apk     --no-tree-shake-icons -v ;;
-              linux)   flutter build linux   -v ;;
-              windows) flutter build windows -v ;;
-              macos)   flutter build macos   -v ;;
+              web)     flutter build web     --no-tree-shake-icons --release "${DEFINES[@]}" ;;
+              android) flutter build apk     --no-tree-shake-icons -v "${DEFINES[@]}" ;;
+              linux)   flutter build linux   -v "${DEFINES[@]}" ;;
+              windows) flutter build windows -v "${DEFINES[@]}" ;;
+              macos)   flutter build macos   -v "${DEFINES[@]}" ;;
             esac
           }
           n=0; max=3

--- a/lib/features/error_reporting/controllers/error_reporting.dart
+++ b/lib/features/error_reporting/controllers/error_reporting.dart
@@ -80,9 +80,11 @@ class ErrorReportingController extends _$ErrorReportingController {
     _active = created;
     _installGlobalHooks();
     // If this provider is torn down (e.g. container disposal) the global
-    // hooks must stop reporting through the dead client.
+    // hooks must stop reporting through the dead client and its HTTP pool
+    // must be released.
     ref.onDispose(() {
       if (identical(_active, created)) _active = null;
+      created.close();
     });
     return true;
   }
@@ -131,7 +133,13 @@ class ErrorReportingController extends _$ErrorReportingController {
     if (client == null) return;
     updateContext();
     client.setTag('type', 'user-feedback');
-    await client.captureMessage(scrubPiiText(description));
+    try {
+      await client.captureMessage(scrubPiiText(description));
+    } finally {
+      // Remove the temporary tag so it doesn't bleed into subsequent
+      // auto-captured error events.
+      client.removeTag('type');
+    }
   }
 
   /// IDs are truncated to their last 4 chars so events can be correlated

--- a/lib/features/error_reporting/controllers/error_reporting.dart
+++ b/lib/features/error_reporting/controllers/error_reporting.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:bonfire/features/error_reporting/repositories/glitchtip_client.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'error_reporting.g.dart';
+
+/// GlitchTip DSN baked into the build. Overridable at build time with
+/// `--dart-define=SENTRY_DSN=...` (release.yml injects the `SENTRY_DSN`
+/// secret); the dev DSN stays in the repo for local testing, mirroring the
+/// reference client's `project.godot` setup.
+const String kDefaultGlitchTipDsn =
+    'https://8ca39e8b380a42548f2d8e9468d47ac2@crash.daccord.gg/1';
+
+const String _envSentryDsn = String.fromEnvironment('SENTRY_DSN');
+
+String resolveGlitchTipDsn() =>
+    _envSentryDsn.isEmpty ? kDefaultGlitchTipDsn : _envSentryDsn;
+
+/// Redacts tokens and server URLs from [msg] before anything leaves the
+/// device — the same patterns as the reference client's
+/// `ErrorReporting.scrub_pii_text`: Bearer tokens, `token=` query params,
+/// `dk_…` hex tokens, bare 64-char hex strings, and URLs with explicit ports.
+String scrubPiiText(String msg) {
+  var out = msg;
+  out = out.replaceAll(
+    RegExp(r'Bearer\s+[A-Za-z0-9._\-]+'),
+    'Bearer [REDACTED]',
+  );
+  out = out.replaceAll(RegExp('token=[^&\\s"\']+'), 'token=[REDACTED]');
+  out = out.replaceAll(RegExp(r'dk_[0-9a-fA-F]{8,}'), '[TOKEN REDACTED]');
+  out = out.replaceAll(RegExp(r'\b[0-9a-fA-F]{64}\b'), '[TOKEN REDACTED]');
+  out = out.replaceAll(
+    RegExp('https?://[^\\s"\']+:\\d{2,5}[^\\s"\']*'),
+    '[URL REDACTED]',
+  );
+  return out;
+}
+
+/// Opt-in error reporting to a self-hosted GlitchTip (Sentry-compatible)
+/// instance. Port of the reference client's `error_reporting.gd` autoload:
+/// nothing is initialized — and no network request ever happens — until the
+/// user enables [AccordSettings.errorReportingEnabled] (first-launch consent
+/// dialog or the settings toggle). State is whether reporting is active.
+///
+/// Once active it also captures unhandled [FlutterError]s and uncaught async
+/// errors, scrubbed through [scrubPiiText]. Breadcrumbs (navigation, message
+/// sent, voice errors) carry structural IDs only — never content.
+@Riverpod(keepAlive: true)
+class ErrorReportingController extends _$ErrorReportingController {
+  /// Client the process-wide error hooks report through; null while reporting
+  /// is disabled. Static because [FlutterError.onError] is process-wide and
+  /// installed once.
+  static GlitchTipClient? _active;
+  static bool _hooksInstalled = false;
+
+  GlitchTipClient? _client;
+
+  @override
+  bool build() {
+    final enabled = ref.watch(
+      settingsControllerProvider.select((s) => s.errorReportingEnabled),
+    );
+    if (!enabled) {
+      _client = null;
+      _active = null;
+      return false;
+    }
+    final created = GlitchTipClient();
+    if (!created.init(resolveGlitchTipDsn())) {
+      _client = null;
+      _active = null;
+      return false;
+    }
+    _client = created;
+    _active = created;
+    _installGlobalHooks();
+    // If this provider is torn down (e.g. container disposal) the global
+    // hooks must stop reporting through the dead client.
+    ref.onDispose(() {
+      if (identical(_active, created)) _active = null;
+    });
+    return true;
+  }
+
+  /// The `event_id` of the last sent event ('' when none / disabled).
+  String get lastEventId => _client?.lastEventId ?? '';
+
+  /// Records a PII-scrubbed breadcrumb; no-op while reporting is disabled.
+  void addBreadcrumb(String message, String category) {
+    _client?.addBreadcrumb(scrubPiiText(message), category);
+  }
+
+  void spaceSelected(String spaceId) =>
+      addBreadcrumb('Switched space: ${_truncateId(spaceId)}', 'navigation');
+
+  void channelSelected(String channelId) =>
+      addBreadcrumb('Opened channel: ${_truncateId(channelId)}', 'navigation');
+
+  /// Breadcrumbs the fact a message was sent — never its content.
+  void messageSent() => addBreadcrumb('Sent message', 'action');
+
+  void voiceError(String error) =>
+      addBreadcrumb('Voice error: $error', 'voice');
+
+  /// Refreshes the context tags (server count, truncated space/channel IDs)
+  /// attached to subsequent events.
+  void updateContext() {
+    final client = _client;
+    if (client == null) return;
+    final connections = ref.read(connectionsControllerProvider);
+    client.setTag('server_count', '${connections.connections.length}');
+    final settings = ref.read(settingsControllerProvider);
+    if (settings.lastSpaceId.isNotEmpty) {
+      client.setTag('space_id', _truncateId(settings.lastSpaceId));
+    }
+    if (settings.lastChannelId.isNotEmpty) {
+      client.setTag('channel_id', _truncateId(settings.lastChannelId));
+    }
+  }
+
+  /// Sends a user-initiated problem report as a `type=user-feedback` tagged
+  /// INFO event (GlitchTip has no Sentry feedback envelope API). No-op while
+  /// reporting is disabled.
+  Future<void> reportProblem(String description) async {
+    final client = _client;
+    if (client == null) return;
+    updateContext();
+    client.setTag('type', 'user-feedback');
+    await client.captureMessage(scrubPiiText(description));
+  }
+
+  /// IDs are truncated to their last 4 chars so events can be correlated
+  /// without identifying the space/channel.
+  static String _truncateId(String id) =>
+      id.length <= 4 ? id : '…${id.substring(id.length - 4)}';
+
+  /// Wraps the process-wide error handlers exactly once, chaining to whatever
+  /// was installed before (main.dart's LiveKit/WebRTC noise filters keep
+  /// working). Capture itself is a no-op while [_active] is null, so consent
+  /// can be toggled without re-wrapping.
+  static void _installGlobalHooks() {
+    if (_hooksInstalled) return;
+    _hooksInstalled = true;
+    final previousOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      _captureGlobal(details.exception, details.stack);
+      previousOnError?.call(details);
+    };
+    final previousPlatformOnError = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (error, stack) {
+      _captureGlobal(error, stack);
+      return previousPlatformOnError?.call(error, stack) ?? false;
+    };
+  }
+
+  static void _captureGlobal(Object error, StackTrace? stack) {
+    final client = _active;
+    if (client == null) return;
+    try {
+      unawaited(
+        client.captureError(
+          scrubPiiText(error.toString()),
+          stack: stack == null ? '' : scrubPiiText(stack.toString()),
+        ),
+      );
+    } catch (_) {
+      // Never let reporting an error raise another one.
+    }
+  }
+}

--- a/lib/features/error_reporting/controllers/error_reporting.g.dart
+++ b/lib/features/error_reporting/controllers/error_reporting.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'error_reporting.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ErrorReportingController)
+const errorReportingControllerProvider = ErrorReportingControllerProvider._();
+
+final class ErrorReportingControllerProvider
+    extends $NotifierProvider<ErrorReportingController, bool> {
+  const ErrorReportingControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'errorReportingControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$errorReportingControllerHash();
+
+  @$internal
+  @override
+  ErrorReportingController create() => ErrorReportingController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$errorReportingControllerHash() =>
+    r'0000000000000000000000000000000000000000';
+
+abstract class _$ErrorReportingController extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/error_reporting/repositories/glitchtip_client.dart
+++ b/lib/features/error_reporting/repositories/glitchtip_client.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:bonfire/shared/app_info.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// Pure Dart error-reporting client for GlitchTip (Sentry-compatible).
+///
+/// Sends events via HTTP POST to the Sentry store API endpoint. Port of the
+/// reference client's `glitchtip_client.gd`, which deliberately avoided the
+/// native Sentry SDK — a plain HTTP client has no platform-specific failure
+/// modes and works identically on web, mobile, and desktop.
+class GlitchTipClient {
+  GlitchTipClient({http.Client? httpClient})
+    : _http = httpClient ?? http.Client();
+
+  static const int maxBreadcrumbs = 100;
+  static const String clientName = 'daccord-flutter/1.0';
+
+  final http.Client _http;
+  final Random _random = Random();
+
+  String _dsnKey = '';
+  String _storeUrl = '';
+  bool _initialized = false;
+  String _lastEventId = '';
+  final Map<String, String> _tags = {};
+  final List<Map<String, dynamic>> _breadcrumbs = [];
+
+  bool get isInitialized => _initialized;
+
+  /// The `event_id` of the most recently built event ('' before any capture).
+  String get lastEventId => _lastEventId;
+
+  /// The resolved Sentry store endpoint (exposed for tests).
+  String get storeUrl => _storeUrl;
+
+  /// Parses [dsn] and prepares default tags. Returns false (and stays
+  /// uninitialized) when the DSN is blank or malformed.
+  bool init(String dsn) {
+    if (dsn.isEmpty) return false;
+    if (!_parseDsn(dsn)) return false;
+    _setDefaultTags();
+    _initialized = true;
+    return true;
+  }
+
+  /// Records a breadcrumb in the in-memory ring buffer (attached to every
+  /// subsequent event). Oldest crumbs are dropped past [maxBreadcrumbs].
+  void addBreadcrumb(
+    String message,
+    String category, {
+    String type = 'default',
+  }) {
+    _breadcrumbs.add({
+      'type': type,
+      'category': category,
+      'message': message,
+      'timestamp': _isoTimestamp(),
+    });
+    while (_breadcrumbs.length > maxBreadcrumbs) {
+      _breadcrumbs.removeAt(0);
+    }
+  }
+
+  void setTag(String key, String value) => _tags[key] = value;
+
+  /// Sends a message-only event at [level] ('info' by default).
+  Future<void> captureMessage(String message, {String level = 'info'}) {
+    if (!_initialized) return Future.value();
+    final event = _buildEvent(level);
+    event['message'] = {'formatted': message};
+    return _sendEvent(event);
+  }
+
+  /// Sends an error event, attaching parsed stack frames when [stack] is given.
+  Future<void> captureError(String message, {String stack = ''}) {
+    if (!_initialized) return Future.value();
+    final event = _buildEvent('error');
+    event['message'] = {'formatted': message};
+    if (stack.isNotEmpty) {
+      event['exception'] = {
+        'values': [
+          {
+            'type': 'DartError',
+            'value': message,
+            'stacktrace': {'frames': parseStackFrames(stack)},
+          },
+        ],
+      };
+    }
+    return _sendEvent(event);
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  /// DSN format: `https://<key>@<host>[/<path>]/<project_id>`, e.g.
+  /// `https://abc123@crash.daccord.gg/1`. The store endpoint becomes
+  /// `<scheme>://<host>[/<path>]/api/<project_id>/store/`.
+  bool _parseDsn(String dsn) {
+    final uri = Uri.tryParse(dsn.trim());
+    if (uri == null || (uri.scheme != 'https' && uri.scheme != 'http')) {
+      return false;
+    }
+    if (uri.userInfo.isEmpty || uri.host.isEmpty) return false;
+    final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+    if (segments.isEmpty) return false;
+    final projectId = segments.last;
+    final prefix = segments.length > 1
+        ? '/${segments.sublist(0, segments.length - 1).join('/')}'
+        : '';
+    final host = uri.hasPort ? '${uri.host}:${uri.port}' : uri.host;
+    _dsnKey = uri.userInfo;
+    _storeUrl = '${uri.scheme}://$host$prefix/api/$projectId/store/';
+    return true;
+  }
+
+  void _setDefaultTags() {
+    _tags['app_version'] = kAppVersion;
+    _tags['os'] = kIsWeb ? 'web' : defaultTargetPlatform.name;
+    _tags['build_mode'] = kReleaseMode
+        ? 'release'
+        : (kProfileMode ? 'profile' : 'debug');
+  }
+
+  Map<String, dynamic> _buildEvent(String level) {
+    final eventId = _generateEventId();
+    _lastEventId = eventId;
+    return {
+      'event_id': eventId,
+      'timestamp': _isoTimestamp(),
+      'platform': 'other',
+      'level': level,
+      'release': 'daccord@$kAppVersion',
+      'environment': kReleaseMode ? 'production' : 'development',
+      'sdk': {'name': clientName, 'version': '1.0.0'},
+      'tags': Map<String, String>.of(_tags),
+      'breadcrumbs': {'values': List<Map<String, dynamic>>.of(_breadcrumbs)},
+    };
+  }
+
+  Future<void> _sendEvent(Map<String, dynamic> event) async {
+    try {
+      await _http.post(
+        Uri.parse(_storeUrl),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Sentry-Auth':
+              'Sentry sentry_version=7, '
+              'sentry_client=$clientName, '
+              'sentry_key=$_dsnKey',
+        },
+        body: jsonEncode(event),
+      );
+    } catch (_) {
+      // Error reporting must never throw back into the app.
+    }
+  }
+
+  /// UUID v4 as 32 hex chars (no dashes), as the Sentry event API expects.
+  String _generateEventId() {
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3F) | 0x80; // RFC 4122 variant
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  String _isoTimestamp() {
+    final now = DateTime.now().toUtc();
+    String pad(int n) => n.toString().padLeft(2, '0');
+    return '${now.year.toString().padLeft(4, '0')}-${pad(now.month)}-'
+        '${pad(now.day)}T${pad(now.hour)}:${pad(now.minute)}:'
+        '${pad(now.second)}Z';
+  }
+
+  static final _frameRe = RegExp(r'^#\d+\s+(.+?)\s+\((.+?):(\d+)(?::\d+)?\)$');
+
+  /// Parses a Dart [StackTrace.toString] into Sentry stack frames (oldest
+  /// first). Lines that don't look like frames (e.g. `<asynchronous
+  /// suspension>`) are kept as filename-only frames, like the reference
+  /// client's lenient GDScript parser.
+  static List<Map<String, dynamic>> parseStackFrames(String stackText) {
+    final frames = <Map<String, dynamic>>[];
+    for (final line in stackText.split('\n')) {
+      final stripped = line.trim();
+      if (stripped.isEmpty) continue;
+      final match = _frameRe.firstMatch(stripped);
+      if (match != null) {
+        frames.add({
+          'function': match.group(1),
+          'filename': match.group(2),
+          'lineno': int.tryParse(match.group(3)!) ?? 0,
+        });
+      } else {
+        frames.add({'filename': stripped});
+      }
+    }
+    return frames.reversed.toList();
+  }
+}

--- a/lib/features/error_reporting/repositories/glitchtip_client.dart
+++ b/lib/features/error_reporting/repositories/glitchtip_client.dart
@@ -19,7 +19,7 @@ class GlitchTipClient {
   static const String clientName = 'daccord-flutter/1.0';
 
   final http.Client _http;
-  final Random _random = Random();
+  final Random _random = Random.secure();
 
   String _dsnKey = '';
   String _storeUrl = '';
@@ -59,12 +59,16 @@ class GlitchTipClient {
       'message': message,
       'timestamp': _isoTimestamp(),
     });
-    while (_breadcrumbs.length > maxBreadcrumbs) {
+    if (_breadcrumbs.length > maxBreadcrumbs) {
       _breadcrumbs.removeAt(0);
     }
   }
 
   void setTag(String key, String value) => _tags[key] = value;
+
+  void removeTag(String key) => _tags.remove(key);
+
+  void close() => _http.close();
 
   /// Sends a message-only event at [level] ('info' by default).
   Future<void> captureMessage(String message, {String level = 'info'}) {

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -2,6 +2,7 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
+import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -138,6 +139,9 @@ class AccordMessagesController extends _$AccordMessagesController {
     }
     final message = result.data;
     if (message is AccordMessage) addMessage(message);
+    // Action breadcrumb for opt-in error reporting — the fact a message was
+    // sent, never its content.
+    ref.read(errorReportingControllerProvider.notifier).messageSent();
     return true;
   }
 
@@ -254,6 +258,9 @@ class AccordMessagesController extends _$AccordMessagesController {
     }
     final message = result.data;
     if (message is AccordMessage) addMessage(message);
+    // Action breadcrumb for opt-in error reporting — the fact a message was
+    // sent, never its content.
+    ref.read(errorReportingControllerProvider.notifier).messageSent();
     return true;
   }
 

--- a/lib/features/settings/controllers/settings.dart
+++ b/lib/features/settings/controllers/settings.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/spaces/models/space_folder.dart';
+import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -374,6 +375,22 @@ class SettingsController extends _$SettingsController {
   void setAutoUpdateCheck(bool enabled) =>
       _update(state.copyWith(autoUpdateCheck: enabled));
 
+  /// Enables/disables anonymous error reporting (GlitchTip). Answering counts
+  /// as having seen the consent prompt, so it is never reshown. Mirrors the
+  /// reference's `Config.set_error_reporting_enabled` + consent stamping.
+  void setErrorReportingEnabled(bool enabled) => _update(
+    state.copyWith(
+      errorReportingEnabled: enabled,
+      errorReportingConsentShown: true,
+    ),
+  );
+
+  /// Marks the first-launch error-reporting consent dialog as answered
+  /// without changing the toggle. Mirrors the reference's
+  /// `Config.set_error_reporting_consent_shown`.
+  void markErrorReportingConsentShown() =>
+      _update(state.copyWith(errorReportingConsentShown: true));
+
   /// Records the release [version] the user dismissed from the update banner.
   void setDismissedUpdateVersion(String version) =>
       _update(state.copyWith(dismissedUpdateVersion: version));
@@ -392,6 +409,15 @@ class SettingsController extends _$SettingsController {
   void setLastSelection(String spaceId, String channelId) {
     if (state.lastSpaceId == spaceId && state.lastChannelId == channelId) {
       return;
+    }
+    // Navigation breadcrumbs for opt-in error reporting (no-ops while
+    // disabled); IDs are truncated before they leave the device.
+    final errorReporting = ref.read(errorReportingControllerProvider.notifier);
+    if (spaceId.isNotEmpty && spaceId != state.lastSpaceId) {
+      errorReporting.spaceSelected(spaceId);
+    }
+    if (channelId.isNotEmpty && channelId != state.lastChannelId) {
+      errorReporting.channelSelected(channelId);
     }
     _update(state.copyWith(lastSpaceId: spaceId, lastChannelId: channelId));
   }

--- a/lib/features/settings/models/accord_settings.dart
+++ b/lib/features/settings/models/accord_settings.dart
@@ -81,6 +81,8 @@ class AccordSettings {
     this.mutedSpaces = const <String>[],
     this.hiddenSpaces = const <String>[],
     this.channelListWidth = defaultChannelListWidth,
+    this.errorReportingEnabled = false,
+    this.errorReportingConsentShown = false,
   });
 
   /// Minimum / maximum UI text scale, matching the reference's `ui_scale` range.
@@ -246,6 +248,16 @@ class AccordSettings {
   /// [minChannelListWidth]–[maxChannelListWidth]; persisted across restarts.
   final double channelListWidth;
 
+  /// Opt-in anonymous crash/error reporting to GlitchTip. Off by default —
+  /// nothing is sent until the user consents. Mirrors the reference client's
+  /// `[error_reporting] enabled` config key.
+  final bool errorReportingEnabled;
+
+  /// Whether the first-launch consent dialog has been answered (in either
+  /// direction), so it is never shown again. Mirrors the reference client's
+  /// `[error_reporting] consent_shown`.
+  final bool errorReportingConsentShown;
+
   AccordSettings copyWith({
     AppThemePreset? themePreset,
     int? accentColor,
@@ -288,6 +300,8 @@ class AccordSettings {
     List<String>? mutedSpaces,
     List<String>? hiddenSpaces,
     double? channelListWidth,
+    bool? errorReportingEnabled,
+    bool? errorReportingConsentShown,
   }) {
     return AccordSettings(
       themePreset: themePreset ?? this.themePreset,
@@ -332,6 +346,10 @@ class AccordSettings {
       mutedSpaces: mutedSpaces ?? this.mutedSpaces,
       hiddenSpaces: hiddenSpaces ?? this.hiddenSpaces,
       channelListWidth: channelListWidth ?? this.channelListWidth,
+      errorReportingEnabled:
+          errorReportingEnabled ?? this.errorReportingEnabled,
+      errorReportingConsentShown:
+          errorReportingConsentShown ?? this.errorReportingConsentShown,
     );
   }
 
@@ -433,6 +451,8 @@ class AccordSettings {
     'mutedSpaces': mutedSpaces,
     'hiddenSpaces': hiddenSpaces,
     'channelListWidth': channelListWidth,
+    'errorReportingEnabled': errorReportingEnabled,
+    'errorReportingConsentShown': errorReportingConsentShown,
   };
 
   factory AccordSettings.fromJson(Map<dynamic, dynamic> json) {
@@ -525,6 +545,9 @@ class AccordSettings {
             maxChannelListWidth,
           ) ??
           defaultChannelListWidth,
+      errorReportingEnabled: json['errorReportingEnabled'] as bool? ?? false,
+      errorReportingConsentShown:
+          json['errorReportingConsentShown'] as bool? ?? false,
     );
   }
 }

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/settings/views/connections_settings_page.dart';
 import 'package:bonfire/features/settings/views/privacy_settings_page.dart';
 import 'package:bonfire/features/settings/views/settings_backup.dart';
+import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/user/views/accord_profile_edit.dart';
@@ -152,6 +153,29 @@ class AccordSettingsScreen extends ConsumerWidget {
             value: settings.suppressEveryone,
             onChanged: settings.notificationsEnabled
                 ? controller.setSuppressEveryone
+                : null,
+          ),
+          const Divider(height: 24),
+          _SectionHeader('Error Reporting'),
+          SwitchListTile(
+            title: const Text('Send error reports'),
+            subtitle: const Text(
+              'Anonymous crash and error reports. No personal data or '
+              'message content is included',
+            ),
+            value: settings.errorReportingEnabled,
+            onChanged: controller.setErrorReportingEnabled,
+          ),
+          ListTile(
+            leading: Icon(Icons.bug_report_outlined, color: colors.dirtyWhite),
+            title: const Text('Report a problem'),
+            subtitle: const Text(
+              'Describe a bug and send it to the developers',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            enabled: settings.errorReportingEnabled,
+            onTap: settings.errorReportingEnabled
+                ? () => _showReportProblemDialog(context, ref)
                 : null,
           ),
           const Divider(height: 24),
@@ -311,6 +335,63 @@ class AccordSettingsScreen extends ConsumerWidget {
       ),
     );
   }
+}
+
+/// User-initiated feedback, mirroring the reference client's "Report a
+/// Problem" dialog: an optional free-text description sent as a tagged
+/// `user-feedback` event through the opt-in error reporting pipeline.
+Future<void> _showReportProblemDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final textController = TextEditingController();
+  final send = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Report a Problem'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: textController,
+            autofocus: true,
+            maxLines: 4,
+            decoration: const InputDecoration(
+              hintText: 'Describe what happened (optional)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'No personal data or message content is included.',
+            style: Theme.of(ctx).textTheme.bodySmall,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: const Text('Send Report'),
+        ),
+      ],
+    ),
+  );
+  if (send == true) {
+    await ref
+        .read(errorReportingControllerProvider.notifier)
+        .reportProblem(textController.text.trim());
+    if (context.mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Report sent. Thank you!')),
+      );
+    }
+  }
+  textController.dispose();
 }
 
 /// Lets the user pick which connected server's profile to edit, then opens the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:bonfire/features/server/utils/server_uri.dart';
 import 'package:bonfire/features/server/views/add_server_dialog.dart';
 import 'package:bonfire/features/developer/controllers/mcp_server_controller.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/router/controller.dart';
 import 'package:bonfire/shared/utils/desktop_window.dart';
 import 'package:bonfire/theme/app_theme.dart';
@@ -167,12 +168,70 @@ class _MainWindowState extends ConsumerState<MainWindow> {
   void initState() {
     super.initState();
     _initDeepLinks();
+    // Every route change becomes an error-reporting breadcrumb (a no-op until
+    // the user opts in).
+    routerController.routerDelegate.addListener(_onRouteChanged);
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _maybeShowErrorReportingConsent(),
+    );
   }
 
   @override
   void dispose() {
+    routerController.routerDelegate.removeListener(_onRouteChanged);
     _linkSub?.cancel();
     super.dispose();
+  }
+
+  void _onRouteChanged() {
+    final path = routerController.routerDelegate.currentConfiguration.uri.path;
+    ref
+        .read(errorReportingControllerProvider.notifier)
+        .addBreadcrumb('Navigated: $path', 'navigation');
+  }
+
+  /// First-launch error-reporting consent, mirroring the reference client's
+  /// `main_window._show_consent_dialog`: asked once, never reshown (answering
+  /// — or toggling the switch in Settings — stamps the preference).
+  Future<void> _maybeShowErrorReportingConsent() async {
+    if (ref.read(settingsControllerProvider).errorReportingConsentShown) {
+      return;
+    }
+    // Give the router a moment to mount its navigator so the dialog has a
+    // context to attach to.
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
+    if (ref.read(settingsControllerProvider).errorReportingConsentShown) {
+      return;
+    }
+    final ctx = rootNavigatorKey.currentContext;
+    if (ctx == null) return;
+    final enable = await showDialog<bool>(
+      context: ctx,
+      barrierDismissible: false,
+      builder: (dialogCtx) => AlertDialog(
+        title: const Text('Help improve daccord'),
+        content: const Text(
+          'Help improve daccord by sending anonymous crash and error '
+          'reports? No personal data is included. You can change this in '
+          'Settings at any time.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(false),
+            child: const Text('No thanks'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(true),
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    ref
+        .read(settingsControllerProvider.notifier)
+        .setErrorReportingEnabled(enable == true);
   }
 
   /// Listens for `daccord://` deep links (cold-start and while running) and
@@ -238,6 +297,9 @@ class _MainWindowState extends ConsumerState<MainWindow> {
     // Keep the local MCP server controller alive so it starts/stops with the
     // Developer Mode + MCP settings (desktop-only; a no-op on web).
     ref.watch(mcpServerControllerProvider);
+    // Keep opt-in error reporting alive; it activates/deactivates with the
+    // persisted consent toggle.
+    ref.watch(errorReportingControllerProvider);
     soundManager.enabled = settings.soundsEnabled;
     soundManager.volume = settings.sfxVolume;
     final theme = buildAppTheme(

--- a/test/features/error_reporting/error_reporting_test.dart
+++ b/test/features/error_reporting/error_reporting_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+void main() {
+  group('scrubPiiText', () {
+    // Ported from the reference client's test_error_reporting.gd.
+    test('redacts Bearer tokens', () {
+      expect(
+        scrubPiiText('Error: Bearer eyJhbGciOi.secret_token in request'),
+        'Error: Bearer [REDACTED] in request',
+      );
+    });
+
+    test('redacts token= query parameters', () {
+      expect(
+        scrubPiiText('GET /cdn/file?token=abc123&size=64 failed'),
+        'GET /cdn/file?token=[REDACTED]&size=64 failed',
+      );
+    });
+
+    test('redacts dk_ hex tokens', () {
+      expect(
+        scrubPiiText('auth with dk_0123456789abcdef rejected'),
+        'auth with [TOKEN REDACTED] rejected',
+      );
+    });
+
+    test('redacts bare 64-char hex tokens', () {
+      final token = 'a' * 64;
+      expect(
+        scrubPiiText('stored $token locally'),
+        'stored [TOKEN REDACTED] locally',
+      );
+    });
+
+    test('redacts URLs with explicit ports', () {
+      expect(
+        scrubPiiText('connect to https://accord.example.com:8443/ws failed'),
+        'connect to [URL REDACTED] failed',
+      );
+    });
+
+    test('leaves ordinary text untouched', () {
+      expect(
+        scrubPiiText('a perfectly normal error'),
+        'a perfectly normal error',
+      );
+    });
+  });
+
+  test('the dev DSN is used when no dart-define override is set', () {
+    expect(resolveGlitchTipDsn(), kDefaultGlitchTipDsn);
+  });
+
+  group('ErrorReportingController', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('error-reporting-test');
+      Hive.init(tempDir.path);
+      await Hive.openBox('accord-settings');
+    });
+
+    tearDown(() async {
+      await Hive.deleteBoxFromDisk('accord-settings');
+      await Hive.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    ProviderContainer makeContainer() {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('inactive by default (no consent given)', () {
+      final c = makeContainer();
+      expect(c.read(errorReportingControllerProvider), isFalse);
+    });
+
+    test('guarded methods are no-ops while disabled', () async {
+      final c = makeContainer();
+      final reporting = c.read(errorReportingControllerProvider.notifier);
+      reporting.addBreadcrumb('test message', 'test');
+      reporting.spaceSelected('space_123');
+      reporting.channelSelected('chan_456');
+      reporting.messageSent();
+      reporting.voiceError('ice failed');
+      reporting.updateContext();
+      await reporting.reportProblem('something broke');
+      expect(reporting.lastEventId, isEmpty);
+      expect(c.read(errorReportingControllerProvider), isFalse);
+    });
+
+    test('the settings toggle activates reporting and stamps consent', () {
+      final c = makeContainer();
+      final settings = c.read(settingsControllerProvider.notifier);
+      expect(
+        c.read(settingsControllerProvider).errorReportingConsentShown,
+        isFalse,
+      );
+
+      settings.setErrorReportingEnabled(true);
+      final state = c.read(settingsControllerProvider);
+      expect(state.errorReportingEnabled, isTrue);
+      expect(state.errorReportingConsentShown, isTrue);
+      // Activation parses the DSN only — no network happens until an event is
+      // actually captured.
+      expect(c.read(errorReportingControllerProvider), isTrue);
+
+      settings.setErrorReportingEnabled(false);
+      expect(c.read(errorReportingControllerProvider), isFalse);
+    });
+
+    test('markErrorReportingConsentShown leaves the toggle off', () {
+      final c = makeContainer();
+      c
+          .read(settingsControllerProvider.notifier)
+          .markErrorReportingConsentShown();
+      final state = c.read(settingsControllerProvider);
+      expect(state.errorReportingConsentShown, isTrue);
+      expect(state.errorReportingEnabled, isFalse);
+    });
+  });
+
+  group('AccordSettings round-trip', () {
+    test('error-reporting flags survive toJson -> fromJson', () {
+      const settings = AccordSettings(
+        errorReportingEnabled: true,
+        errorReportingConsentShown: true,
+      );
+      final restored = AccordSettings.fromJson(settings.toJson());
+      expect(restored.errorReportingEnabled, isTrue);
+      expect(restored.errorReportingConsentShown, isTrue);
+    });
+
+    test('error-reporting flags default to off', () {
+      final restored = AccordSettings.fromJson(const {});
+      expect(restored.errorReportingEnabled, isFalse);
+      expect(restored.errorReportingConsentShown, isFalse);
+    });
+  });
+}

--- a/test/features/error_reporting/glitchtip_client_test.dart
+++ b/test/features/error_reporting/glitchtip_client_test.dart
@@ -114,6 +114,22 @@ void main() {
     });
   });
 
+  test('removeTag removes a previously set tag from events', () async {
+    late http.Request captured;
+    final client = GlitchTipClient(
+      httpClient: MockClient((request) async {
+        captured = request;
+        return http.Response('', 200);
+      }),
+    );
+    client.init('https://k@host.example/1');
+    client.setTag('type', 'user-feedback');
+    client.removeTag('type');
+    await client.captureMessage('check');
+    final event = jsonDecode(captured.body) as Map<String, dynamic>;
+    expect((event['tags'] as Map).containsKey('type'), isFalse);
+  });
+
   test('breadcrumbs are capped at maxBreadcrumbs', () async {
     late http.Request captured;
     final client = GlitchTipClient(

--- a/test/features/error_reporting/glitchtip_client_test.dart
+++ b/test/features/error_reporting/glitchtip_client_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+
+import 'package:bonfire/features/error_reporting/repositories/glitchtip_client.dart';
+import 'package:bonfire/shared/app_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  group('DSN parsing', () {
+    test('valid DSN initializes and derives the store URL', () {
+      final client = GlitchTipClient();
+      expect(client.init('https://abc123@crash.daccord.gg/1'), isTrue);
+      expect(client.isInitialized, isTrue);
+      expect(client.storeUrl, 'https://crash.daccord.gg/api/1/store/');
+    });
+
+    test('DSN with port and path prefix keeps both', () {
+      final client = GlitchTipClient();
+      expect(client.init('http://key@errors.example.com:8000/gt/42'), isTrue);
+      expect(
+        client.storeUrl,
+        'http://errors.example.com:8000/gt/api/42/store/',
+      );
+    });
+
+    test('rejects blank, schemeless, keyless, and projectless DSNs', () {
+      expect(GlitchTipClient().init(''), isFalse);
+      expect(GlitchTipClient().init('crash.daccord.gg/1'), isFalse);
+      expect(GlitchTipClient().init('ftp://key@host/1'), isFalse);
+      expect(GlitchTipClient().init('https://crash.daccord.gg/1'), isFalse);
+      expect(GlitchTipClient().init('https://key@crash.daccord.gg'), isFalse);
+    });
+  });
+
+  group('event sending', () {
+    late List<http.Request> requests;
+    late GlitchTipClient client;
+
+    setUp(() {
+      requests = [];
+      client = GlitchTipClient(
+        httpClient: MockClient((request) async {
+          requests.add(request);
+          return http.Response('{"id":"1"}', 200);
+        }),
+      );
+      client.init('https://thekey@crash.example.com/7');
+    });
+
+    test('captureMessage posts a Sentry event with auth header', () async {
+      client.setTag('type', 'user-feedback');
+      client.addBreadcrumb('Opened channel: …1234', 'navigation');
+      await client.captureMessage('it broke');
+
+      expect(requests, hasLength(1));
+      final request = requests.single;
+      expect(request.url.toString(), 'https://crash.example.com/api/7/store/');
+      expect(request.headers['X-Sentry-Auth'], contains('sentry_version=7'));
+      expect(request.headers['X-Sentry-Auth'], contains('sentry_key=thekey'));
+
+      final event = jsonDecode(request.body) as Map<String, dynamic>;
+      expect(event['event_id'], matches(RegExp(r'^[0-9a-f]{32}$')));
+      expect(event['event_id'], client.lastEventId);
+      expect(event['level'], 'info');
+      expect(event['release'], 'daccord@$kAppVersion');
+      expect(event['message'], {'formatted': 'it broke'});
+      expect(event['tags']['type'], 'user-feedback');
+      expect(event['tags']['app_version'], kAppVersion);
+      final crumbs = event['breadcrumbs']['values'] as List;
+      expect(crumbs.single['message'], 'Opened channel: …1234');
+      expect(crumbs.single['category'], 'navigation');
+      expect(event['timestamp'], matches(RegExp(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$')));
+    });
+
+    test('captureError attaches parsed stack frames', () async {
+      const stack = '''
+#0      Foo.bar (package:bonfire/foo.dart:12:5)
+#1      main (package:bonfire/main.dart:3:1)
+<asynchronous suspension>
+''';
+      await client.captureError('boom', stack: stack);
+
+      final event = jsonDecode(requests.single.body) as Map<String, dynamic>;
+      expect(event['level'], 'error');
+      final frames =
+          event['exception']['values'][0]['stacktrace']['frames'] as List;
+      // Oldest first: the non-frame line, then main, then Foo.bar.
+      expect(frames.first, {'filename': '<asynchronous suspension>'});
+      expect(frames.last, {
+        'function': 'Foo.bar',
+        'filename': 'package:bonfire/foo.dart',
+        'lineno': 12,
+      });
+    });
+
+    test('nothing is sent before init', () async {
+      final uninitialized = GlitchTipClient(
+        httpClient: MockClient((request) async {
+          requests.add(request);
+          return http.Response('', 200);
+        }),
+      );
+      await uninitialized.captureMessage('dropped');
+      expect(requests, isEmpty);
+    });
+
+    test('a failing transport never throws', () async {
+      final failing = GlitchTipClient(
+        httpClient: MockClient((_) async => throw Exception('offline')),
+      );
+      failing.init('https://k@host.example/1');
+      await failing.captureMessage('still fine');
+    });
+  });
+
+  test('breadcrumbs are capped at maxBreadcrumbs', () async {
+    late http.Request captured;
+    final client = GlitchTipClient(
+      httpClient: MockClient((request) async {
+        captured = request;
+        return http.Response('', 200);
+      }),
+    );
+    client.init('https://k@host.example/1');
+    for (var i = 0; i < GlitchTipClient.maxBreadcrumbs + 10; i++) {
+      client.addBreadcrumb('crumb $i', 'test');
+    }
+    await client.captureMessage('check');
+    final event = jsonDecode(captured.body) as Map<String, dynamic>;
+    final crumbs = event['breadcrumbs']['values'] as List;
+    expect(crumbs, hasLength(GlitchTipClient.maxBreadcrumbs));
+    expect(crumbs.first['message'], 'crumb 10'); // oldest dropped
+    expect(crumbs.last['message'], 'crumb 109');
+  });
+}


### PR DESCRIPTION
## Summary

Implements anonymous, opt-in error reporting to a self-hosted GlitchTip instance, mirroring the reference Godot client's error reporting feature. Nothing is sent until the user explicitly consents via a first-launch dialog or the Settings toggle. All personally identifiable information (tokens, URLs, message content) is scrubbed before transmission.

## Key Changes

- **GlitchTipClient** (`lib/features/error_reporting/repositories/glitchtip_client.dart`): Pure Dart HTTP client for the Sentry-compatible store API. Handles DSN parsing, event building, breadcrumb management, and stack frame parsing. Deliberately avoids native SDKs for cross-platform consistency (web, mobile, desktop).

- **ErrorReportingController** (`lib/features/error_reporting/controllers/error_reporting.dart`): Riverpod-based state management for error reporting. Wraps global `FlutterError.onError` and `PlatformDispatcher.onError` hooks once, capturing unhandled exceptions and async errors. Provides breadcrumb recording for navigation, messaging, and voice events. All text is scrubbed via `scrubPiiText()` before leaving the device.

- **PII Scrubbing** (`scrubPiiText`): Redacts Bearer tokens, `token=` query parameters, `dk_` hex tokens, bare 64-char hex strings, and URLs with explicit ports — matching the reference client's patterns.

- **Settings Integration**: Added `errorReportingEnabled` and `errorReportingConsentShown` flags to `AccordSettings`. First-launch consent dialog shown in `main.dart` (never reshown once answered). Settings screen includes toggle and "Report a Problem" dialog for user-initiated feedback.

- **Release Build Integration** (`.github/workflows/release.yml`): Injects `SENTRY_DSN` secret at build time via `--dart-define`. Falls back to in-repo dev DSN when unset, mirroring the reference client's `project.godot` setup.

- **Comprehensive Tests** (`test/features/error_reporting/`): Unit tests for DSN parsing, PII scrubbing, event sending, breadcrumb capping, and settings round-trip serialization.

## Implementation Details

- **No-op until consent**: All guarded methods (`addBreadcrumb`, `captureMessage`, `captureError`, `reportProblem`) return immediately if reporting is disabled, so toggling consent requires no re-initialization.

- **Global hooks installed once**: `FlutterError.onError` and `PlatformDispatcher.onError` are wrapped exactly once and chain to any previously installed handlers (e.g., LiveKit noise filters in `main.dart`).

- **Breadcrumb ring buffer**: Capped at 100 entries; oldest are dropped when exceeded. Attached to every subsequent event.

- **Stack frame parsing**: Lenient regex-based parser (matching the reference client) handles both well-formed Dart frames and anomalies like `<asynchronous suspension>`.

- **Event ID tracking**: UUID v4 (32 hex chars, no dashes) generated per event; `lastEventId` exposed for correlation in the UI.

- **Transport resilience**: HTTP errors never throw back into the app; all exceptions are silently caught.

https://claude.ai/code/session_01BWiFwfBbVEzQr9Tdgq33F6