### PR TITLE
feat: MCP permission tools + rail reorder, image cropping, faster member loading

### DIFF
--- a/lib/features/admin/views/admin_spaces_tab.dart
+++ b/lib/features/admin/views/admin_spaces_tab.dart
@@ -1,9 +1,11 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 /// Instance-admin "Spaces" tab: lists every space on the instance, with search,
 /// create, delete and owner-transfer. Mirrors the reference client's
@@ -61,6 +63,20 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
       _busy = false;
       _spaces = data is List ? data.cast<AccordSpace>() : <AccordSpace>[];
     });
+  }
+
+  /// Opens [space] in the rail using the admin's own connection — no public
+  /// join. As an instance admin we already have access, so we just surface the
+  /// space and navigate into it rather than hitting the member-join endpoint.
+  void _open(AccordSpace space) {
+    final state = ref.read(accordAuthProvider);
+    final key = state is AccordAuthLoggedIn ? state.session.key : null;
+    // Flip the active server *before* upserting: `setActiveServer` reseeds the
+    // rail from the connection's cached space list, which would otherwise wipe
+    // out the space we surface here.
+    if (key != null) ref.read(accordAuthProvider.notifier).setActiveServer(key);
+    ref.read(spacesControllerProvider.notifier).upsertSpace(space);
+    context.go('/spaces?space=${Uri.encodeComponent(space.id)}');
   }
 
   Future<void> _create() async {
@@ -230,6 +246,7 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
                         itemBuilder: (context, i) => _SpaceRow(
                           space: list[i],
                           busy: _busy,
+                          onOpen: () => _open(list[i]),
                           onDelete: () => _delete(list[i]),
                           onTransfer: () => _transfer(list[i]),
                         ),
@@ -245,12 +262,14 @@ class _SpaceRow extends StatelessWidget {
   const _SpaceRow({
     required this.space,
     required this.busy,
+    required this.onOpen,
     required this.onDelete,
     required this.onTransfer,
   });
 
   final AccordSpace space;
   final bool busy;
+  final VoidCallback onOpen;
   final VoidCallback onDelete;
   final VoidCallback onTransfer;
 
@@ -277,6 +296,10 @@ class _SpaceRow extends StatelessWidget {
       trailing: Wrap(
         spacing: 4,
         children: [
+          TextButton(
+            onPressed: busy ? null : onOpen,
+            child: const Text('Open'),
+          ),
           TextButton(
             onPressed: busy ? null : onTransfer,
             child: const Text('Transfer'),

--- a/lib/features/developer/services/mcp_tools.dart
+++ b/lib/features/developer/services/mcp_tools.dart
@@ -492,16 +492,14 @@ class McpTools {
     return {'ok': true, 'roles': [for (final role in roles) _roleFull(role)]};
   }
 
-  Future<Map<String, dynamic>> _listPermissions(
-      Map<String, dynamic> args) async {
-    return {
-      'ok': true,
-      'permissions': [
-        for (final p in AccordPermission.all())
-          {'id': p, 'description': AccordPermission.description(p)},
-      ],
-    };
-  }
+  Future<Map<String, dynamic>> _listPermissions(Map<String, dynamic> args) =>
+      Future.value({
+        'ok': true,
+        'permissions': [
+          for (final p in AccordPermission.all())
+            {'id': p, 'description': AccordPermission.description(p)},
+        ],
+      });
 
   // ── navigate handlers ───────────────────────────────────────────────────
 
@@ -712,7 +710,11 @@ class McpTools {
     final client = _client;
     if (client == null) return _notConnected;
     final data = <String, dynamic>{};
-    if (args.containsKey('name')) data['name'] = (args['name'] ?? '').toString();
+    if (args.containsKey('name')) {
+      final name = (args['name'] ?? '').toString();
+      if (name.isEmpty) return {'error': 'name cannot be empty'};
+      data['name'] = name;
+    }
     if (args.containsKey('color')) data['color'] = _asInt(args['color'], 0);
     final perms = _permList(args['permissions']);
     if (perms != null) data['permissions'] = perms;

--- a/lib/features/developer/services/mcp_tools.dart
+++ b/lib/features/developer/services/mcp_tools.dart
@@ -683,9 +683,9 @@ class McpTools {
     final spaceId = (args['space_id'] ?? '').toString();
     final name = (args['name'] ?? '').toString();
     if (spaceId.isEmpty) return {'error': 'space_id is required'};
-    if (name.isEmpty) return {'error': 'name is required'};
     final client = _client;
     if (client == null) return _notConnected;
+    if (name.isEmpty) return {'error': 'name is required'};
     final data = <String, dynamic>{'name': name};
     if (args.containsKey('color')) data['color'] = _asInt(args['color'], 0);
     final perms = _permList(args['permissions']);
@@ -707,8 +707,6 @@ class McpTools {
     final roleId = (args['role_id'] ?? '').toString();
     if (spaceId.isEmpty) return {'error': 'space_id is required'};
     if (roleId.isEmpty) return {'error': 'role_id is required'};
-    final client = _client;
-    if (client == null) return _notConnected;
     final data = <String, dynamic>{};
     if (args.containsKey('name')) {
       final name = (args['name'] ?? '').toString();
@@ -726,6 +724,8 @@ class McpTools {
       data['mentionable'] = _asBool(args['mentionable']);
     }
     if (data.isEmpty) return {'error': 'No fields to update'};
+    final client = _client;
+    if (client == null) return _notConnected;
     final r = await client.roles.update(spaceId, roleId, data);
     if (!r.ok) return _restError(r);
     return {

--- a/lib/features/developer/services/mcp_tools.dart
+++ b/lib/features/developer/services/mcp_tools.dart
@@ -124,6 +124,14 @@ class McpTools {
         _schema({'user_id': 'string'}, ['user_id']), _getUser);
     _register('get_space', 'read', 'Get space details by ID',
         _schema({'space_id': 'string'}, ['space_id']), _getSpace);
+    _register('list_roles', 'read', 'List roles in a space',
+        _schema({'space_id': 'string'}, ['space_id']), _listRoles);
+    _register(
+        'list_permissions',
+        'read',
+        'List all known permission identifiers and their descriptions',
+        {},
+        _listPermissions);
 
     // ── navigate ────────────────────────────────────────────────────────────
     _register('select_space', 'navigate', 'Switch to a space',
@@ -231,6 +239,110 @@ class McpTools {
           'duration'
         ]),
         _timeoutMember);
+
+    // ── manage ────────────────────────────────────────────────────────────
+    _register(
+        'create_role',
+        'manage',
+        'Create a role in a space (permissions is an array of permission ids)',
+        _schema({
+          'space_id': 'string',
+          'name': 'string',
+          'color': 'integer',
+          'permissions': 'array',
+          'hoist': 'boolean',
+          'mentionable': 'boolean',
+        }, [
+          'space_id',
+          'name'
+        ]),
+        _createRole);
+    _register(
+        'update_role',
+        'manage',
+        'Update a role; only the provided fields change. permissions replaces '
+            'the role\'s full permission set',
+        _schema({
+          'space_id': 'string',
+          'role_id': 'string',
+          'name': 'string',
+          'color': 'integer',
+          'permissions': 'array',
+          'position': 'integer',
+          'hoist': 'boolean',
+          'mentionable': 'boolean',
+        }, [
+          'space_id',
+          'role_id'
+        ]),
+        _updateRole);
+    _register(
+        'delete_role',
+        'manage',
+        'Delete a role from a space',
+        _schema({'space_id': 'string', 'role_id': 'string'},
+            ['space_id', 'role_id']),
+        _deleteRole);
+    _register(
+        'add_member_role',
+        'manage',
+        'Assign a role to a member',
+        _schema({
+          'space_id': 'string',
+          'user_id': 'string',
+          'role_id': 'string',
+        }, [
+          'space_id',
+          'user_id',
+          'role_id'
+        ]),
+        _addMemberRole);
+    _register(
+        'remove_member_role',
+        'manage',
+        'Remove a role from a member',
+        _schema({
+          'space_id': 'string',
+          'user_id': 'string',
+          'role_id': 'string',
+        }, [
+          'space_id',
+          'user_id',
+          'role_id'
+        ]),
+        _removeMemberRole);
+    _register(
+        'list_channel_permissions',
+        'manage',
+        'List a channel\'s permission overwrites (per-role and per-member '
+            'allow/deny rules)',
+        _schema({'channel_id': 'string'}, ['channel_id']),
+        _listChannelPermissions);
+    _register(
+        'set_channel_permission',
+        'manage',
+        'Create or update a channel permission overwrite for a role or member. '
+            'target_type is "role" or "member"; target_id is the role/user id. '
+            'allow and deny are arrays of permission ids (see list_permissions)',
+        _schema({
+          'channel_id': 'string',
+          'target_id': 'string',
+          'target_type': 'string',
+          'allow': 'array',
+          'deny': 'array',
+        }, [
+          'channel_id',
+          'target_id',
+          'target_type'
+        ]),
+        _setChannelPermission);
+    _register(
+        'delete_channel_permission',
+        'manage',
+        'Remove a channel permission overwrite for a role or member',
+        _schema({'channel_id': 'string', 'target_id': 'string'},
+            ['channel_id', 'target_id']),
+        _deleteChannelPermission);
 
     // ── voice ─────────────────────────────────────────────────────────────
     _register('join_voice_channel', 'voice', 'Join a voice channel',
@@ -367,6 +479,28 @@ class McpTools {
     if (!r.ok) return _restError(r);
     if (r.data is! AccordUser) return {'error': 'User not found: $id'};
     return {'ok': true, 'user': _userBrief(r.data as AccordUser)};
+  }
+
+  Future<Map<String, dynamic>> _listRoles(Map<String, dynamic> args) async {
+    final id = (args['space_id'] ?? '').toString();
+    if (id.isEmpty) return {'error': 'space_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.roles.list(id);
+    if (!r.ok) return _restError(r);
+    final roles = (r.data as List? ?? const []).whereType<AccordRole>();
+    return {'ok': true, 'roles': [for (final role in roles) _roleFull(role)]};
+  }
+
+  Future<Map<String, dynamic>> _listPermissions(
+      Map<String, dynamic> args) async {
+    return {
+      'ok': true,
+      'permissions': [
+        for (final p in AccordPermission.all())
+          {'id': p, 'description': AccordPermission.description(p)},
+      ],
+    };
   }
 
   // ── navigate handlers ───────────────────────────────────────────────────
@@ -545,6 +679,145 @@ class McpTools {
     return r.ok ? {'ok': true} : _restError(r);
   }
 
+  // ── manage handlers ───────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> _createRole(Map<String, dynamic> args) async {
+    final spaceId = (args['space_id'] ?? '').toString();
+    final name = (args['name'] ?? '').toString();
+    if (spaceId.isEmpty) return {'error': 'space_id is required'};
+    if (name.isEmpty) return {'error': 'name is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final data = <String, dynamic>{'name': name};
+    if (args.containsKey('color')) data['color'] = _asInt(args['color'], 0);
+    final perms = _permList(args['permissions']);
+    if (perms != null) data['permissions'] = perms;
+    if (args.containsKey('hoist')) data['hoist'] = _asBool(args['hoist']);
+    if (args.containsKey('mentionable')) {
+      data['mentionable'] = _asBool(args['mentionable']);
+    }
+    final r = await client.roles.create(spaceId, data);
+    if (!r.ok) return _restError(r);
+    return {
+      'ok': true,
+      if (r.data is AccordRole) 'role': _roleFull(r.data as AccordRole),
+    };
+  }
+
+  Future<Map<String, dynamic>> _updateRole(Map<String, dynamic> args) async {
+    final spaceId = (args['space_id'] ?? '').toString();
+    final roleId = (args['role_id'] ?? '').toString();
+    if (spaceId.isEmpty) return {'error': 'space_id is required'};
+    if (roleId.isEmpty) return {'error': 'role_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final data = <String, dynamic>{};
+    if (args.containsKey('name')) data['name'] = (args['name'] ?? '').toString();
+    if (args.containsKey('color')) data['color'] = _asInt(args['color'], 0);
+    final perms = _permList(args['permissions']);
+    if (perms != null) data['permissions'] = perms;
+    if (args.containsKey('position')) {
+      data['position'] = _asInt(args['position'], 0);
+    }
+    if (args.containsKey('hoist')) data['hoist'] = _asBool(args['hoist']);
+    if (args.containsKey('mentionable')) {
+      data['mentionable'] = _asBool(args['mentionable']);
+    }
+    if (data.isEmpty) return {'error': 'No fields to update'};
+    final r = await client.roles.update(spaceId, roleId, data);
+    if (!r.ok) return _restError(r);
+    return {
+      'ok': true,
+      if (r.data is AccordRole) 'role': _roleFull(r.data as AccordRole),
+    };
+  }
+
+  Future<Map<String, dynamic>> _deleteRole(Map<String, dynamic> args) async {
+    final spaceId = (args['space_id'] ?? '').toString();
+    final roleId = (args['role_id'] ?? '').toString();
+    if (spaceId.isEmpty) return {'error': 'space_id is required'};
+    if (roleId.isEmpty) return {'error': 'role_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.roles.delete(spaceId, roleId);
+    return r.ok ? {'ok': true} : _restError(r);
+  }
+
+  Future<Map<String, dynamic>> _addMemberRole(Map<String, dynamic> args) async {
+    final spaceId = (args['space_id'] ?? '').toString();
+    final userId = (args['user_id'] ?? '').toString();
+    final roleId = (args['role_id'] ?? '').toString();
+    if (spaceId.isEmpty) return {'error': 'space_id is required'};
+    if (userId.isEmpty) return {'error': 'user_id is required'};
+    if (roleId.isEmpty) return {'error': 'role_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.members.addRole(spaceId, userId, roleId);
+    return r.ok ? {'ok': true} : _restError(r);
+  }
+
+  Future<Map<String, dynamic>> _removeMemberRole(
+      Map<String, dynamic> args) async {
+    final spaceId = (args['space_id'] ?? '').toString();
+    final userId = (args['user_id'] ?? '').toString();
+    final roleId = (args['role_id'] ?? '').toString();
+    if (spaceId.isEmpty) return {'error': 'space_id is required'};
+    if (userId.isEmpty) return {'error': 'user_id is required'};
+    if (roleId.isEmpty) return {'error': 'role_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.members.removeRole(spaceId, userId, roleId);
+    return r.ok ? {'ok': true} : _restError(r);
+  }
+
+  Future<Map<String, dynamic>> _listChannelPermissions(
+      Map<String, dynamic> args) async {
+    final channelId = (args['channel_id'] ?? '').toString();
+    if (channelId.isEmpty) return {'error': 'channel_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.channels.listOverwrites(channelId);
+    if (!r.ok) return _restError(r);
+    final raw = r.data is List ? r.data as List : const [];
+    return {
+      'ok': true,
+      'overwrites': [for (final o in raw) _overwriteBrief(o)],
+    };
+  }
+
+  Future<Map<String, dynamic>> _setChannelPermission(
+      Map<String, dynamic> args) async {
+    final channelId = (args['channel_id'] ?? '').toString();
+    final targetId = (args['target_id'] ?? '').toString();
+    final type = (args['target_type'] ?? '').toString().toLowerCase();
+    if (channelId.isEmpty) return {'error': 'channel_id is required'};
+    if (targetId.isEmpty) return {'error': 'target_id is required'};
+    if (type != 'role' && type != 'member') {
+      return {'error': 'target_type must be "role" or "member"'};
+    }
+    final client = _client;
+    if (client == null) return _notConnected;
+    final data = <String, dynamic>{
+      'type': type,
+      'allow': _permList(args['allow']) ?? const <String>[],
+      'deny': _permList(args['deny']) ?? const <String>[],
+    };
+    final r = await client.channels.upsertOverwrite(channelId, targetId, data);
+    return r.ok ? {'ok': true} : _restError(r);
+  }
+
+  Future<Map<String, dynamic>> _deleteChannelPermission(
+      Map<String, dynamic> args) async {
+    final channelId = (args['channel_id'] ?? '').toString();
+    final targetId = (args['target_id'] ?? '').toString();
+    if (channelId.isEmpty) return {'error': 'channel_id is required'};
+    if (targetId.isEmpty) return {'error': 'target_id is required'};
+    final client = _client;
+    if (client == null) return _notConnected;
+    final r = await client.channels.deleteOverwrite(channelId, targetId);
+    return r.ok ? {'ok': true} : _restError(r);
+  }
+
   // ── voice handlers ────────────────────────────────────────────────────────
 
   Future<Map<String, dynamic>> _joinVoice(Map<String, dynamic> args) async {
@@ -660,6 +933,27 @@ class McpTools {
         'roles': m.roles,
       };
 
+  Map<String, dynamic> _roleFull(AccordRole r) => {
+        'id': r.id,
+        'name': r.name,
+        'color': r.color,
+        'hoist': r.hoist,
+        'position': r.position,
+        'permissions': [for (final p in r.permissions) p.toString()],
+        'managed': r.managed,
+        'mentionable': r.mentionable,
+      };
+
+  Map<String, dynamic> _overwriteBrief(Object? o) {
+    final m = o is Map ? o : const {};
+    return {
+      'id': (m['id'] ?? '').toString(),
+      'type': (m['type'] ?? 'role').toString(),
+      'allow': [for (final p in (m['allow'] as List? ?? const [])) p.toString()],
+      'deny': [for (final p in (m['deny'] as List? ?? const [])) p.toString()],
+    };
+  }
+
   Map<String, dynamic> _messageBrief(AccordMessage m) => {
         'id': m.id,
         'content': m.content,
@@ -684,5 +978,17 @@ class McpTools {
     if (v is int) return v;
     if (v is num) return v.toInt();
     return int.tryParse('$v') ?? fallback;
+  }
+
+  bool _asBool(Object? v) {
+    if (v is bool) return v;
+    return '$v'.toLowerCase() == 'true';
+  }
+
+  /// Coerces an arg into a list of permission id strings, or null when the
+  /// caller didn't supply a list (so the field is left untouched on update).
+  List<String>? _permList(Object? v) {
+    if (v is List) return [for (final e in v) e.toString()];
+    return null;
   }
 }

--- a/lib/features/developer/views/developer_settings_page.dart
+++ b/lib/features/developer/views/developer_settings_page.dart
@@ -24,6 +24,7 @@ class DeveloperSettingsPage extends ConsumerWidget {
     'navigate': 'Navigate (switch space/channel, open views)',
     'message': 'Message (send, edit, delete, react)',
     'moderate': 'Moderate (kick, ban, timeout)',
+    'manage': 'Manage (roles, permissions, member roles)',
     'voice': 'Voice (join, leave, mute, deafen)',
   };
 

--- a/lib/features/error_reporting/controllers/error_reporting.dart
+++ b/lib/features/error_reporting/controllers/error_reporting.dart
@@ -80,6 +80,22 @@ class ErrorReportingController extends _$ErrorReportingController {
     _client = created;
     _active = created;
     _installGlobalHooks();
+    // Navigation breadcrumbs: react to the persisted selection changing rather
+    // than having SettingsController push to us (that would form a dependency
+    // cycle, since we watch settings above). IDs are truncated before they
+    // leave the device.
+    ref.listen(settingsControllerProvider.select((s) => s.lastSpaceId), (
+      prev,
+      next,
+    ) {
+      if (next.isNotEmpty && next != prev) spaceSelected(next);
+    });
+    ref.listen(settingsControllerProvider.select((s) => s.lastChannelId), (
+      prev,
+      next,
+    ) {
+      if (next.isNotEmpty && next != prev) channelSelected(next);
+    });
     // If this provider is torn down (e.g. container disposal) the global
     // hooks must stop reporting through the dead client and its HTTP pool
     // must be released.

--- a/lib/features/events/utils/accord_event_handler.dart
+++ b/lib/features/events/utils/accord_event_handler.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:bonfire/features/channels/controllers/open_tabs.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/events/controllers/connection.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
@@ -194,11 +195,19 @@ VoidCallback handleAccordEvents(
     final spaceId = channel.spaceId;
     if (spaceId == null) {
       ref.read(dmChannelsControllerProvider.notifier).upsert(channel);
-      return;
+    } else {
+      container
+          .read(accordChannelsControllerProvider(spaceId).notifier)
+          .upsertChannel(channel);
     }
-    container
-        .read(accordChannelsControllerProvider(spaceId).notifier)
-        .upsertChannel(channel);
+    // Keep the open-tab strip's captured label in sync on rename; it renders
+    // OpenTab.name, which is otherwise only refreshed when the tab is reopened.
+    final name = channel.name;
+    if (name != null) {
+      ref
+          .read(openTabsControllerProvider.notifier)
+          .updateName('$serverKey ${channel.id}', name);
+    }
   }
 
   subs.add(client.onChannelCreate.listen(cacheChannel));

--- a/lib/features/member/controllers/accord_members.dart
+++ b/lib/features/member/controllers/accord_members.dart
@@ -14,6 +14,14 @@ part 'accord_members.g.dart';
 /// every space that happens to emit an event.
 final Set<String> activeMemberSpaces = <String>{};
 
+/// Upper bound on simultaneous `users.fetch` calls when backfilling the user
+/// objects a member page omits. The members endpoint returns only `user_id`, so
+/// a 100-member space would otherwise fan out 100 parallel requests on the first
+/// space switch, collide with the REST rate limiter (each then 429-retried with
+/// backoff), and stall the roster. A small pool keeps the requests flowing
+/// without tripping the limiter.
+const int _maxConcurrentUserFetches = 8;
+
 /// A space's members, keyed by space ID and indexed by user ID for O(1) author
 /// resolution. Self-loads via `members.list` the first time it's watched (once
 /// logged in) and is kept in sync by member join/update/leave gateway events.
@@ -36,8 +44,11 @@ class AccordMembersController extends _$AccordMembersController {
   }
 
   Future<void> _load(AccordClient client, String spaceId) async {
-    final result =
-        await client.members.list(spaceId, query: {'limit': 100});
+    // `withUser` asks the server to embed each member's user object, so
+    // `_resolveUsers` finds them already populated and skips the per-member
+    // fetch. Older servers ignore the flag; the fallback fetch still runs then.
+    final result = await client.members
+        .list(spaceId, query: {'limit': 100}, withUser: true);
     if (!result.ok) {
       debugPrint('Failed to load members for $spaceId: ${result.error}');
       return;
@@ -72,16 +83,28 @@ class AccordMembersController extends _$AccordMembersController {
       }
     }
 
-    await Future.wait(missing.map((userId) async {
-      final result = await client.users.fetch(userId);
-      final user = result.data;
-      if (result.ok && user is AccordUser) {
-        members[userId]?.user = user;
-        usersController.upsert(user);
-      } else if (!result.ok) {
-        debugPrint('Failed to fetch user $userId: ${result.error}');
+    // Drain the missing IDs through a bounded worker pool rather than firing
+    // them all at once. Dart's single isolate means `removeLast` and the member
+    // mutations below never race; the cap only limits in-flight requests.
+    final queue = List<String>.of(missing);
+    Future<void> worker() async {
+      while (queue.isNotEmpty) {
+        final userId = queue.removeLast();
+        final result = await client.users.fetch(userId);
+        final user = result.data;
+        if (result.ok && user is AccordUser) {
+          members[userId]?.user = user;
+          usersController.upsert(user);
+        } else if (!result.ok) {
+          debugPrint('Failed to fetch user $userId: ${result.error}');
+        }
       }
-    }));
+    }
+
+    final workerCount = missing.length < _maxConcurrentUserFetches
+        ? missing.length
+        : _maxConcurrentUserFetches;
+    await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
 
     // Replace the map identity so watchers rebuild with enriched members.
     if (state != null) state = {...members};

--- a/lib/features/messaging/components/box/accord_message_content.dart
+++ b/lib/features/messaging/components/box/accord_message_content.dart
@@ -56,7 +56,14 @@ class AccordMessageContent extends ConsumerWidget {
       );
     }
 
-    final members = ref.watch(accordMembersControllerProvider(id));
+    // The member roster is only consulted to resolve `@handle` mentions, and
+    // backfilling it fans out a fetch per member. Most messages contain no
+    // mention, so skip the load entirely unless this one does — that keeps a
+    // mention-free channel from triggering the roster fetch when the member
+    // sidebar (which loads it on its own) is collapsed.
+    final members = content.contains('@')
+        ? ref.watch(accordMembersControllerProvider(id))
+        : null;
     final space = ref.watch(
       spacesControllerProvider.select(
         (s) => s?.firstWhereOrNull((sp) => sp.id == id),

--- a/lib/features/settings/controllers/settings.dart
+++ b/lib/features/settings/controllers/settings.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/spaces/models/space_folder.dart';
-import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -198,18 +197,26 @@ class SettingsController extends _$SettingsController {
     ),
   );
 
-  /// Moves [spaceId] into [folderId] (appended), or out of all folders when
-  /// [folderId] is null. Empty folders left behind are pruned.
-  void moveSpaceToFolder(String spaceId, String? folderId) {
+  /// Moves [spaceId] into [folderId], or out of all folders when [folderId] is
+  /// null. Within the target folder it is inserted before [before] (when that
+  /// id is present) or appended otherwise — so this also reorders a space within
+  /// a folder. Empty folders left behind are pruned.
+  void moveSpaceToFolder(String spaceId, String? folderId, {String? before}) {
     final next = <SpaceFolder>[];
     for (final f in state.spaceFolders) {
-      final without = [
+      var ids = [
         for (final s in f.spaceIds)
           if (s != spaceId) s,
       ];
-      final updated = f.id == folderId
-          ? f.copyWith(spaceIds: [...without, spaceId])
-          : f.copyWith(spaceIds: without);
+      if (f.id == folderId) {
+        final at = before == null ? -1 : ids.indexOf(before);
+        if (at < 0) {
+          ids = [...ids, spaceId];
+        } else {
+          ids = [...ids.sublist(0, at), spaceId, ...ids.sublist(at)];
+        }
+      }
+      final updated = f.copyWith(spaceIds: ids);
       // Drop folders emptied by this move (but keep the target).
       if (updated.spaceIds.isNotEmpty || updated.id == folderId) {
         next.add(updated);
@@ -409,15 +416,6 @@ class SettingsController extends _$SettingsController {
   void setLastSelection(String spaceId, String channelId) {
     if (state.lastSpaceId == spaceId && state.lastChannelId == channelId) {
       return;
-    }
-    // Navigation breadcrumbs for opt-in error reporting (no-ops while
-    // disabled); IDs are truncated before they leave the device.
-    final errorReporting = ref.read(errorReportingControllerProvider.notifier);
-    if (spaceId.isNotEmpty && spaceId != state.lastSpaceId) {
-      errorReporting.spaceSelected(spaceId);
-    }
-    if (channelId.isNotEmpty && channelId != state.lastChannelId) {
-      errorReporting.channelSelected(channelId);
     }
     _update(state.copyWith(lastSpaceId: spaceId, lastChannelId: channelId));
   }

--- a/lib/features/settings/models/accord_settings.dart
+++ b/lib/features/settings/models/accord_settings.dart
@@ -34,6 +34,7 @@ class AccordSettings {
     'navigate',
     'message',
     'moderate',
+    'manage',
     'voice',
   ];
 

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -65,6 +65,8 @@ import 'package:bonfire/features/voice/views/voice_view.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -85,7 +87,11 @@ part 'accord_home_attachments.dart';
 /// The primary Accord screen: a three-pane view (space rail → channel list →
 /// message history) wired to the Accord controllers.
 class AccordHomeScreen extends ConsumerStatefulWidget {
-  const AccordHomeScreen({super.key});
+  const AccordHomeScreen({super.key, this.initialSpaceId});
+
+  /// A space to focus as soon as the screen mounts (e.g. when arriving from the
+  /// admin panel's "Open"). Takes precedence over the restored last selection.
+  final String? initialSpaceId;
 
   @override
   ConsumerState<AccordHomeScreen> createState() => _AccordHomeScreenState();
@@ -120,6 +126,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
   @override
   void initState() {
     super.initState();
+    _pendingOpenSpaceId = widget.initialSpaceId;
     mcpHomeBridge.registerAll(_mcpNavHandlers());
     // Passive, throttled startup update check (gated on the setting).
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -282,7 +289,9 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
             name: channel?.name ?? channelId,
           ),
         );
-    if (channel?.type != 'voice') _markChannelRead(channelId);
+    if (channel?.type != 'voice') {
+      _markChannelRead(channelId, fallbackMessageId: channel?.lastMessageId);
+    }
     setState(() => _pendingOpenSpaceId = null);
     ref
         .read(settingsControllerProvider.notifier)
@@ -308,7 +317,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
               name: channel.name ?? channel.id,
             ),
           );
-      _markChannelRead(channel.id);
+      _markChannelRead(channel.id, fallbackMessageId: channel.lastMessageId);
       ref
           .read(settingsControllerProvider.notifier)
           .setLastSelection(spaceId, channel.id);
@@ -319,10 +328,14 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
   }
 
   /// Marks [channelId] read locally and POSTs `channels.ack` with the latest
-  /// known message ID so the server's read position catches up too. Safe to
-  /// call when the channel has no cached messages (no last ID → ack is a
-  /// no-op; the local clear still happens).
-  void _markChannelRead(String channelId) {
+  /// known message ID so the server's read position catches up too. Prefers the
+  /// newest cached message; when the cache is empty it falls back to
+  /// [fallbackMessageId] (the channel's `last_message_id`). That fallback is
+  /// what clears a *phantom* unread: if the message that lit the channel was
+  /// since deleted, the cache loads empty but the server still lists the channel
+  /// in its READY `unread` array — without acking the channel's last_message_id
+  /// the badge would re-light on every cold start.
+  void _markChannelRead(String channelId, {String? fallbackMessageId}) {
     final activeKey = ref.read(connectionsControllerProvider).activeKey;
     if (activeKey != null) {
       ref
@@ -330,7 +343,8 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
           .markRead(channelId);
     }
     final messages = ref.read(accordMessagesControllerProvider(channelId));
-    final lastId = messages?.isNotEmpty == true ? messages!.last.id : null;
+    final lastId =
+        messages?.isNotEmpty == true ? messages!.last.id : fallbackMessageId;
     if (lastId == null) return;
     final client = ref.read(
       accordAuthProvider.select(

--- a/lib/features/spaces/views/accord_home_rail.dart
+++ b/lib/features/spaces/views/accord_home_rail.dart
@@ -95,20 +95,41 @@ class _SpaceRail extends ConsumerWidget {
         child: Divider(color: colors.darkGray, height: 2, thickness: 2),
       ),
     ];
+    // A drop zone for the track at [anchorId] (null = end of the list), so a
+    // space/folder can be inserted between items — including between a space and
+    // a folder — rather than only onto an icon.
+    Widget gapFor(String? anchorId) => _InsertionGap(
+      onDropSpace: (spaceId) =>
+          _dropSpaceBefore(settingsCtl, settings, globalOrder, spaceId, anchorId),
+      onDropFolder: (folderId) =>
+          _moveFolderBefore(settingsCtl, settings, globalOrder, folderId, anchorId),
+    );
+
     for (final unit in units) {
+      railItems.add(gapFor(_unitAnchor(unit)));
       if (unit.isFolder) {
         railItems.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: _FolderTile(
-              folder: unit.folder!,
-              spaces: unit.spaces,
-              connOf: connOf,
-              selectedSpaceId: selectedSpaceId,
-              onSelect: onSelect,
-              onDropSpace: (spaceId) =>
-                  settingsCtl.moveSpaceToFolder(spaceId, unit.folder!.id),
+          _FolderTile(
+            folder: unit.folder!,
+            spaces: unit.spaces,
+            connOf: connOf,
+            selectedSpaceId: selectedSpaceId,
+            onSelect: onSelect,
+            onDropSpace: (spaceId) =>
+                settingsCtl.moveSpaceToFolder(spaceId, unit.folder!.id),
+            onReorderFolderBefore: (folderId) => _moveFolderBefore(
+              settingsCtl,
+              settings,
+              globalOrder,
+              folderId,
+              unit.spaces.first.id,
             ),
+            onMemberDropBefore: (draggedId, targetMemberId) =>
+                settingsCtl.moveSpaceToFolder(
+                  draggedId,
+                  unit.folder!.id,
+                  before: targetMemberId,
+                ),
           ),
         );
       } else {
@@ -116,27 +137,33 @@ class _SpaceRail extends ConsumerWidget {
         final sc = connOf[space.id];
         final serverKey = sc?.serverKey ?? '';
         railItems.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: _DraggableSpace(
-              space: space,
-              cdnUrl: sc?.cdnUrl,
-              serverKey: serverKey,
-              selected: (sc?.active ?? false) && space.id == selectedSpaceId,
-              onTap: () => onSelect(serverKey, space.id),
-              onReorderBefore: (movedId) => _reorderBefore(
-                settingsCtl,
-                globalOrder,
-                movedId,
-                space.id,
-              ),
-              onMenu: (pos) =>
-                  _spaceMenu(context, ref, space, serverKey, pos),
+          _DraggableSpace(
+            space: space,
+            cdnUrl: sc?.cdnUrl,
+            serverKey: serverKey,
+            selected: (sc?.active ?? false) && space.id == selectedSpaceId,
+            onTap: () => onSelect(serverKey, space.id),
+            onDropSpaceBefore: (movedId) => _dropSpaceBefore(
+              settingsCtl,
+              settings,
+              globalOrder,
+              movedId,
+              space.id,
             ),
+            onDropFolderBefore: (folderId) => _moveFolderBefore(
+              settingsCtl,
+              settings,
+              globalOrder,
+              folderId,
+              space.id,
+            ),
+            onMenu: (pos) => _spaceMenu(context, ref, space, serverKey, pos),
           ),
         );
       }
     }
+    // Trailing gap so items can be dropped at the very end of the list.
+    railItems.add(gapFor(null));
 
     railItems.add(
       Padding(
@@ -252,24 +279,86 @@ class _SpaceRail extends ConsumerWidget {
     return units;
   }
 
+  /// The id used to anchor an insertion before [unit]: a standalone space's own
+  /// id, or a folder's first member (folders anchor at their first member's
+  /// position in [spaceOrder]).
+  String _unitAnchor(_RailUnit unit) =>
+      unit.isFolder ? unit.spaces.first.id : unit.space!.id;
+
   void _reorderBefore(
     SettingsController ctl,
     List<String> globalOrder,
     String movedId,
-    String targetId,
+    String? targetId,
   ) {
     if (movedId == targetId) return;
     final next = [
       for (final id in globalOrder)
         if (id != movedId) id,
     ];
-    final idx = next.indexOf(targetId);
+    final idx = targetId == null ? -1 : next.indexOf(targetId);
     if (idx < 0) {
       next.add(movedId);
     } else {
       next.insert(idx, movedId);
     }
     ctl.setSpaceOrder(next);
+  }
+
+  /// Drops [movedId] before [targetId] in the rail, first pulling it out of any
+  /// folder it belonged to (so a folder member dragged onto a rail space leaves
+  /// the folder and lands at that position).
+  void _dropSpaceBefore(
+    SettingsController ctl,
+    AccordSettings settings,
+    List<String> globalOrder,
+    String movedId,
+    String? targetId,
+  ) {
+    if (movedId == targetId) return;
+    final inFolder = settings.spaceFolders.any(
+      (f) => f.spaceIds.contains(movedId),
+    );
+    if (inFolder) ctl.moveSpaceToFolder(movedId, null);
+    _reorderBefore(ctl, globalOrder, movedId, targetId);
+  }
+
+  /// Reorders the whole folder [folderId] so it sits just before [anchorId] in
+  /// the rail. Folders anchor at their first member's position in [spaceOrder],
+  /// so this relocates the folder's member ids as a contiguous block.
+  void _moveFolderBefore(
+    SettingsController ctl,
+    AccordSettings settings,
+    List<String> globalOrder,
+    String folderId,
+    String? anchorId,
+  ) {
+    SpaceFolder? folder;
+    for (final f in settings.spaceFolders) {
+      if (f.id == folderId) {
+        folder = f;
+        break;
+      }
+    }
+    if (folder == null) return;
+    final inOrder = globalOrder.toSet();
+    final block = [
+      for (final id in folder.spaceIds)
+        if (inOrder.contains(id)) id,
+    ];
+    if (block.isEmpty || block.contains(anchorId)) return;
+    final blockSet = block.toSet();
+    final rest = [
+      for (final id in globalOrder)
+        if (!blockSet.contains(id)) id,
+    ];
+    final idx = anchorId == null ? -1 : rest.indexOf(anchorId);
+    if (idx < 0) {
+      rest.addAll(block);
+    } else {
+      rest.insertAll(idx, block);
+    }
+    ctl.setSpaceOrder(rest);
   }
 
   /// Context menu for a space (double-tap / right-click): server actions

--- a/lib/features/spaces/views/accord_home_rail_tiles.dart
+++ b/lib/features/spaces/views/accord_home_rail_tiles.dart
@@ -1,14 +1,115 @@
 part of 'accord_home.dart';
 
-/// A space icon that can be dragged (to reorder / into folders) and accepts a
-/// dropped space to reorder before itself.
+/// Payload carried while dragging a rail item, so a drop target can tell a
+/// space drag (reorder / move between folders) from a folder drag (reorder the
+/// whole folder) without overloading a bare id string.
+sealed class _RailDrag {
+  const _RailDrag();
+}
+
+class _SpaceDrag extends _RailDrag {
+  const _SpaceDrag(this.spaceId);
+  final String spaceId;
+}
+
+class _FolderDrag extends _RailDrag {
+  const _FolderDrag(this.folderId);
+  final String folderId;
+}
+
+/// Desktop pointers have no "long press" affordance and scroll via the wheel,
+/// so a drag should start immediately on click-drag. Touch platforms keep the
+/// long-press gesture so dragging doesn't fight finger-scrolling.
+bool get _immediateDrag => switch (defaultTargetPlatform) {
+  TargetPlatform.linux ||
+  TargetPlatform.macOS ||
+  TargetPlatform.windows => true,
+  _ => false,
+};
+
+/// Builds the platform-appropriate draggable for a rail item: an immediate
+/// [Draggable] on desktop, a [LongPressDraggable] on touch.
+Widget _railDraggable({
+  required _RailDrag data,
+  required Widget feedback,
+  required Widget childWhenDragging,
+  required Widget child,
+}) => _immediateDrag
+    ? Draggable<_RailDrag>(
+        data: data,
+        feedback: feedback,
+        childWhenDragging: childWhenDragging,
+        child: child,
+      )
+    : LongPressDraggable<_RailDrag>(
+        data: data,
+        feedback: feedback,
+        childWhenDragging: childWhenDragging,
+        child: child,
+      );
+
+/// A drop zone occupying the track between two rail items, so a space or folder
+/// can be inserted *at* that position (e.g. between a space and a folder)
+/// instead of only onto an icon. Grows and shows an insertion bar while a
+/// compatible drag hovers it.
+class _InsertionGap extends StatelessWidget {
+  const _InsertionGap({
+    required this.onDropSpace,
+    required this.onDropFolder,
+  });
+
+  /// A space [spaceId] was dropped in this gap: place it here as a standalone
+  /// rail entry (pulled out of any folder it was in).
+  final ValueChanged<String> onDropSpace;
+
+  /// A folder [folderId] was dropped in this gap: move the whole folder here.
+  final ValueChanged<String> onDropFolder;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return DragTarget<_RailDrag>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (d) {
+        switch (d.data) {
+          case _SpaceDrag(:final spaceId):
+            onDropSpace(spaceId);
+          case _FolderDrag(:final folderId):
+            onDropFolder(folderId);
+        }
+      },
+      builder: (context, candidate, _) {
+        final active = candidate.isNotEmpty;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: active ? 24 : 12,
+          alignment: Alignment.center,
+          child: active
+              ? Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colors.primary,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                )
+              : null,
+        );
+      },
+    );
+  }
+}
+
+/// A space icon that can be dragged (to reorder / into-or-out-of folders) and
+/// accepts a dropped space or folder to place it before itself in the rail.
 class _DraggableSpace extends StatefulWidget {
   const _DraggableSpace({
     required this.space,
     required this.cdnUrl,
     required this.selected,
     required this.onTap,
-    required this.onReorderBefore,
+    required this.onDropSpaceBefore,
+    required this.onDropFolderBefore,
     required this.onMenu,
     this.serverKey = '',
   });
@@ -17,7 +118,14 @@ class _DraggableSpace extends StatefulWidget {
   final String? cdnUrl;
   final bool selected;
   final VoidCallback onTap;
-  final ValueChanged<String> onReorderBefore;
+
+  /// A space [spaceId] was dropped on this tile: place it before this space
+  /// (pulling it out of any folder it was in).
+  final ValueChanged<String> onDropSpaceBefore;
+
+  /// A folder [folderId] was dropped on this tile: move the whole folder before
+  /// this space.
+  final ValueChanged<String> onDropFolderBefore;
   final void Function(Offset position) onMenu;
   final String serverKey;
 
@@ -39,13 +147,23 @@ class _DraggableSpaceState extends State<_DraggableSpace> {
       serverKey: widget.serverKey,
       onTap: widget.onTap,
     );
-    return DragTarget<String>(
-      onWillAcceptWithDetails: (d) => d.data != widget.space.id,
-      onAcceptWithDetails: (d) => widget.onReorderBefore(d.data),
+    return DragTarget<_RailDrag>(
+      onWillAcceptWithDetails: (d) => switch (d.data) {
+        _SpaceDrag(:final spaceId) => spaceId != widget.space.id,
+        _FolderDrag() => true,
+      },
+      onAcceptWithDetails: (d) {
+        switch (d.data) {
+          case _SpaceDrag(:final spaceId):
+            widget.onDropSpaceBefore(spaceId);
+          case _FolderDrag(:final folderId):
+            widget.onDropFolderBefore(folderId);
+        }
+      },
       builder: (context, candidate, _) => Opacity(
         opacity: candidate.isNotEmpty ? 0.5 : 1,
-        child: LongPressDraggable<String>(
-          data: widget.space.id,
+        child: _railDraggable(
+          data: _SpaceDrag(widget.space.id),
           feedback: Material(
             color: Colors.transparent,
             child: _SpaceIcon(
@@ -57,9 +175,9 @@ class _DraggableSpaceState extends State<_DraggableSpace> {
             ),
           ),
           childWhenDragging: Opacity(opacity: 0.3, child: icon),
-          // Long-press drives the drag (reorder / into-folder); the rail
-          // management menu (new folder, move/remove) opens on double-tap or
-          // right-click so it stays reachable on every platform.
+          // Drag drives the reorder / into-folder move; the rail management menu
+          // (new folder, move/remove) opens on double-tap or right-click so it
+          // stays reachable on every platform.
           child: GestureDetector(
             onDoubleTapDown: (d) => _lastTap = d.globalPosition,
             onDoubleTap: () => widget.onMenu(_lastTap),
@@ -72,9 +190,11 @@ class _DraggableSpaceState extends State<_DraggableSpace> {
   }
 }
 
-/// A collapsible folder tile in the rail. Tap toggles collapse; long-press opens
-/// the management menu; it accepts dropped spaces to add them.
-class _FolderTile extends ConsumerWidget {
+/// A collapsible folder tile in the rail. Tap toggles collapse; double-tap /
+/// right-click opens the management menu; long-press drags the folder to
+/// reorder it. It accepts dropped spaces (to add them) and dropped folders (to
+/// reorder before it).
+class _FolderTile extends ConsumerStatefulWidget {
   const _FolderTile({
     required this.folder,
     required this.spaces,
@@ -82,6 +202,8 @@ class _FolderTile extends ConsumerWidget {
     required this.selectedSpaceId,
     required this.onSelect,
     required this.onDropSpace,
+    required this.onReorderFolderBefore,
+    required this.onMemberDropBefore,
   });
 
   final SpaceFolder folder;
@@ -92,75 +214,116 @@ class _FolderTile extends ConsumerWidget {
   final Map<String, _SpaceConn> connOf;
   final String? selectedSpaceId;
   final void Function(String serverKey, String spaceId) onSelect;
+
+  /// A space [spaceId] was dropped on the folder tile: add it to this folder.
   final ValueChanged<String> onDropSpace;
 
+  /// A folder [folderId] was dropped on this folder tile: move that folder
+  /// before this one.
+  final ValueChanged<String> onReorderFolderBefore;
+
+  /// A space [draggedSpaceId] was dropped on member [targetMemberId]: place it
+  /// in this folder before that member (reorder within, or move in positioned).
+  final void Function(String draggedSpaceId, String targetMemberId)
+  onMemberDropBefore;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_FolderTile> createState() => _FolderTileState();
+}
+
+class _FolderTileState extends ConsumerState<_FolderTile> {
+  // Captured on the down event so the double-tap menu can anchor where the
+  // user clicked (onDoubleTap itself carries no position).
+  Offset _lastTap = Offset.zero;
+
+  SpaceFolder get folder => widget.folder;
+  List<AccordSpace> get spaces => widget.spaces;
+
+  @override
+  Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
     final ctl = ref.read(settingsControllerProvider.notifier);
     final folderColor = folder.color != null
         ? Color(folder.color!)
         : colors.darkGray;
 
-    return DragTarget<String>(
-      onWillAcceptWithDetails: (d) => !folder.spaceIds.contains(d.data),
-      onAcceptWithDetails: (d) => onDropSpace(d.data),
-      builder: (context, candidate, _) {
-        final highlight = candidate.isNotEmpty;
-        return Column(
-          children: [
-            Center(
-              child: GestureDetector(
-                onTap: () =>
-                    ctl.setFolderCollapsed(folder.id, !folder.collapsed),
-                onLongPressStart: (d) =>
-                    _folderMenu(context, ref, d.globalPosition),
-                onSecondaryTapUp: (d) =>
-                    _folderMenu(context, ref, d.globalPosition),
-                child: Tooltip(
-                  message: folder.name.isEmpty ? 'Folder' : folder.name,
+    final folderIcon = Tooltip(
+      message: folder.name.isEmpty ? 'Folder' : folder.name,
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: folderColor.withValues(alpha: 0.5),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          folder.collapsed ? Icons.folder : Icons.folder_open,
+          color: colors.dirtyWhite,
+        ),
+      ),
+    );
+
+    return Column(
+      children: [
+        Center(
+          child: DragTarget<_RailDrag>(
+            onWillAcceptWithDetails: (d) => switch (d.data) {
+              _SpaceDrag(:final spaceId) => !folder.spaceIds.contains(spaceId),
+              _FolderDrag(:final folderId) => folderId != folder.id,
+            },
+            onAcceptWithDetails: (d) {
+              switch (d.data) {
+                case _SpaceDrag(:final spaceId):
+                  widget.onDropSpace(spaceId);
+                case _FolderDrag(:final folderId):
+                  widget.onReorderFolderBefore(folderId);
+              }
+            },
+            builder: (context, candidate, _) {
+              final highlight = candidate.isNotEmpty;
+              return _railDraggable(
+                data: _FolderDrag(folder.id),
+                feedback: Material(color: Colors.transparent, child: folderIcon),
+                childWhenDragging: Opacity(opacity: 0.3, child: folderIcon),
+                child: GestureDetector(
+                  onTap: () =>
+                      ctl.setFolderCollapsed(folder.id, !folder.collapsed),
+                  onDoubleTapDown: (d) => _lastTap = d.globalPosition,
+                  onDoubleTap: () => _folderMenu(context, ref, _lastTap),
+                  onSecondaryTapUp: (d) =>
+                      _folderMenu(context, ref, d.globalPosition),
                   child: Container(
-                    width: 48,
-                    height: 48,
                     decoration: BoxDecoration(
-                      color: folderColor.withValues(alpha: highlight ? 1 : 0.5),
                       borderRadius: BorderRadius.circular(16),
                       border: highlight
                           ? Border.all(color: colors.primary, width: 2)
                           : null,
                     ),
-                    alignment: Alignment.center,
-                    child: Icon(
-                      folder.collapsed ? Icons.folder : Icons.folder_open,
-                      color: colors.dirtyWhite,
-                    ),
+                    child: folderIcon,
                   ),
                 ),
+              );
+            },
+          ),
+        ),
+        if (!folder.collapsed)
+          for (final space in spaces)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: _FolderMemberTile(
+                space: space,
+                conn: widget.connOf[space.id],
+                selected: (widget.connOf[space.id]?.active ?? false) &&
+                    space.id == widget.selectedSpaceId,
+                onTap: () =>
+                    widget.onSelect(widget.connOf[space.id]?.serverKey ?? '', space.id),
+                onDropBefore: (draggedId) =>
+                    widget.onMemberDropBefore(draggedId, space.id),
+                onMenu: (pos) => _memberMenu(context, ref, ctl, space, pos),
               ),
             ),
-            if (!folder.collapsed)
-              for (final space in spaces)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: GestureDetector(
-                    onLongPressStart: (d) =>
-                        _memberMenu(context, ref, ctl, space, d.globalPosition),
-                    onSecondaryTapUp: (d) =>
-                        _memberMenu(context, ref, ctl, space, d.globalPosition),
-                    child: _SpaceIcon(
-                      space: space,
-                      selected: (connOf[space.id]?.active ?? false) &&
-                          space.id == selectedSpaceId,
-                      cdnUrl: connOf[space.id]?.cdnUrl,
-                      serverKey: connOf[space.id]?.serverKey ?? '',
-                      onTap: () =>
-                          onSelect(connOf[space.id]?.serverKey ?? '', space.id),
-                    ),
-                  ),
-                ),
-          ],
-        );
-      },
+      ],
     );
   }
 
@@ -176,7 +339,7 @@ class _FolderTile extends ConsumerWidget {
         context,
         ref,
         space,
-        connOf[space.id]?.serverKey ?? '',
+        widget.connOf[space.id]?.serverKey ?? '',
       ),
       AccordMenuEntry(
         label: 'Remove "${space.name}" from folder',
@@ -294,6 +457,82 @@ class _FolderTile extends ConsumerWidget {
                 ),
               ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A space icon shown inside an expanded folder. Like [_DraggableSpace] but its
+/// drops are scoped to the folder: dragging it out onto a rail space pulls it
+/// from the folder, and a space dropped on it lands before it within the folder.
+class _FolderMemberTile extends StatefulWidget {
+  const _FolderMemberTile({
+    required this.space,
+    required this.conn,
+    required this.selected,
+    required this.onTap,
+    required this.onDropBefore,
+    required this.onMenu,
+  });
+
+  final AccordSpace space;
+  final _SpaceConn? conn;
+  final bool selected;
+  final VoidCallback onTap;
+
+  /// A space [draggedSpaceId] was dropped on this member: place it before this
+  /// member within the folder.
+  final ValueChanged<String> onDropBefore;
+  final void Function(Offset position) onMenu;
+
+  @override
+  State<_FolderMemberTile> createState() => _FolderMemberTileState();
+}
+
+class _FolderMemberTileState extends State<_FolderMemberTile> {
+  Offset _lastTap = Offset.zero;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = _SpaceIcon(
+      space: widget.space,
+      selected: widget.selected,
+      cdnUrl: widget.conn?.cdnUrl,
+      serverKey: widget.conn?.serverKey ?? '',
+      onTap: widget.onTap,
+    );
+    return DragTarget<_RailDrag>(
+      onWillAcceptWithDetails: (d) => switch (d.data) {
+        _SpaceDrag(:final spaceId) => spaceId != widget.space.id,
+        _FolderDrag() => false,
+      },
+      onAcceptWithDetails: (d) {
+        if (d.data case _SpaceDrag(:final spaceId)) {
+          widget.onDropBefore(spaceId);
+        }
+      },
+      builder: (context, candidate, _) => Opacity(
+        opacity: candidate.isNotEmpty ? 0.5 : 1,
+        child: _railDraggable(
+          data: _SpaceDrag(widget.space.id),
+          feedback: Material(
+            color: Colors.transparent,
+            child: _SpaceIcon(
+              space: widget.space,
+              selected: false,
+              cdnUrl: widget.conn?.cdnUrl,
+              serverKey: widget.conn?.serverKey ?? '',
+              onTap: () {},
+            ),
+          ),
+          childWhenDragging: Opacity(opacity: 0.3, child: icon),
+          child: GestureDetector(
+            onDoubleTapDown: (d) => _lastTap = d.globalPosition,
+            onDoubleTap: () => widget.onMenu(_lastTap),
+            onSecondaryTapUp: (d) => widget.onMenu(d.globalPosition),
+            child: icon,
+          ),
         ),
       ),
     );

--- a/lib/features/spaces/views/accord_space_settings.dart
+++ b/lib/features/spaces/views/accord_space_settings.dart
@@ -14,6 +14,7 @@ import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/features/spaces/views/accord_role_management.dart';
 import 'package:bonfire/features/spaces/views/accord_soundboard.dart';
 import 'package:bonfire/features/spaces/views/accord_transfer_ownership.dart';
+import 'package:bonfire/shared/components/image_crop_dialog.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
@@ -205,8 +206,15 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
       withData: true,
     );
     final file = picked?.files.firstOrNull;
-    if (file?.bytes == null) return;
-    final dataUri = AccordCDN.buildDataUri(file!.bytes!, file.name);
+    if (file?.bytes == null || !mounted) return;
+    final cropped = await showImageCropDialog(
+      context,
+      imageBytes: file!.bytes!,
+      aspectRatio: 16 / 9,
+      title: 'Crop banner',
+    );
+    if (cropped == null) return;
+    final dataUri = AccordCDN.buildDataUri(cropped, 'banner.png');
     await _update({'banner': dataUri}, 'Failed to update banner');
   }
 
@@ -219,9 +227,17 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
       withData: true,
     );
     final file = picked?.files.firstOrNull;
-    if (file?.bytes == null) return;
+    if (file?.bytes == null || !mounted) return;
+    final cropped = await showImageCropDialog(
+      context,
+      imageBytes: file!.bytes!,
+      aspectRatio: 1,
+      circular: true,
+      title: 'Crop icon',
+    );
+    if (cropped == null) return;
     setState(() {
-      _pendingIconDataUri = AccordCDN.buildDataUri(file!.bytes!, file.name);
+      _pendingIconDataUri = AccordCDN.buildDataUri(cropped, 'icon.png');
       _iconRemoved = false;
     });
   }

--- a/lib/features/user/views/accord_profile_edit.dart
+++ b/lib/features/user/views/accord_profile_edit.dart
@@ -8,6 +8,7 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/shared/components/image_crop_dialog.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:file_picker/file_picker.dart';
@@ -140,10 +141,18 @@ class _ProfileEditState extends ConsumerState<_ProfileEdit> {
       withData: true,
     );
     final file = picked?.files.firstOrNull;
-    if (file?.bytes == null) return;
+    if (file?.bytes == null || !mounted) return;
+    final cropped = await showImageCropDialog(
+      context,
+      imageBytes: file!.bytes!,
+      aspectRatio: 1,
+      circular: true,
+      title: 'Crop avatar',
+    );
+    if (cropped == null) return;
     setState(() {
-      _newAvatarBytes = file!.bytes!;
-      _newAvatarFilename = file.name;
+      _newAvatarBytes = cropped;
+      _newAvatarFilename = 'avatar.png';
       // An uploaded image hides the colored fallback, so reset the picker to
       // transparent — the chosen color only applies to imageless avatars.
       _accentColor = null;

--- a/lib/router/controller.dart
+++ b/lib/router/controller.dart
@@ -42,7 +42,9 @@ final routerController = GoRouter(
               ),
               GoRoute(
                 path: 'spaces',
-                builder: (context, state) => const AccordHomeScreen(),
+                builder: (context, state) => AccordHomeScreen(
+                  initialSpaceId: state.uri.queryParameters['space'],
+                ),
               ),
               GoRoute(
                 path: 'settings',

--- a/lib/shared/components/image_crop_dialog.dart
+++ b/lib/shared/components/image_crop_dialog.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:bonfire/theme/theme.dart';
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:flutter/material.dart';
+
+/// Modal that lets the user pan (x/y) and zoom an image inside a fixed-aspect
+/// frame, then returns the cropped bytes (PNG). Mirrors the reposition+zoom
+/// flow Discord uses for server icons/banners and user avatars.
+///
+/// The crop rect is fixed at [aspectRatio]; the user moves the image behind it.
+/// [circular] only changes the mask shape — the output is always rectangular
+/// (square when [aspectRatio] is 1), since icons/avatars are rounded at display
+/// time. Returns null if the user cancels.
+Future<Uint8List?> showImageCropDialog(
+  BuildContext context, {
+  required Uint8List imageBytes,
+  required double aspectRatio,
+  bool circular = false,
+  String title = 'Edit image',
+}) {
+  return showDialog<Uint8List?>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => _ImageCropDialog(
+      imageBytes: imageBytes,
+      aspectRatio: aspectRatio,
+      circular: circular,
+      title: title,
+    ),
+  );
+}
+
+class _ImageCropDialog extends StatefulWidget {
+  const _ImageCropDialog({
+    required this.imageBytes,
+    required this.aspectRatio,
+    required this.circular,
+    required this.title,
+  });
+
+  final Uint8List imageBytes;
+  final double aspectRatio;
+  final bool circular;
+  final String title;
+
+  @override
+  State<_ImageCropDialog> createState() => _ImageCropDialogState();
+}
+
+class _ImageCropDialogState extends State<_ImageCropDialog> {
+  final _controller = CropController();
+  bool _busy = false;
+
+  void _apply() {
+    if (_busy) return;
+    setState(() => _busy = true);
+    _controller.crop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Dialog(
+      backgroundColor: colors.foreground,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480, maxHeight: 580),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(widget.title, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 12),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Crop(
+                    image: widget.imageBytes,
+                    controller: _controller,
+                    aspectRatio: widget.aspectRatio,
+                    withCircleUi: widget.circular,
+                    interactive: true,
+                    fixCropRect: true,
+                    initialRectBuilder: InitialRectBuilder.withSizeAndRatio(
+                      size: 1,
+                      aspectRatio: widget.aspectRatio,
+                    ),
+                    baseColor: colors.background,
+                    maskColor: Colors.black.withValues(alpha: 0.55),
+                    radius: widget.circular ? 0 : 6,
+                    cornerDotBuilder: (_, _) => const SizedBox.shrink(),
+                    onCropped: (result) {
+                      if (!mounted) return;
+                      switch (result) {
+                        case CropSuccess(:final croppedImage):
+                          Navigator.of(context).pop(croppedImage);
+                        case CropFailure():
+                          setState(() => _busy = false);
+                      }
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Drag to reposition · scroll or pinch to zoom',
+                style: theme.textTheme.bodySmall!.copyWith(color: colors.gray),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: _busy
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _busy ? null : _apply,
+                    child: _busy
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Apply'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/accordkit/lib/src/rest/endpoints/members_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/members_api.dart
@@ -6,11 +6,14 @@ import '../rest_result.dart';
 class MembersApi extends EndpointBase {
   MembersApi(super.rest);
 
-  /// Lists members of a space. Supports `limit`/`after`.
+  /// Lists members of a space. Supports `limit`/`after`. When [withUser] is
+  /// true, the server embeds each member's public `user` object (resolved in a
+  /// single batched query), so callers can skip the per-member user fetch.
   Future<RestResult> list(String spaceId,
-      {Map<String, dynamic> query = const {}}) async {
+      {Map<String, dynamic> query = const {}, bool withUser = false}) async {
+    final q = withUser ? {...query, 'with_user': true} : query;
     final result =
-        await rest.makeRequest('GET', '/spaces/$spaceId/members', query: query);
+        await rest.makeRequest('GET', '/spaces/$spaceId/members', query: q);
     return result.deserializeArray(AccordMember.fromJson);
   }
 

--- a/packages/accordkit/test/endpoints_test.dart
+++ b/packages/accordkit/test/endpoints_test.dart
@@ -141,6 +141,20 @@ void main() {
   });
 
   group('MembersApi', () {
+    test('list with withUser sets with_user query', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await MembersApi(rest).list('7', query: {'limit': 100}, withUser: true);
+      expect(req.url.path, '/api/v1/spaces/7/members');
+      expect(req.url.queryParameters['limit'], '100');
+      expect(req.url.queryParameters['with_user'], 'true');
+    });
+
+    test('list omits with_user by default', () async {
+      rest = mockRest(log: log, responder: (_) => jsonData([]));
+      await MembersApi(rest).list('7');
+      expect(req.url.queryParameters.containsKey('with_user'), isFalse);
+    });
+
     test('leaveMe with deleteData sets query', () async {
       rest = mockRest(log: log, responder: (_) => jsonData(null));
       await MembersApi(rest).leaveMe('7', deleteData: true);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -344,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  crop_your_image:
+    dependency: "direct main"
+    description:
+      name: crop_your_image
+      sha256: "14c8977b11a009dc5e73e0f6522970f93363e38183f1b2ffefe1676dc9c3f49d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   cross_file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,7 @@ dependencies:
   # in-place binary swap. Pure Dart, used only by features/updates. Pinned to the
   # already-resolved transitive version to avoid a version-solve conflict.
   archive: ^3.6.1
+  crop_your_image: ^2.0.0
 
 dependency_overrides:
   http: ^1.2.1

--- a/test/features/developer/mcp_tools_test.dart
+++ b/test/features/developer/mcp_tools_test.dart
@@ -1,0 +1,213 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/developer/services/mcp_tools.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A Provider that exposes a McpTools backed by a real ProviderContainer Ref.
+/// Handlers that call the network will return {'error': 'Not connected'} because
+/// no AccordAuthLoggedIn state is present; pure handlers work without setup.
+final _toolsProvider = Provider<McpTools>((ref) => McpTools(ref));
+
+void main() {
+  late ProviderContainer container;
+  late McpTools tools;
+
+  setUp(() {
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+    tools = container.read(_toolsProvider);
+  });
+
+  // ── tool registration ────────────────────────────────────────────────────
+
+  group('tool registration', () {
+    test('list_roles is registered in the read group', () {
+      final t = tools.tools['list_roles'];
+      expect(t, isNotNull);
+      expect(t!.group, 'read');
+    });
+
+    test('list_permissions is registered in the read group', () {
+      final t = tools.tools['list_permissions'];
+      expect(t, isNotNull);
+      expect(t!.group, 'read');
+    });
+
+    test('create_role is registered in the manage group', () {
+      final t = tools.tools['create_role'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('update_role is registered in the manage group', () {
+      final t = tools.tools['update_role'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('delete_role is registered in the manage group', () {
+      final t = tools.tools['delete_role'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('add_member_role is registered in the manage group', () {
+      final t = tools.tools['add_member_role'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('remove_member_role is registered in the manage group', () {
+      final t = tools.tools['remove_member_role'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('list_channel_permissions is registered in the manage group', () {
+      final t = tools.tools['list_channel_permissions'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('set_channel_permission is registered in the manage group', () {
+      final t = tools.tools['set_channel_permission'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('delete_channel_permission is registered in the manage group', () {
+      final t = tools.tools['delete_channel_permission'];
+      expect(t, isNotNull);
+      expect(t!.group, 'manage');
+    });
+
+    test('list_roles schema requires space_id', () {
+      final schema = tools.tools['list_roles']!.inputSchema;
+      expect((schema['required'] as List), contains('space_id'));
+    });
+
+    test('set_channel_permission schema requires channel_id, target_id, target_type', () {
+      final schema = tools.tools['set_channel_permission']!.inputSchema;
+      final required = schema['required'] as List;
+      expect(required, containsAll(['channel_id', 'target_id', 'target_type']));
+    });
+  });
+
+  // ── list_permissions handler ──────────────────────────────────────────────
+
+  group('list_permissions', () {
+    late Map<String, dynamic> result;
+
+    setUp(() async {
+      result = await tools.tools['list_permissions']!.handler({});
+    });
+
+    test('returns ok: true', () {
+      expect(result['ok'], isTrue);
+    });
+
+    test('returns a non-empty permissions list', () {
+      final perms = result['permissions'] as List;
+      expect(perms, isNotEmpty);
+    });
+
+    test('every entry has an id and description', () {
+      final perms = result['permissions'] as List;
+      for (final p in perms) {
+        final m = p as Map;
+        expect(m['id'], isA<String>());
+        expect((m['id'] as String), isNotEmpty);
+        expect(m['description'], isA<String>());
+        expect((m['description'] as String), isNotEmpty);
+      }
+    });
+
+    test('includes known permissions', () {
+      final perms = result['permissions'] as List;
+      final ids = perms.map((p) => (p as Map)['id'] as String).toSet();
+      expect(ids, containsAll([
+        AccordPermission.administrator,
+        AccordPermission.sendMessages,
+        AccordPermission.manageRoles,
+        AccordPermission.viewChannel,
+      ]));
+    });
+
+    test('count matches AccordPermission.all()', () {
+      final perms = result['permissions'] as List;
+      expect(perms.length, AccordPermission.all().length);
+    });
+  });
+
+  // ── update_role validation ────────────────────────────────────────────────
+
+  group('update_role validation', () {
+    test('returns error when name is empty string', () async {
+      final result = await tools.tools['update_role']!.handler({
+        'space_id': 'space-1',
+        'role_id': 'role-1',
+        'name': '',
+      });
+      expect(result['error'], contains('empty'));
+      expect(result.containsKey('ok'), isFalse);
+    });
+
+    test('returns not-connected when no fields to update', () async {
+      // With no optional fields, returns 'No fields to update' before
+      // touching the client.
+      final result = await tools.tools['update_role']!.handler({
+        'space_id': 'space-1',
+        'role_id': 'role-1',
+      });
+      expect(result['error'], 'No fields to update');
+    });
+  });
+
+  // ── set_channel_permission validation ────────────────────────────────────
+
+  group('set_channel_permission', () {
+    test('rejects invalid target_type', () async {
+      final result = await tools.tools['set_channel_permission']!.handler({
+        'channel_id': 'chan-1',
+        'target_id': 'target-1',
+        'target_type': 'user',
+      });
+      expect(result['error'], contains('"role" or "member"'));
+    });
+
+    test('rejects empty target_type', () async {
+      final result = await tools.tools['set_channel_permission']!.handler({
+        'channel_id': 'chan-1',
+        'target_id': 'target-1',
+        'target_type': '',
+      });
+      expect(result['error'], isNotNull);
+    });
+  });
+
+  // ── manage tools return not-connected without a client ───────────────────
+
+  group('network tools without a client', () {
+    for (final toolName in [
+      'list_roles',
+      'create_role',
+      'delete_role',
+      'add_member_role',
+      'remove_member_role',
+      'list_channel_permissions',
+      'delete_channel_permission',
+    ]) {
+      test('$toolName returns not-connected', () async {
+        final args = <String, dynamic>{
+          'space_id': 's',
+          'role_id': 'r',
+          'user_id': 'u',
+          'channel_id': 'c',
+          'target_id': 't',
+        };
+        final result = await tools.tools[toolName]!.handler(args);
+        expect(result['error'], 'Not connected');
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Bundles the current in-flight working-tree changes across the client and accordkit.

### MCP / developer tooling
- **Permission management tools** in the in-app MCP client (`mcp_tools.dart`):
  - Read: `list_roles`, `list_permissions` (local enum of valid permission ids + descriptions)
  - Manage (privileged, off by default like `moderate`): `create_role`, `update_role`, `delete_role`, `add_member_role`, `remove_member_role`, and per-channel overwrites `list_channel_permissions` / `set_channel_permission` / `delete_channel_permission`
  - Surfaces the new `manage` permission group in settings + the developer settings page
  - Includes follow-up review fixes (reject empty-name `update_role`) and `mcp_tools` tests

### Member roster loading
- `members.list` gains a `withUser` flag — the server embeds each member's `user` object in one batched query, so the controller skips the per-member fetch. Older servers ignore the flag and fall back to a **bounded-concurrency (8)** user backfill instead of one request per member.
- Message rendering only loads the roster when the message actually contains a mention.

### Space rail
- Drag-reorder with insertion gaps between items; reorder spaces within and across folders. `moveSpaceToFolder` gains a `before` anchor for precise placement.

### Image cropping
- New shared `showImageCropDialog` (`crop_your_image`) with a pan/zoom frame, wired into avatar (circular 1:1), space icon, and banner (16:9) editing.

### Admin
- Open a space directly in the rail via `/spaces?space=<id>` using the admin's own connection, rather than a public member-join.

### Misc
- Error reporting: navigation breadcrumbs driven off persisted space/channel selection (avoids a settings→reporting dependency cycle).
- Open-tab strip: keep a tab's captured label in sync on channel rename.

## Test plan
- `flutter analyze --no-fatal-infos` clean on touched files
- `dart test` in `packages/accordkit` (members `withUser` endpoint test added)
- `mcp_tools` tests added for the new permission tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)