### PR TITLE
ci: speed up CI by gating PRs on analyze/test only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,14 @@ name: CI
 # Continuous integration for the Daccord Flutter client.
 #
 # - `analyze`  : code generation + static analysis + unit tests (the gate).
+#                Runs on every push/PR — this is what blocks merges.
 # - `build`    : release builds for web / Android / Linux / Windows, uploaded
-#                as artifacts so any commit can be smoke-tested by hand.
+#                as artifacts. Only runs on manual `workflow_dispatch` — PRs
+#                don't need four release builds to merge, and tagged releases
+#                build every platform themselves in release.yml.
 #
 # This workflow is also `workflow_call`-able so the Release workflow can reuse
-# it as a pre-release gate (see release.yml).
+# the analyze/test gate (see release.yml).
 
 on:
   push:
@@ -17,14 +20,6 @@ on:
       - "**"
   pull_request:
   workflow_call:
-    inputs:
-      skip_build:
-        description: >-
-          Skip the per-platform build matrix and run only analyze/test.
-          release.yml sets this true because it builds every platform itself,
-          so there's no point building everything twice on the release path.
-        type: boolean
-        default: false
   workflow_dispatch:
 
 concurrency:
@@ -86,9 +81,9 @@ jobs:
   build:
     name: Build ${{ matrix.name }}
     needs: analyze
-    # On normal push/PR/dispatch, inputs.skip_build is null (falsy) so the
-    # matrix runs. release.yml passes skip_build: true to gate on tests only.
-    if: ${{ !inputs.skip_build }}
+    # Smoke-test artifacts only — run on demand, never automatically on push/PR
+    # (analyze is the merge gate) or workflow_call (release.yml builds its own).
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -192,9 +187,9 @@ jobs:
           build_once() {
             case "${{ matrix.platform }}" in
               web)     flutter build web     --no-tree-shake-icons --release ;;
-              android) flutter build apk     --no-tree-shake-icons -v ;;
-              linux)   flutter build linux   -v ;;
-              windows) flutter build windows -v ;;
+              android) flutter build apk     --no-tree-shake-icons ;;
+              linux)   flutter build linux ;;
+              windows) flutter build windows ;;
             esac
           }
           n=0; max=3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,9 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
-    # Test gate only — the build job below builds every platform, so running
-    # CI's build matrix here too would just compile everything twice.
-    with:
-      skip_build: true
+    # Runs the analyze/test gate. CI's build matrix only runs on
+    # workflow_dispatch, so calling it here gates on tests without
+    # double-building every platform.
     secrets: inherit
 
   build:


### PR DESCRIPTION
## Summary

CI was slow because the `build` job compiled release binaries for **all four platforms** (Web, Android, Linux, Windows) on every push and PR. Each of those runners independently repeated the checkout → `pub get` → `build_runner` codegen that the `analyze` job already did, so a single CI run did ~5 Flutter setups + 4 release builds.

The release builds are smoke-test artifacts, not the merge gate (`analyze` is). This change restricts them to run only on demand.

## What changed

- **`ci.yml`** — the `build` job now runs only on manual `workflow_dispatch` (`if: github.event_name == 'workflow_dispatch'`). PRs and pushes now run just the `analyze` (codegen + analyze + test) gate.
- **`ci.yml`** — removed the now-unused `skip_build` `workflow_call` input.
- **`ci.yml`** — dropped `-v` verbose flags from the Android/Linux/Windows smoke builds (faster log streaming, no functional change).
- **`release.yml`** — dropped the defunct `with: skip_build: true` from its `ci.yml` call. Tagged releases still gate on analyze/test and build every platform via their own matrix (unchanged).

## Net effect

- PR/push CI drops from ~5 Flutter setups + 4 release builds to a single analyze/test job.
- Tagged releases are unaffected (release.yml builds all platforms itself).
- On-demand smoke builds remain available via the Actions "Run workflow" button.

## Reviewer notes

- No application code touched — workflow files only.
- `grep` confirms no remaining references to `skip_build` or `inputs.` in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)