### PR TITLE
feat(android): survive backgrounding — reconnect on resume + optional foreground service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,8 +7,19 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />. <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission
         android:name="android.permission.VIBRATE" />
+    <!-- Android 13+: runtime permission to post notifications (mentions and
+         the background-connection service's status notification). -->
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Background connection: a dataSync foreground service keeps the process
+         (and so the gateway socket) alive while the app is backgrounded. -->
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
 
     <uses-feature
@@ -72,6 +83,13 @@
                 <data android:scheme="daccord" />
             </intent-filter>
         </activity>
+        <!-- Optional (settings-gated) foreground service that keeps the app
+             process out of the cached-app freezer while backgrounded, so the
+             gateway connection and mention notifications keep working. -->
+        <service
+            android:name=".BackgroundConnectionService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/com/daccord_projects/daccord/BackgroundConnectionService.kt
+++ b/android/app/src/main/kotlin/com/daccord_projects/daccord/BackgroundConnectionService.kt
@@ -1,0 +1,93 @@
+package com.daccord_projects.daccord
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+
+/// Foreground service behind the "Background connection" setting. It runs no
+/// logic of its own: holding a foreground service exempts the whole app
+/// process from Android's cached-app freezer and Doze network cutoffs, so the
+/// Dart isolate's gateway socket keeps receiving messages and posting mention
+/// notifications while the app is backgrounded. Started/stopped over the
+/// `com.daccord.app/background_connection` channel (see MainActivity).
+class BackgroundConnectionService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startInForeground()
+        return START_STICKY
+    }
+
+    private fun startInForeground() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Background connection",
+                // MIN keeps the persistent notification silent and collapsed.
+                NotificationManager.IMPORTANCE_MIN,
+            ).apply {
+                description =
+                    "Keeps Daccord connected while the app is in the background."
+                setShowBadge(false)
+            }
+            (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .createNotificationChannel(channel)
+        }
+
+        val openApp = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Daccord is connected")
+            .setContentText("Receiving messages in the background")
+            .setSmallIcon(R.drawable.app_icon)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setContentIntent(openApp)
+            .build()
+
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "background-connection"
+        private const val NOTIFICATION_ID = 41672
+
+        fun start(context: Context) {
+            val intent = Intent(context, BackgroundConnectionService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(
+                Intent(context, BackgroundConnectionService::class.java),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/daccord_projects/daccord/BackgroundConnectionService.kt
+++ b/android/app/src/main/kotlin/com/daccord_projects/daccord/BackgroundConnectionService.kt
@@ -23,7 +23,12 @@ class BackgroundConnectionService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         startInForeground()
-        return START_STICKY
+        // START_NOT_STICKY: the service exists only to keep the Dart isolate's
+        // process unfrozen while the app is backgrounded. If the OS kills the
+        // process there is no Flutter engine left to reconnect, so auto-restart
+        // serves no purpose; the Flutter Riverpod controller re-starts it when
+        // the user brings the app back.
+        return START_NOT_STICKY
     }
 
     private fun startInForeground() {

--- a/android/app/src/main/kotlin/com/daccord_projects/daccord/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/daccord_projects/daccord/MainActivity.kt
@@ -15,8 +15,13 @@ import java.io.File
 /// `installApk` opens a downloaded APK with the system package installer via a
 /// FileProvider content URI, routing the user to grant "install unknown apps"
 /// first when needed.
+///
+/// Also hosts `com.daccord.app/background_connection`, which starts/stops the
+/// [BackgroundConnectionService] foreground service (see
+/// `lib/features/notifications/controllers/background_connection.dart`).
 class MainActivity : FlutterActivity() {
     private val channelName = "com.daccord.app/installer"
+    private val backgroundChannelName = "com.daccord.app/background_connection"
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -35,6 +40,24 @@ class MainActivity : FlutterActivity() {
                                 result.error("install_failed", e.message, null)
                             }
                         }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, backgroundChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "start" -> {
+                        try {
+                            BackgroundConnectionService.start(this)
+                            result.success(null)
+                        } catch (e: Exception) {
+                            result.error("start_failed", e.message, null)
+                        }
+                    }
+                    "stop" -> {
+                        BackgroundConnectionService.stop(this)
+                        result.success(null)
                     }
                     else -> result.notImplemented()
                 }

--- a/lib/features/authentication/repositories/accord_auth.dart
+++ b/lib/features/authentication/repositories/accord_auth.dart
@@ -488,6 +488,17 @@ class AccordAuth extends _$AccordAuth {
     return AddServerOutcome.ok();
   }
 
+  /// Pokes every live connection's gateway to verify it's still alive,
+  /// reconnecting any that died (see [AccordClient.ensureConnected]). Called
+  /// when the app returns to the foreground: mobile OSes freeze the process
+  /// while backgrounded, which stops heartbeats, silently kills sockets, and
+  /// can exhaust the automatic reconnect budget before the user comes back.
+  void ensureConnectedAll() {
+    for (final conn in _connections.values) {
+      conn.client.ensureConnected();
+    }
+  }
+
   /// Flips the active connection to [key] (a server already connected). No-op if
   /// [key] is not connected.
   void setActiveServer(String key) {

--- a/lib/features/authentication/repositories/accord_auth.g.dart
+++ b/lib/features/authentication/repositories/accord_auth.g.dart
@@ -74,7 +74,7 @@ final class AccordAuthProvider
   }
 }
 
-String _$accordAuthHash() => r'3f25a2f3b1a21e0a87e29114bbf0b17f012dae93';
+String _$accordAuthHash() => r'128a8c2cc13ff24d293f148e4ccd61fd23da8a30';
 
 /// Authentication + connection lifecycle against Accord servers. The Accord
 /// replacement for the Discord-specific `Auth` provider.

--- a/lib/features/events/utils/accord_event_handler.dart
+++ b/lib/features/events/utils/accord_event_handler.dart
@@ -81,6 +81,7 @@ VoidCallback handleAccordEvents(
   }));
 
   // ── Initial sync ─────────────────────────────────────────────────────────
+  var hadReady = false;
   subs.add(client.onReady.listen((data) async {
     setConnection(ConnectionStatus.ready);
     // Hydrate this server's read state from the authoritative unread list the
@@ -93,6 +94,21 @@ VoidCallback handleAccordEvents(
       _seedVoiceStates(ref, data);
     }
     await _loadSpaces(ref, client, serverKey: serverKey, isActive: isActive);
+    // A READY after the first means the gateway re-identified on a fresh
+    // session (a resumed session replays missed events instead, and emits
+    // `resumed`, not `ready`). Nothing replays what was missed while
+    // disconnected, so re-fetch the history of every open message pane.
+    // Active server only: the open panes are its channels.
+    if (hadReady && isActive()) {
+      for (final channelId in [...activeMessageChannels]) {
+        unawaited(
+          container
+              .read(accordMessagesControllerProvider(channelId).notifier)
+              .reload(client),
+        );
+      }
+    }
+    hadReady = true;
   }));
 
   // ── Presence (active server only) ────────────────────────────────────────

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -80,6 +80,9 @@ class AccordMessagesController extends _$AccordMessagesController {
   /// event replay, so anything that happened while disconnected is missing
   /// from the cache until refetched.
   Future<void> reload(AccordClient client) {
+    // Reset the pagination guard so that if loadOlder was in flight its
+    // eventual state-write is superseded by the reload result.
+    isLoadingOlder = false;
     hasMoreOlder = true;
     return _load(client, channelId);
   }

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -75,6 +75,15 @@ class AccordMessagesController extends _$AccordMessagesController {
     }
   }
 
+  /// Re-fetches the newest page, replacing the cache in place (no flash to the
+  /// loading state). Used after a gateway re-identify: a fresh session gets no
+  /// event replay, so anything that happened while disconnected is missing
+  /// from the cache until refetched.
+  Future<void> reload(AccordClient client) {
+    hasMoreOlder = true;
+    return _load(client, channelId);
+  }
+
   /// Loads the previous page of messages (older than the currently-oldest one
   /// in cache) and prepends them to [state]. Idempotent under concurrent calls
   /// and a no-op once [hasMoreOlder] is false. Returns the number of new

--- a/lib/features/messaging/controllers/accord_messages.g.dart
+++ b/lib/features/messaging/controllers/accord_messages.g.dart
@@ -72,7 +72,7 @@ final class AccordMessagesControllerProvider
 }
 
 String _$accordMessagesControllerHash() =>
-    r'8281d23fc3219eabf894995f3ba0c2940aa90270';
+    r'bbdadcccc5ca549221f9730d5051e2851ade8a06';
 
 /// A channel's recent message history, keyed by channel ID, ordered
 /// oldest→newest for display. Self-loads via `messages.list` the first time

--- a/lib/features/notifications/controllers/background_connection.dart
+++ b/lib/features/notifications/controllers/background_connection.dart
@@ -1,0 +1,54 @@
+import 'package:bonfire/features/authentication/models/accord_auth.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:universal_platform/universal_platform.dart';
+
+part 'background_connection.g.dart';
+
+/// Starts/stops the Android foreground service (`BackgroundConnectionService`)
+/// that exempts the app process from Android's cached-app freezer while
+/// backgrounded, so the gateway sockets stay alive and mention notifications
+/// keep firing. The service holds no logic of its own — keeping the process
+/// unfrozen is the whole job.
+///
+/// Mirrors the MCP server controller pattern: kept alive by a `ref.watch` in
+/// `MainWindow`, reacting to the persisted "Background connection" setting and
+/// the login state. A no-op on every platform but Android.
+@Riverpod(keepAlive: true)
+class BackgroundConnectionController extends _$BackgroundConnectionController {
+  static const _channel = MethodChannel(
+    'com.daccord.app/background_connection',
+  );
+
+  bool _running = false;
+
+  @override
+  void build() {
+    if (!UniversalPlatform.isAndroid) return;
+    final enabled = ref.watch(
+      settingsControllerProvider.select((s) => s.backgroundConnection),
+    );
+    final loggedIn = ref.watch(
+      accordAuthProvider.select((s) => s is AccordAuthLoggedIn),
+    );
+    _apply(enabled && loggedIn);
+  }
+
+  Future<void> _apply(bool shouldRun) async {
+    if (shouldRun == _running) return;
+    _running = shouldRun;
+    try {
+      await _channel.invokeMethod<void>(shouldRun ? 'start' : 'stop');
+    } catch (e) {
+      // Roll back so the next build retries instead of believing the lie.
+      _running = !shouldRun;
+      debugPrint(
+        'BackgroundConnectionService ${shouldRun ? 'start' : 'stop'} failed: $e',
+      );
+    }
+  }
+}

--- a/lib/features/notifications/controllers/background_connection.g.dart
+++ b/lib/features/notifications/controllers/background_connection.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'background_connection.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Starts/stops the Android foreground service (`BackgroundConnectionService`)
+/// that exempts the app process from Android's cached-app freezer while
+/// backgrounded, so the gateway sockets stay alive and mention notifications
+/// keep firing. The service holds no logic of its own — keeping the process
+/// unfrozen is the whole job.
+///
+/// Mirrors the MCP server controller pattern: kept alive by a `ref.watch` in
+/// `MainWindow`, reacting to the persisted "Background connection" setting and
+/// the login state. A no-op on every platform but Android.
+
+@ProviderFor(BackgroundConnectionController)
+const backgroundConnectionControllerProvider =
+    BackgroundConnectionControllerProvider._();
+
+/// Starts/stops the Android foreground service (`BackgroundConnectionService`)
+/// that exempts the app process from Android's cached-app freezer while
+/// backgrounded, so the gateway sockets stay alive and mention notifications
+/// keep firing. The service holds no logic of its own — keeping the process
+/// unfrozen is the whole job.
+///
+/// Mirrors the MCP server controller pattern: kept alive by a `ref.watch` in
+/// `MainWindow`, reacting to the persisted "Background connection" setting and
+/// the login state. A no-op on every platform but Android.
+final class BackgroundConnectionControllerProvider
+    extends $NotifierProvider<BackgroundConnectionController, void> {
+  /// Starts/stops the Android foreground service (`BackgroundConnectionService`)
+  /// that exempts the app process from Android's cached-app freezer while
+  /// backgrounded, so the gateway sockets stay alive and mention notifications
+  /// keep firing. The service holds no logic of its own — keeping the process
+  /// unfrozen is the whole job.
+  ///
+  /// Mirrors the MCP server controller pattern: kept alive by a `ref.watch` in
+  /// `MainWindow`, reacting to the persisted "Background connection" setting and
+  /// the login state. A no-op on every platform but Android.
+  const BackgroundConnectionControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'backgroundConnectionControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$backgroundConnectionControllerHash();
+
+  @$internal
+  @override
+  BackgroundConnectionController create() => BackgroundConnectionController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$backgroundConnectionControllerHash() =>
+    r'8430eb8e85f11ec016f7145f5c9e8188dfd22f5a';
+
+/// Starts/stops the Android foreground service (`BackgroundConnectionService`)
+/// that exempts the app process from Android's cached-app freezer while
+/// backgrounded, so the gateway sockets stay alive and mention notifications
+/// keep firing. The service holds no logic of its own — keeping the process
+/// unfrozen is the whole job.
+///
+/// Mirrors the MCP server controller pattern: kept alive by a `ref.watch` in
+/// `MainWindow`, reacting to the persisted "Background connection" setting and
+/// the login state. A no-op on every platform but Android.
+
+abstract class _$BackgroundConnectionController extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    build();
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, null);
+  }
+}

--- a/lib/features/notifications/controllers/notification.dart
+++ b/lib/features/notifications/controllers/notification.dart
@@ -36,6 +36,10 @@ Future<void> initializeNotifications() async {
       flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
           AndroidFlutterLocalNotificationsPlugin>();
   await androidPlugin?.createNotificationChannel(_androidChannel);
+  // Android 13+ gates notifications behind a runtime permission; without this
+  // request nothing the app posts (mentions, the background-connection
+  // service's status notification) is ever shown.
+  await androidPlugin?.requestNotificationsPermission();
 
   _initialized = true;
 }

--- a/lib/features/settings/controllers/settings.dart
+++ b/lib/features/settings/controllers/settings.dart
@@ -47,6 +47,11 @@ class SettingsController extends _$SettingsController {
   void setSuppressEveryone(bool suppress) =>
       _update(state.copyWith(suppressEveryone: suppress));
 
+  /// Android only: keep a foreground service (and so the gateway connection)
+  /// alive while the app is backgrounded.
+  void setBackgroundConnection(bool enabled) =>
+      _update(state.copyWith(backgroundConnection: enabled));
+
   void setSoundsEnabled(bool enabled) =>
       _update(state.copyWith(soundsEnabled: enabled));
 

--- a/lib/features/settings/controllers/settings.g.dart
+++ b/lib/features/settings/controllers/settings.g.dart
@@ -51,7 +51,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'b40eb8c4cc15e8c7bd8c3b2b3da8ddbf5893f3b4';
+    r'f41b2b6700ef752bfbdf3e87d03724bd637f279f';
 
 /// Local client preferences (theme, notifications, recent emoji), persisted to
 /// the `accord-settings` Hive box (opened in `setupHive`). Watched by `main`

--- a/lib/features/settings/models/accord_settings.dart
+++ b/lib/features/settings/models/accord_settings.dart
@@ -46,6 +46,7 @@ class AccordSettings {
     this.accentColor,
     this.notificationsEnabled = true,
     this.suppressEveryone = false,
+    this.backgroundConnection = false,
     this.soundsEnabled = true,
     this.sfxVolume = 1.0,
     this.videoResolution = 1,
@@ -106,6 +107,12 @@ class AccordSettings {
 
   /// When true, `@everyone` mentions never raise a notification.
   final bool suppressEveryone;
+
+  /// Android only: run a foreground service while backgrounded so the gateway
+  /// connection (and with it message delivery + notifications) survives the
+  /// OS freezing the app. Off by default — it shows a persistent notification
+  /// and costs battery.
+  final bool backgroundConnection;
 
   /// Whether to play SFX (message sent/received, mentions).
   final bool soundsEnabled;
@@ -265,6 +272,7 @@ class AccordSettings {
     bool clearAccentColor = false,
     bool? notificationsEnabled,
     bool? suppressEveryone,
+    bool? backgroundConnection,
     bool? soundsEnabled,
     double? sfxVolume,
     int? videoResolution,
@@ -309,6 +317,7 @@ class AccordSettings {
       accentColor: clearAccentColor ? null : (accentColor ?? this.accentColor),
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
       suppressEveryone: suppressEveryone ?? this.suppressEveryone,
+      backgroundConnection: backgroundConnection ?? this.backgroundConnection,
       soundsEnabled: soundsEnabled ?? this.soundsEnabled,
       sfxVolume: sfxVolume ?? this.sfxVolume,
       videoResolution: videoResolution ?? this.videoResolution,
@@ -416,6 +425,7 @@ class AccordSettings {
     'accentColor': accentColor,
     'notificationsEnabled': notificationsEnabled,
     'suppressEveryone': suppressEveryone,
+    'backgroundConnection': backgroundConnection,
     'soundsEnabled': soundsEnabled,
     'sfxVolume': sfxVolume,
     'videoResolution': videoResolution,
@@ -463,6 +473,7 @@ class AccordSettings {
       accentColor: (json['accentColor'] as num?)?.toInt(),
       notificationsEnabled: json['notificationsEnabled'] as bool? ?? true,
       suppressEveryone: json['suppressEveryone'] as bool? ?? false,
+      backgroundConnection: json['backgroundConnection'] as bool? ?? false,
       soundsEnabled: json['soundsEnabled'] as bool? ?? true,
       sfxVolume: (json['sfxVolume'] as num?)?.toDouble() ?? 1.0,
       videoResolution: (json['videoResolution'] as num?)?.toInt() ?? 1,

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -18,6 +18,7 @@ import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:universal_platform/universal_platform.dart';
 
 /// Client settings: appearance (theme preset + accent), notifications, account.
 class AccordSettingsScreen extends ConsumerWidget {
@@ -155,6 +156,17 @@ class AccordSettingsScreen extends ConsumerWidget {
                 ? controller.setSuppressEveryone
                 : null,
           ),
+          if (UniversalPlatform.isAndroid)
+            SwitchListTile(
+              title: const Text('Background connection'),
+              subtitle: const Text(
+                'Stay connected while the app is in the background so '
+                'messages and notifications keep arriving. Shows a '
+                'persistent notification and uses more battery.',
+              ),
+              value: settings.backgroundConnection,
+              onChanged: controller.setBackgroundConnection,
+            ),
           const Divider(height: 24),
           _SectionHeader('Error Reporting'),
           SwitchListTile(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:app_links/app_links.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/authentication/utils/hive.dart';
+import 'package:bonfire/features/notifications/controllers/background_connection.dart';
 import 'package:bonfire/features/notifications/controllers/notification.dart';
 import 'package:bonfire/features/notifications/controllers/sound.dart';
 import 'package:bonfire/features/profiles/views/app_restart.dart';
@@ -163,10 +164,18 @@ class MainWindow extends ConsumerStatefulWidget {
 
 class _MainWindowState extends ConsumerState<MainWindow> {
   StreamSubscription<Uri>? _linkSub;
+  AppLifecycleListener? _lifecycle;
 
   @override
   void initState() {
     super.initState();
+    // Mobile OSes freeze the process while backgrounded: heartbeats stop, the
+    // gateway sockets die, and the automatic reconnect budget can burn out
+    // before the user comes back. Verify/revive every connection on resume.
+    _lifecycle = AppLifecycleListener(
+      onResume: () =>
+          ref.read(accordAuthProvider.notifier).ensureConnectedAll(),
+    );
     _initDeepLinks();
     // Every route change becomes an error-reporting breadcrumb (a no-op until
     // the user opts in).
@@ -179,6 +188,7 @@ class _MainWindowState extends ConsumerState<MainWindow> {
   @override
   void dispose() {
     routerController.routerDelegate.removeListener(_onRouteChanged);
+    _lifecycle?.dispose();
     _linkSub?.cancel();
     super.dispose();
   }
@@ -297,6 +307,9 @@ class _MainWindowState extends ConsumerState<MainWindow> {
     // Keep the local MCP server controller alive so it starts/stops with the
     // Developer Mode + MCP settings (desktop-only; a no-op on web).
     ref.watch(mcpServerControllerProvider);
+    // Keep the Android background-connection service in sync with its setting
+    // and the login state (a no-op everywhere but Android).
+    ref.watch(backgroundConnectionControllerProvider);
     // Keep opt-in error reporting alive; it activates/deactivates with the
     // persisted consent toggle.
     ref.watch(errorReportingControllerProvider);

--- a/packages/accordkit/lib/src/core/accord_client.dart
+++ b/packages/accordkit/lib/src/core/accord_client.dart
@@ -136,6 +136,11 @@ class AccordClient {
   /// Closes the gateway connection.
   Future<void> logout() => gateway.disconnectFromGateway();
 
+  /// Verifies the gateway connection is alive and revives it if not (see
+  /// [GatewaySocket.ensureConnected]). Call when the app returns to the
+  /// foreground on platforms that suspend background processes.
+  void ensureConnected() => gateway.ensureConnected();
+
   /// Sends a presence update through the gateway.
   void updatePresence(String status,
           {Map<String, dynamic> activity = const {}}) =>

--- a/packages/accordkit/lib/src/gateway/gateway_socket.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_socket.dart
@@ -336,21 +336,29 @@ class GatewaySocket {
           : GatewayState.connecting);
       return;
     }
-    _probeLiveness();
+    // Only probe a fully-established connection; if we're mid-handshake
+    // (connecting/resuming) the existing attempt is already in progress.
+    if (_state != GatewayState.connected) return;
+    unawaited(_probeLiveness());
   }
 
   Future<void> _probeLiveness() async {
     if (_probePending) return;
     _probePending = true;
+    // Stop the heartbeat timer for the duration of the probe. Without this,
+    // the timer can fire while _heartbeatAckReceived is false (reset below)
+    // and close a live connection before the probe ACK arrives.
+    _stopHeartbeat();
     try {
       _heartbeatAckReceived = false;
       _send({'op': GatewayOpcodes.heartbeat, 'data': _sequence});
       await _sleep(probeTimeout);
-      if (_heartbeatAckReceived ||
-          _reconnectCancelled ||
-          _state == GatewayState.disconnected) {
+      if (_heartbeatAckReceived) {
+        // Connection is alive; resume normal heartbeating.
+        _startHeartbeat();
         return;
       }
+      if (_reconnectCancelled || _state == GatewayState.disconnected) return;
       _conn?.close(4000, 'liveness probe timeout');
     } finally {
       _probePending = false;

--- a/packages/accordkit/lib/src/gateway/gateway_socket.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_socket.dart
@@ -38,6 +38,10 @@ class GatewaySocket {
   final String _osName;
   final int maxReconnectAttempts;
 
+  /// How long [ensureConnected] waits for a heartbeat ACK before declaring a
+  /// nominally-connected socket dead and forcing a reconnect.
+  final Duration probeTimeout;
+
   AccordConfig? _config;
   GatewayConnection? _conn;
   StreamSubscription<String>? _sub;
@@ -52,6 +56,7 @@ class GatewaySocket {
   int _reconnectAttempts = 0;
   bool _reconnectCancelled = false;
   bool _resumePending = false;
+  bool _probePending = false;
 
   GatewaySocket({
     GatewayConnectionFactory? connectionFactory,
@@ -59,6 +64,7 @@ class GatewaySocket {
     double Function()? random,
     String osName = 'dart',
     this.maxReconnectAttempts = 10,
+    this.probeTimeout = const Duration(seconds: 5),
     this.token = '',
     this.tokenType = 'Bot',
     List<String>? intents,
@@ -305,6 +311,50 @@ class GatewaySocket {
     _sub = null;
     await conn?.close(code, reason);
     _disconnected.add(DisconnectInfo(code, reason));
+  }
+
+  /// Verifies the connection is alive and revives it if not. Call after a
+  /// period of process suspension (e.g. the app returning to the foreground on
+  /// mobile, where the OS freezes timers and silently kills sockets).
+  ///
+  /// - Disconnected: reconnects immediately with a fresh backoff budget, even
+  ///   when earlier automatic reconnects exhausted [maxReconnectAttempts].
+  ///   Resumes the previous session when one is held, else re-identifies.
+  /// - Nominally connected: the socket may be dead without a close frame ever
+  ///   having been delivered, so send an out-of-band heartbeat and force-close
+  ///   (triggering the normal reconnect path) if no ACK arrives within
+  ///   [probeTimeout].
+  ///
+  /// No-op before [connectToGateway] is first called or after an explicit
+  /// [disconnectFromGateway]/[dispose] — being offline is then intentional.
+  void ensureConnected() {
+    if (_reconnectCancelled || _gatewayUrl.isEmpty) return;
+    if (_state == GatewayState.disconnected) {
+      _reconnectAttempts = 0;
+      _openConnection(_sessionId.isNotEmpty
+          ? GatewayState.resuming
+          : GatewayState.connecting);
+      return;
+    }
+    _probeLiveness();
+  }
+
+  Future<void> _probeLiveness() async {
+    if (_probePending) return;
+    _probePending = true;
+    try {
+      _heartbeatAckReceived = false;
+      _send({'op': GatewayOpcodes.heartbeat, 'data': _sequence});
+      await _sleep(probeTimeout);
+      if (_heartbeatAckReceived ||
+          _reconnectCancelled ||
+          _state == GatewayState.disconnected) {
+        return;
+      }
+      _conn?.close(4000, 'liveness probe timeout');
+    } finally {
+      _probePending = false;
+    }
   }
 
   /// Sends a presence update.

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -301,6 +301,22 @@ void main() {
       await socket.dispose();
     });
 
+    test('is a no-op when the handshake is still in progress', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      // Start connecting but don't pump — the socket is in the 'connecting'
+      // state (ready future hasn't resolved yet).
+      socket.connectToGateway('ws://x');
+
+      socket.ensureConnected();
+      await pump();
+
+      // Still only the one connection; no probe heartbeat was sent.
+      expect(factory.connections, hasLength(1));
+      expect(socket.state, GatewayState.connected);
+      await socket.dispose();
+    });
+
     test('revives a dead socket even after reconnects are exhausted',
         () async {
       final factory = FakeConnectionFactory();
@@ -396,6 +412,52 @@ void main() {
       gate!.complete();
       await pump();
 
+      expect(factory.connections, hasLength(1));
+      expect(socket.state, GatewayState.connected);
+      await socket.dispose();
+    });
+
+    test('heartbeat timer does not race with probe during ack window', () async {
+      // Verify that the probe stops the heartbeat timer before sending its OOB
+      // heartbeat, so a timer tick mid-probe can't close a live connection that
+      // hasn't had time to ACK yet.
+      final factory = FakeConnectionFactory();
+      Completer<void>? sleepGate;
+      final socket = GatewaySocket(
+        connectionFactory: factory.call,
+        sleep: (_) {
+          sleepGate = Completer<void>();
+          return sleepGate!.future;
+        },
+        random: () => 0.0,
+        token: 'tok',
+        tokenType: 'Bot',
+        probeTimeout: const Duration(seconds: 5),
+      );
+      socket.setup(AccordConfig(), 'tok', tknType: 'Bot');
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      // Receive HELLO so the heartbeat timer starts.
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 30000},
+      }));
+      await pump();
+
+      // Start a probe — it should stop the heartbeat timer immediately.
+      socket.ensureConnected();
+      await pump();
+
+      // Simulate an ACK arriving before the probe timeout.
+      factory.last.receive(jsonEncode({'op': GatewayOpcodes.heartbeatAck}));
+      await pump();
+
+      // Complete the probe sleep.
+      sleepGate!.complete();
+      await pump();
+
+      // Connection still intact; no second connection was opened.
       expect(factory.connections, hasLength(1));
       expect(socket.state, GatewayState.connected);
       await socket.dispose();

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:accordkit/accordkit.dart';
@@ -254,6 +255,149 @@ void main() {
 
       expect(socket.sessionId, '');
       expect(factory.connections.length, 2);
+      await socket.dispose();
+    });
+  });
+
+  group('ensureConnected', () {
+    /// A socket whose automatic reconnects are exhausted immediately, so tests
+    /// can observe ensureConnected reviving a connection the backoff gave up on.
+    GatewaySocket makeExhaustedSocket(FakeConnectionFactory factory) {
+      final s = GatewaySocket(
+        connectionFactory: factory.call,
+        sleep: (_) async {},
+        random: () => 0.0,
+        maxReconnectAttempts: 0,
+        token: 'tok',
+        tokenType: 'Bot',
+      );
+      s.setup(AccordConfig(), 'tok', tknType: 'Bot', intentList: ['messages']);
+      return s;
+    }
+
+    test('is a no-op before the first connect', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+
+      socket.ensureConnected();
+      await pump();
+
+      expect(factory.connections, isEmpty);
+      await socket.dispose();
+    });
+
+    test('is a no-op after an explicit disconnect', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      await socket.disconnectFromGateway();
+
+      socket.ensureConnected();
+      await pump();
+
+      expect(factory.connections, hasLength(1));
+      expect(socket.state, GatewayState.disconnected);
+      await socket.dispose();
+    });
+
+    test('revives a dead socket even after reconnects are exhausted',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeExhaustedSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      factory.last.simulateClose(1006);
+      await pump();
+      expect(socket.state, GatewayState.disconnected);
+      expect(factory.connections, hasLength(1));
+
+      socket.ensureConnected();
+      await pump();
+
+      expect(factory.connections, hasLength(2));
+      expect(socket.state, GatewayState.connected);
+      await socket.dispose();
+    });
+
+    test('resumes the previous session when one is held', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeExhaustedSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'seq': 3,
+        'data': {'session_id': 'S1'},
+      }));
+      await pump();
+
+      factory.last.simulateClose(1006);
+      await pump();
+      socket.ensureConnected();
+      await pump();
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 60000},
+      }));
+      await pump();
+
+      final sent = lastSent(factory.last);
+      expect(sent['op'], GatewayOpcodes.resume);
+      expect(sent['data']['session_id'], 'S1');
+      expect(sent['data']['seq'], 3);
+      await socket.dispose();
+    });
+
+    test('force-closes a stale connection that misses the probe ack',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      expect(socket.state, GatewayState.connected);
+
+      socket.ensureConnected();
+      await pump(4);
+
+      // The probe heartbeat went out, was never acked, and the dead socket was
+      // closed and reopened through the normal reconnect path.
+      final probe =
+          jsonDecode(factory.connections.first.sent.last) as Map<String, dynamic>;
+      expect(probe['op'], GatewayOpcodes.heartbeat);
+      expect(factory.connections.first.closeCode, 4000);
+      expect(factory.connections, hasLength(2));
+      await socket.dispose();
+    });
+
+    test('leaves a live connection alone when the probe is acked', () async {
+      final factory = FakeConnectionFactory();
+      Completer<void>? gate;
+      final socket = GatewaySocket(
+        connectionFactory: factory.call,
+        sleep: (_) {
+          gate = Completer<void>();
+          return gate!.future;
+        },
+        random: () => 0.0,
+        token: 'tok',
+        tokenType: 'Bot',
+      );
+      socket.setup(AccordConfig(), 'tok', tknType: 'Bot');
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      socket.ensureConnected();
+      await pump();
+      factory.last.receive(jsonEncode({'op': GatewayOpcodes.heartbeatAck}));
+      await pump();
+      gate!.complete();
+      await pump();
+
+      expect(factory.connections, hasLength(1));
+      expect(socket.state, GatewayState.connected);
       await socket.dispose();
     });
   });


### PR DESCRIPTION
The app lost its gateway connection whenever Android froze the process
(cached-app freezer / Doze): heartbeats stopped, sockets died silently,
the automatic reconnect budget burned out while frozen, and nothing
recovered on refocus. Notifications also never showed on Android 13+
because POST_NOTIFICATIONS was never declared or requested.

accordkit:
- GatewaySocket.ensureConnected(): revives a dead socket with a fresh
  backoff budget (resuming the session when one is held), and probes a
  nominally-connected socket with an out-of-band heartbeat, force-closing
  it into the reconnect path when the ACK never arrives. Forwarded on
  AccordClient; covered by six new gateway tests.

app:
- AppLifecycleListener in MainWindow calls AccordAuth.ensureConnectedAll()
  on resume, so every server connection is verified/revived on refocus.
- A re-READY (fresh identify gets no event replay) now refetches the
  history of every open message pane so panes catch up on what was missed.
- POST_NOTIFICATIONS declared + requested at startup (Android 13+).

background connection (new, opt-in setting):
- BackgroundConnectionService: a dataSync foreground service that keeps
  the process out of the cached-app freezer while backgrounded, so the
  gateway stays connected and mention notifications keep firing. Driven
  by a new 'Background connection' settings toggle (Android only) via a
  Riverpod controller and a small platform channel in MainActivity.

Partially addresses #81 (the app-alive half; closed-app push delivery
remains a server-side follow-up).

https://claude.ai/code/session_01DG54V8d6B9scQEvcU168RQ