### PR TITLE
Inset top banners below the OS status bar on mobile

### DIFF
--- a/lib/features/updates/views/update_banner.dart
+++ b/lib/features/updates/views/update_banner.dart
@@ -29,31 +29,34 @@ class UpdateBanner extends ConsumerWidget {
     final colors = BonfireThemeExtension.of(context);
     return Material(
       color: colors.primary,
-      child: InkWell(
-        onTap: () => showUpdatesSettings(context),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: Row(
-            children: [
-              const Icon(Icons.system_update, size: 16, color: Colors.white),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Update available — ${release.name}. Tap to view.',
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(color: Colors.white, fontSize: 13),
+      child: SafeArea(
+        bottom: false,
+        child: InkWell(
+          onTap: () => showUpdatesSettings(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.system_update, size: 16, color: Colors.white),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Update available — ${release.name}. Tap to view.',
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white, fontSize: 13),
+                  ),
                 ),
-              ),
-              InkWell(
-                onTap: () => ref
-                    .read(updateControllerProvider.notifier)
-                    .dismissCurrent(),
-                child: const Padding(
-                  padding: EdgeInsets.all(4),
-                  child: Icon(Icons.close, size: 16, color: Colors.white),
+                InkWell(
+                  onTap: () => ref
+                      .read(updateControllerProvider.notifier)
+                      .dismissCurrent(),
+                  child: const Padding(
+                    padding: EdgeInsets.all(4),
+                    child: Icon(Icons.close, size: 16, color: Colors.white),
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/updates/views/web_update_prompt.dart
+++ b/lib/features/updates/views/web_update_prompt.dart
@@ -49,36 +49,39 @@ class _WebUpdatePromptState extends State<WebUpdatePrompt> {
     final colors = BonfireThemeExtension.of(context);
     return Material(
       color: colors.primary,
-      child: InkWell(
-        onTap: applyWebUpdate,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: Row(
-            children: [
-              const Icon(Icons.refresh, size: 16, color: Colors.white),
-              const SizedBox(width: 8),
-              const Expanded(
-                child: Text(
-                  'A new version is available — reload to update.',
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(color: Colors.white, fontSize: 13),
+      child: SafeArea(
+        bottom: false,
+        child: InkWell(
+          onTap: applyWebUpdate,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.refresh, size: 16, color: Colors.white),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'A new version is available — reload to update.',
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(color: Colors.white, fontSize: 13),
+                  ),
                 ),
-              ),
-              TextButton(
-                onPressed: applyWebUpdate,
-                child: const Text(
-                  'Reload',
-                  style: TextStyle(color: Colors.white),
+                TextButton(
+                  onPressed: applyWebUpdate,
+                  child: const Text(
+                    'Reload',
+                    style: TextStyle(color: Colors.white),
+                  ),
                 ),
-              ),
-              InkWell(
-                onTap: () => setState(() => _dismissed = true),
-                child: const Padding(
-                  padding: EdgeInsets.all(4),
-                  child: Icon(Icons.close, size: 16, color: Colors.white),
+                InkWell(
+                  onTap: () => setState(() => _dismissed = true),
+                  child: const Padding(
+                    padding: EdgeInsets.all(4),
+                    child: Icon(Icons.close, size: 16, color: Colors.white),
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/test/features/updates/update_banner_test.dart
+++ b/test/features/updates/update_banner_test.dart
@@ -1,0 +1,124 @@
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/updates/controllers/update_controller.dart';
+import 'package:bonfire/features/updates/models/app_release.dart';
+import 'package:bonfire/features/updates/views/update_banner.dart';
+import 'package:bonfire/features/updates/views/web_update_prompt.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeUpdateController extends UpdateController {
+  _FakeUpdateController(this._state);
+  final UpdateState _state;
+  @override
+  UpdateState build() => _state;
+}
+
+class _FakeSettingsController extends SettingsController {
+  _FakeSettingsController(this._settings);
+  final AccordSettings _settings;
+  @override
+  AccordSettings build() => _settings;
+}
+
+// Version well ahead of kAppVersion (0.2.1) so updateAvailable == true.
+const _newerRelease = AppRelease(
+  version: '99.0.0',
+  name: 'v99.0.0',
+  notes: '',
+  url: '',
+  publishedAt: '',
+);
+
+Widget _host({required UpdateState update, AccordSettings? settings}) =>
+    ProviderScope(
+      overrides: [
+        updateControllerProvider.overrideWith(
+          () => _FakeUpdateController(update),
+        ),
+        settingsControllerProvider.overrideWith(
+          () => _FakeSettingsController(settings ?? const AccordSettings()),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: const Scaffold(body: UpdateBanner()),
+      ),
+    );
+
+void main() {
+  group('UpdateBanner', () {
+    testWidgets('collapses to zero height when no update is available',
+        (tester) async {
+      await tester.pumpWidget(_host(update: const UpdateState()));
+      await tester.pump();
+
+      expect(tester.getSize(find.byType(UpdateBanner)).height, 0);
+    });
+
+    testWidgets('renders banner text when update is available', (tester) async {
+      await tester.pumpWidget(
+        _host(update: const UpdateState(latest: _newerRelease)),
+      );
+      await tester.pump();
+
+      expect(
+        find.textContaining('Update available'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('wraps content in SafeArea(bottom: false) when visible',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(update: const UpdateState(latest: _newerRelease)),
+      );
+      await tester.pump();
+
+      final safeArea = tester.widget<SafeArea>(find.byType(SafeArea));
+      expect(safeArea.bottom, isFalse);
+      expect(safeArea.top, isTrue);
+    });
+
+    testWidgets('collapses when dismissedVersion matches release version',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(
+            latest: _newerRelease,
+            dismissedVersion: '99.0.0',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.getSize(find.byType(UpdateBanner)).height, 0);
+    });
+
+    testWidgets('collapses when skippedUpdateVersion matches release version',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(latest: _newerRelease),
+          settings: const AccordSettings(skippedUpdateVersion: '99.0.0'),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.getSize(find.byType(UpdateBanner)).height, 0);
+    });
+  });
+
+  group('WebUpdatePrompt', () {
+    testWidgets('renders nothing on non-web platforms', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: WebUpdatePrompt())),
+      );
+      await tester.pump();
+
+      expect(tester.getSize(find.byType(WebUpdatePrompt)).height, 0);
+    });
+  });
+}


### PR DESCRIPTION
The update and web-update banners render in the top-level Column above
the body's SafeArea, so on Android they slid under the status bar and
their text/dismiss controls were partly unreachable. Wrap each in
SafeArea(bottom: false), matching the existing RolePreviewBanner.