### PR TITLE
chore: update Apple bundle id to com.cattrall.daccord

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -512,7 +512,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -530,7 +530,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -546,7 +546,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -678,7 +678,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -701,7 +701,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Daccord.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Daccord";
@@ -504,7 +504,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Daccord.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Daccord";
@@ -519,7 +519,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Daccord.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Daccord";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = Daccord
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.daccord-projects.daccord
+PRODUCT_BUNDLE_IDENTIFIER = com.cattrall.daccord
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 The Daccord Project. All rights reserved.


### PR DESCRIPTION
## What
Updates the iOS and macOS `PRODUCT_BUNDLE_IDENTIFIER` from `com.daccord-projects.daccord` to **`com.cattrall.daccord`** to match the App ID newly registered in the Apple Developer portal (Team `8MVM4FMRRC`).

## Changes
- `ios/Runner.xcodeproj/project.pbxproj` — main Runner target + `.RunnerTests`
- `macos/Runner.xcodeproj/project.pbxproj` — `.RunnerTests` targets
- `macos/Runner/Configs/AppInfo.xcconfig` — macOS app bundle id

## Not changed
- **Android** `applicationId` (`com.daccord_projects.daccord`) — separate Google Play identifier, not governed by the Apple App ID.
- `markdown_viewer` example project (`com.example.*`) — vendored package, out of scope.

## Notes
No App ID capabilities were enabled on the new identifier; the app uses only sandbox device permissions (camera/mic/network) and a custom `daccord://` URL scheme, none of which require portal capability toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)