### PR TITLE
Fix mobile left-edge swipe popping home to sign-in

### DIFF
--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -578,73 +578,95 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
         // Narrow: rail + channel list move into a drawer, members into an
         // end-drawer, so the message pane keeps full width instead of
         // overflowing.
-        return Scaffold(
-          key: _scaffoldKey,
-          backgroundColor: colors.background,
-          drawerEdgeDragWidth: 48,
-          drawer: Drawer(
-            width: 292,
+        //
+        // Wrap in [PopScope] so Android's left-edge back swipe (which shares the
+        // same edge as the swipe-to-open-sidebar gesture) steps through / opens
+        // the drawers instead of popping the route. The home (`/spaces`) is a
+        // child of the login route (`/`), so an un-intercepted system back would
+        // pop down to the sign-in screen — the cause of the "swiping left
+        // re-prompts for sign in" bug.
+        return PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (didPop) return;
+            final scaffold = _scaffoldKey.currentState;
+            if (scaffold == null) return;
+            if (scaffold.isEndDrawerOpen) {
+              scaffold.closeEndDrawer();
+            } else if (scaffold.isDrawerOpen) {
+              scaffold.closeDrawer();
+            } else {
+              scaffold.openDrawer();
+            }
+          },
+          child: Scaffold(
+            key: _scaffoldKey,
             backgroundColor: colors.background,
-            child: SafeArea(
-              child: Row(
-                children: [
-                  rail,
-                  Expanded(child: channelList(inDrawer: true)),
-                ],
-              ),
-            ),
-          ),
-          endDrawer: hasMembers
-              ? Drawer(
-                  width: 260,
-                  backgroundColor: colors.background,
-                  child: SafeArea(
-                    child: AccordMemberList(spaceId: effectiveSpaceId),
-                  ),
-                )
-              : null,
-          body: Stack(
-            children: [
-              // Inset the mobile chrome below the OS status bar / nav bar.
-              // The pip overlay stays outside so it can use the full screen.
-              SafeArea(
-                child: Column(
+            drawerEdgeDragWidth: 48,
+            drawer: Drawer(
+              width: 292,
+              backgroundColor: colors.background,
+              child: SafeArea(
+                child: Row(
                   children: [
-                    Row(
-                      children: [
-                        IconButton(
-                          tooltip: 'Channels',
-                          icon: Icon(Icons.menu, color: colors.dirtyWhite),
-                          onPressed: () =>
-                              _scaffoldKey.currentState?.openDrawer(),
-                        ),
-                        Expanded(child: _TabStrip(onSelect: _selectTab)),
-                        if (hasMembers)
-                          IconButton(
-                            tooltip: 'Members',
-                            icon: Icon(
-                              Icons.people_alt_outlined,
-                              color: colors.dirtyWhite,
-                            ),
-                            onPressed: () =>
-                                _scaffoldKey.currentState?.openEndDrawer(),
-                          ),
-                      ],
-                    ),
-                    Expanded(
-                      child: _MessagePane(
-                        channel: channels?.firstWhereOrNull(
-                          (c) => c.id == shownChannelId,
-                        ),
-                        channelId: shownChannelId,
-                        spaceId: effectiveSpaceId,
-                      ),
-                    ),
+                    rail,
+                    Expanded(child: channelList(inDrawer: true)),
                   ],
                 ),
               ),
-              pip,
-            ],
+            ),
+            endDrawer: hasMembers
+                ? Drawer(
+                    width: 260,
+                    backgroundColor: colors.background,
+                    child: SafeArea(
+                      child: AccordMemberList(spaceId: effectiveSpaceId),
+                    ),
+                  )
+                : null,
+            body: Stack(
+              children: [
+                // Inset the mobile chrome below the OS status bar / nav bar.
+                // The pip overlay stays outside so it can use the full screen.
+                SafeArea(
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          IconButton(
+                            tooltip: 'Channels',
+                            icon: Icon(Icons.menu, color: colors.dirtyWhite),
+                            onPressed: () =>
+                                _scaffoldKey.currentState?.openDrawer(),
+                          ),
+                          Expanded(child: _TabStrip(onSelect: _selectTab)),
+                          if (hasMembers)
+                            IconButton(
+                              tooltip: 'Members',
+                              icon: Icon(
+                                Icons.people_alt_outlined,
+                                color: colors.dirtyWhite,
+                              ),
+                              onPressed: () =>
+                                  _scaffoldKey.currentState?.openEndDrawer(),
+                            ),
+                        ],
+                      ),
+                      Expanded(
+                        child: _MessagePane(
+                          channel: channels?.firstWhereOrNull(
+                            (c) => c.id == shownChannelId,
+                          ),
+                          channelId: shownChannelId,
+                          spaceId: effectiveSpaceId,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                pip,
+              ],
+            ),
           ),
         );
       },

--- a/test/features/spaces/mobile_pop_scope_test.dart
+++ b/test/features/spaces/mobile_pop_scope_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Minimal widget that replicates the PopScope + Scaffold + drawer structure
+/// used in AccordHomeScreen's narrow layout, stripped of all network/Riverpod
+/// dependencies so the back-gesture drawer logic can be exercised in isolation.
+class _MobileHome extends StatefulWidget {
+  const _MobileHome({this.hasEndDrawer = true});
+
+  final bool hasEndDrawer;
+
+  @override
+  State<_MobileHome> createState() => _MobileHomeState();
+}
+
+class _MobileHomeState extends State<_MobileHome> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  Widget build(BuildContext context) => PopScope(
+    canPop: false,
+    onPopInvokedWithResult: (didPop, _) {
+      if (didPop) return;
+      final scaffold = _scaffoldKey.currentState;
+      if (scaffold == null) return;
+      if (scaffold.isEndDrawerOpen) {
+        scaffold.closeEndDrawer();
+      } else if (scaffold.isDrawerOpen) {
+        scaffold.closeDrawer();
+      } else {
+        scaffold.openDrawer();
+      }
+    },
+    child: Scaffold(
+      key: _scaffoldKey,
+      drawer: const Drawer(child: Text('channels')),
+      endDrawer: widget.hasEndDrawer
+          ? const Drawer(child: Text('members'))
+          : null,
+      body: const Center(child: Text('content')),
+    ),
+  );
+}
+
+void main() {
+  group('mobile narrow-layout PopScope back-gesture behavior', () {
+    testWidgets('opens channel drawer when no drawer is open', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: _MobileHome()));
+      final scaffold = tester.state<ScaffoldState>(find.byType(Scaffold));
+
+      expect(scaffold.isDrawerOpen, isFalse);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(scaffold.isDrawerOpen, isTrue);
+    });
+
+    testWidgets('closes channel drawer when it is open', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: _MobileHome()));
+      final scaffold = tester.state<ScaffoldState>(find.byType(Scaffold));
+
+      scaffold.openDrawer();
+      await tester.pumpAndSettle();
+      expect(scaffold.isDrawerOpen, isTrue);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(scaffold.isDrawerOpen, isFalse);
+    });
+
+    testWidgets('closes end drawer (members) when it is open', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: _MobileHome()));
+      final scaffold = tester.state<ScaffoldState>(find.byType(Scaffold));
+
+      scaffold.openEndDrawer();
+      await tester.pumpAndSettle();
+      expect(scaffold.isEndDrawerOpen, isTrue);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(scaffold.isEndDrawerOpen, isFalse);
+    });
+
+    testWidgets('does not pop the route when no drawer is open', (tester) async {
+      // Regression guard: back must never pop /spaces back to the sign-in screen.
+      // Push a route before _MobileHome so there is somewhere to pop to.
+      await tester.pumpWidget(
+        MaterialApp(
+          initialRoute: '/home',
+          routes: {
+            '/': (_) => const Scaffold(body: Text('sign-in')),
+            '/home': (_) => const _MobileHome(),
+          },
+        ),
+      );
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // Sign-in screen must not be shown.
+      expect(find.text('sign-in'), findsNothing);
+      expect(find.text('content'), findsOneWidget);
+    });
+
+    testWidgets('works without an end drawer (no space selected)', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: _MobileHome(hasEndDrawer: false)),
+      );
+      final scaffold = tester.state<ScaffoldState>(find.byType(Scaffold));
+
+      expect(scaffold.isDrawerOpen, isFalse);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(scaffold.isDrawerOpen, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
On narrow layouts the home screen (/spaces) is a child of the login
route (/). Android's left-edge back gesture shares the same edge as the
swipe-to-open-sidebar gesture, so it would pop the home route down to
the sign-in screen instead of opening the channel drawer.

Wrap the mobile Scaffold in a PopScope (canPop: false) that intercepts
the system back gesture and steps through / opens the drawers instead:
close the member end-drawer, else close the channel drawer, else open
the channel drawer. The left swipe now opens the left sidebar as
expected.