### PR TITLE
fix(messaging): make message header times date-aware

### DIFF
--- a/lib/features/spaces/utils/message_time.dart
+++ b/lib/features/spaces/utils/message_time.dart
@@ -1,0 +1,39 @@
+const _weekdays = [
+  'Monday', 'Tuesday', 'Wednesday', 'Thursday',
+  'Friday', 'Saturday', 'Sunday',
+];
+
+/// Bare `HH:MM` string for a local [DateTime].
+String messageClockString(DateTime local) {
+  final hh = local.hour.toString().padLeft(2, '0');
+  final mm = local.minute.toString().padLeft(2, '0');
+  return '$hh:$mm';
+}
+
+/// Date-aware label for a message timestamp shown in the message header.
+///
+/// | Age      | Result                  |
+/// |----------|-------------------------|
+/// | Today    | `18:43`                 |
+/// | Yesterday| `Yesterday at 18:43`    |
+/// | 2–6 days | `Monday at 18:43`       |
+/// | Older    | `12/06/2026 18:43`      |
+///
+/// The 6-day ceiling keeps weekday names unambiguous (a 7-day-old message
+/// would repeat today's weekday). [now] is injected for testability; callers
+/// omit it and the current wall-clock time is used.
+String messageTimeString(DateTime local, {DateTime? now}) {
+  final clock = messageClockString(local);
+  final ref = now ?? DateTime.now();
+  final today = DateTime(ref.year, ref.month, ref.day);
+  final thatDay = DateTime(local.year, local.month, local.day);
+  final daysAgo = today.difference(thatDay).inDays;
+
+  if (daysAgo <= 0) return clock;
+  if (daysAgo == 1) return 'Yesterday at $clock';
+  if (daysAgo <= 6) return '${_weekdays[local.weekday - 1]} at $clock';
+
+  final dd = local.day.toString().padLeft(2, '0');
+  final mo = local.month.toString().padLeft(2, '0');
+  return '$dd/$mo/${local.year} $clock';
+}

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -44,6 +44,7 @@ import 'package:bonfire/features/spaces/views/accord_gates.dart';
 import 'package:bonfire/features/spaces/views/accord_channel_reorder.dart';
 import 'package:bonfire/features/spaces/views/accord_invites.dart';
 import 'package:bonfire/features/spaces/views/accord_reports.dart';
+import 'package:bonfire/features/spaces/utils/message_time.dart';
 import 'package:bonfire/features/spaces/views/accord_search.dart';
 import 'package:bonfire/features/user/components/self_status_button.dart';
 import 'package:bonfire/features/user/views/accord_direct_messages.dart';

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -91,10 +91,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
   String get _clock {
     final dt = DateTime.tryParse(_message.timestamp);
     if (dt == null) return '';
-    final local = dt.toLocal();
-    final hh = local.hour.toString().padLeft(2, '0');
-    final mm = local.minute.toString().padLeft(2, '0');
-    return '$hh:$mm';
+    return messageClockString(dt.toLocal());
   }
 
   // The header time is date-aware so a message from days ago isn't mistaken for
@@ -104,27 +101,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
   String get _time {
     final dt = DateTime.tryParse(_message.timestamp);
     if (dt == null) return '';
-    final local = dt.toLocal();
-    final clock = _clock;
-
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
-    final thatDay = DateTime(local.year, local.month, local.day);
-    final daysAgo = today.difference(thatDay).inDays;
-
-    if (daysAgo == 0) return clock;
-    if (daysAgo == 1) return 'Yesterday at $clock';
-    if (daysAgo >= 2 && daysAgo <= 6) {
-      const weekdays = [
-        'Monday', 'Tuesday', 'Wednesday', 'Thursday',
-        'Friday', 'Saturday', 'Sunday', //
-      ];
-      return '${weekdays[local.weekday - 1]} at $clock';
-    }
-
-    final dd = local.day.toString().padLeft(2, '0');
-    final mo = local.month.toString().padLeft(2, '0');
-    return '$dd/$mo/${local.year} $clock';
+    return messageTimeString(dt.toLocal());
   }
 
   // intl isn't a dependency, so the full timestamp shown in the tooltip is

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -86,13 +86,45 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     super.dispose();
   }
 
-  String get _time {
+  // Bare HH:MM. Used in the grouped-message gutter, a fixed narrow slot where a
+  // full date wouldn't fit (grouped rows are within minutes of their header).
+  String get _clock {
     final dt = DateTime.tryParse(_message.timestamp);
     if (dt == null) return '';
     final local = dt.toLocal();
     final hh = local.hour.toString().padLeft(2, '0');
     final mm = local.minute.toString().padLeft(2, '0');
     return '$hh:$mm';
+  }
+
+  // The header time is date-aware so a message from days ago isn't mistaken for
+  // a recent one: today shows just the time, yesterday is prefixed, earlier this
+  // week shows the weekday, and older messages get the calendar date. intl isn't
+  // a dependency, so this is formatted by hand.
+  String get _time {
+    final dt = DateTime.tryParse(_message.timestamp);
+    if (dt == null) return '';
+    final local = dt.toLocal();
+    final clock = _clock;
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final thatDay = DateTime(local.year, local.month, local.day);
+    final daysAgo = today.difference(thatDay).inDays;
+
+    if (daysAgo == 0) return clock;
+    if (daysAgo == 1) return 'Yesterday at $clock';
+    if (daysAgo >= 2 && daysAgo <= 6) {
+      const weekdays = [
+        'Monday', 'Tuesday', 'Wednesday', 'Thursday',
+        'Friday', 'Saturday', 'Sunday', //
+      ];
+      return '${weekdays[local.weekday - 1]} at $clock';
+    }
+
+    final dd = local.day.toString().padLeft(2, '0');
+    final mo = local.month.toString().padLeft(2, '0');
+    return '$dd/$mo/${local.year} $clock';
   }
 
   // intl isn't a dependency, so the full timestamp shown in the tooltip is
@@ -317,7 +349,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
                       child: Tooltip(
                         message: _fullTime,
                         child: Text(
-                          _time,
+                          _clock,
                           textAlign: TextAlign.center,
                           style: theme.textTheme.labelSmall!.copyWith(
                             color: colors.gray,

--- a/test/features/spaces/message_time_test.dart
+++ b/test/features/spaces/message_time_test.dart
@@ -1,0 +1,78 @@
+import 'package:bonfire/features/spaces/utils/message_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('messageClockString', () {
+    test('pads single-digit hour and minute', () {
+      final dt = DateTime(2026, 6, 13, 9, 5);
+      expect(messageClockString(dt), '09:05');
+    });
+
+    test('handles midnight', () {
+      final dt = DateTime(2026, 6, 13, 0, 0);
+      expect(messageClockString(dt), '00:00');
+    });
+
+    test('handles end of day', () {
+      final dt = DateTime(2026, 6, 13, 23, 59);
+      expect(messageClockString(dt), '23:59');
+    });
+  });
+
+  group('messageTimeString', () {
+    // Fix "now" to a known Saturday so weekday assertions are deterministic.
+    // 2026-06-13 is a Saturday.
+    final now = DateTime(2026, 6, 13, 12, 0);
+
+    test('today shows bare clock', () {
+      final local = DateTime(2026, 6, 13, 18, 43);
+      expect(messageTimeString(local, now: now), '18:43');
+    });
+
+    test('yesterday shows "Yesterday at HH:MM"', () {
+      final local = DateTime(2026, 6, 12, 9, 5);
+      expect(messageTimeString(local, now: now), 'Yesterday at 09:05');
+    });
+
+    test('2 days ago shows weekday', () {
+      final local = DateTime(2026, 6, 11, 14, 30); // Thursday
+      expect(messageTimeString(local, now: now), 'Thursday at 14:30');
+    });
+
+    test('6 days ago shows weekday (boundary — still within week)', () {
+      final local = DateTime(2026, 6, 7, 8, 0); // Sunday
+      expect(messageTimeString(local, now: now), 'Sunday at 08:00');
+    });
+
+    test('7 days ago falls through to calendar date', () {
+      final local = DateTime(2026, 6, 6, 8, 0); // Saturday — same weekday as now
+      expect(messageTimeString(local, now: now), '06/06/2026 08:00');
+    });
+
+    test('older message shows DD/MM/YYYY HH:MM', () {
+      final local = DateTime(2026, 1, 5, 7, 3);
+      expect(messageTimeString(local, now: now), '05/01/2026 07:03');
+    });
+
+    test('future timestamp (negative daysAgo) shows bare clock', () {
+      final local = DateTime(2026, 6, 14, 10, 0); // tomorrow
+      expect(messageTimeString(local, now: now), '10:00');
+    });
+
+    test('weekday names cover full week', () {
+      const expectedNames = [
+        'Monday', 'Tuesday', 'Wednesday', 'Thursday',
+        'Friday', 'Saturday', 'Sunday',
+      ];
+      // now is Saturday 2026-06-13; 6 days back lands on Sunday 2026-06-07.
+      // Step through each day offset 2-6 from a known Monday anchor.
+      // Monday 2026-06-08 is 5 days before our Saturday.
+      for (var offset = 2; offset <= 6; offset++) {
+        final local = now.subtract(Duration(days: offset));
+        final result = messageTimeString(local, now: now);
+        final day = local.weekday; // 1 = Monday … 7 = Sunday
+        expect(result, contains(expectedNames[day - 1]));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The message header timestamp always rendered as bare `HH:MM`, so a message sent days ago looked identical to one sent today (e.g. `18:43`).

## Change

`_time` in `accord_home_message_row.dart` now shows progressively more context the older a message is:

| When | Shown |
|------|-------|
| Today | `18:43` |
| Yesterday | `Yesterday at 18:43` |
| 2–6 days ago | `Monday at 18:43` |
| Older | `12/06/2026 18:43` |

The 6-day bound keeps the weekday unambiguous (a 7-day-old message would repeat today's weekday name), so it falls through to the calendar date.

The grouped-message hover gutter is a fixed narrow slot (`avatarRadius * 2`) where the longer strings would overflow, so it uses a new bare-clock `_clock` getter. Grouped rows are within minutes of their header anyway, so the clock alone is correct there. The full hover tooltip (`Monday, 5 June 2026 at 14:30`) is unchanged.

No new dependencies — still hand-formatted (intl isn't a dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)