### PR TITLE
fix(reactions): dedup unicode reaction so it shows once

### DIFF
--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -321,7 +321,7 @@ class AccordMessagesController extends _$AccordMessagesController {
     final message = state?.firstWhereOrNull((m) => m.id == messageId);
     if (message == null) return;
     final existing = message.reactions?.firstWhereOrNull(
-      (r) => _emojiName(r) == emojiName,
+      (r) => _emojiName(r) == _emojiKey(emojiName, emojiId),
     );
     final adding = !(existing?.includesMe ?? false);
     final token = emojiId == null
@@ -408,8 +408,9 @@ class AccordMessagesController extends _$AccordMessagesController {
     final message = current.firstWhereOrNull((m) => m.id == messageId);
     if (message == null) return;
 
+    final key = _emojiKey(emojiName, emojiId);
     final reactions = [...(message.reactions ?? const <AccordReaction>[])];
-    final index = reactions.indexWhere((r) => _emojiName(r) == emojiName);
+    final index = reactions.indexWhere((r) => _emojiName(r) == key);
 
     if (added) {
       if (index >= 0) {
@@ -420,7 +421,9 @@ class AccordMessagesController extends _$AccordMessagesController {
       } else {
         reactions.add(
           AccordReaction(
-            emoji: {'id': emojiId, 'name': emojiName},
+            // Store the canonical key (glyph for unicode) so an optimistic pill
+            // and its later gateway echo dedup to one — see [_emojiKey].
+            emoji: {'id': emojiId, 'name': key},
             count: 1,
             includesMe: isOwn,
           ),
@@ -462,13 +465,18 @@ class AccordMessagesController extends _$AccordMessagesController {
     state = [...current];
   }
 
-  // Dedup/match key for a reaction. Custom emoji may arrive with the id baked
-  // into the name (`name:id`) when the source didn't split it; strip it so a
-  // gateway echo and a REST-loaded reaction for the same emoji collapse to one.
-  String _emojiName(AccordReaction r) {
-    final name = r.emoji['name']?.toString() ?? '';
-    final id = r.emoji['id']?.toString();
+  // Dedup/match key for a reaction.
+  String _emojiName(AccordReaction r) =>
+      _emojiKey(r.emoji['name']?.toString() ?? '', r.emoji['id']?.toString());
+
+  // Canonical dedup key for an emoji reference. Custom emoji key on their name
+  // (the id is carried separately, and may arrive baked into the name as
+  // `name:id` when the source didn't split it — strip it). Unicode emoji key on
+  // their glyph: the picker hands us a shortcode (`hamburger`) while the gateway
+  // echoes the glyph (`🍔`), so without resolving both to the glyph an optimistic
+  // pill and its echo wouldn't match, leaving two pills for one reaction.
+  String _emojiKey(String name, String? id) {
     if (id != null && id.isNotEmpty) return name;
-    return parseEmojiToken(name).name;
+    return resolveEmojiGlyph(parseEmojiToken(name).name);
   }
 }

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -450,7 +450,7 @@ class AccordMessagesController extends _$AccordMessagesController {
     final message = current.firstWhereOrNull((m) => m.id == messageId);
     if (message?.reactions == null) return;
     message!.reactions = message.reactions!
-        .where((r) => _emojiName(r) != emojiName)
+        .where((r) => _emojiName(r) != _emojiKey(emojiName, null))
         .toList();
     state = [...current];
   }

--- a/test/features/messaging/accord_messages_reactions_test.dart
+++ b/test/features/messaging/accord_messages_reactions_test.dart
@@ -1,0 +1,207 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+ProviderContainer makeContainer() {
+  final container = ProviderContainer(
+    overrides: [
+      // Prevents AccordAuth.build from touching Hive or opening a gateway.
+      accordAuthProvider.overrideWithValue(const AccordAuthLoggedOut()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+AccordMessagesController notifier(ProviderContainer c) =>
+    c.read(accordMessagesControllerProvider('ch1').notifier);
+
+List<AccordMessage>? messages(ProviderContainer c) =>
+    c.read(accordMessagesControllerProvider('ch1'));
+
+AccordMessage _msg({List<AccordReaction>? reactions}) => AccordMessage(
+      id: 'm1',
+      channelId: 'ch1',
+      content: 'hi',
+      reactions: reactions,
+    );
+
+AccordReaction _reaction(String name, {String? id, int count = 1, bool me = false}) =>
+    AccordReaction(emoji: {'name': name, 'id': id}, count: count, includesMe: me);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('applyReaction — unicode emoji dedup', () {
+    test('shortcode-keyed optimistic pill and glyph-keyed echo collapse to one',
+        () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      // Seed the message with no reactions.
+      n.state = [_msg()];
+
+      // 1. Optimistic add from picker: the picker passes a shortcode.
+      n.applyReaction('m1', 'hamburger', added: true, isOwn: true);
+
+      var reactions = messages(c)!.first.reactions!;
+      expect(reactions.length, 1,
+          reason: 'one pill after optimistic add');
+      // The stored name must be the canonical glyph.
+      expect(reactions.first.emoji['name'], '🍔');
+      expect(reactions.first.count, 1);
+      expect(reactions.first.includesMe, isTrue);
+
+      // 2. Gateway echo arrives with the glyph — must update, not add.
+      n.applyReaction('m1', '🍔', added: true, isOwn: true);
+
+      reactions = messages(c)!.first.reactions!;
+      expect(reactions.length, 1,
+          reason: 'gateway echo must merge into the optimistic pill');
+      expect(reactions.first.count, 1,
+          reason: 'includesMe guard prevents double-count');
+    });
+
+    test('glyph-keyed add from existing pill works correctly', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      // Seed with an existing reaction from another user (stored as glyph).
+      n.state = [_msg(reactions: [_reaction('🍔', count: 1)])];
+
+      // Current user taps the pill (passes the glyph).
+      n.applyReaction('m1', '🍔', added: true, isOwn: true);
+
+      final reactions = messages(c)!.first.reactions!;
+      expect(reactions.length, 1);
+      expect(reactions.first.count, 2);
+      expect(reactions.first.includesMe, isTrue);
+    });
+
+    test('REST-loaded shortcode-named reaction matches a glyph toggle', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      // A reaction loaded from REST might still have the shortcode as its name.
+      n.state = [_msg(reactions: [_reaction('hamburger', count: 1)])];
+
+      // Toggle off via glyph (what toggleReaction builds the token from).
+      n.applyReaction('m1', '🍔', added: false, isOwn: true, emojiId: null);
+
+      // Even though stored as 'hamburger', the remove should match.
+      final reactions = messages(c)!.first.reactions ?? [];
+      expect(reactions, isEmpty,
+          reason: 'count drops to 0 → pill is removed');
+    });
+
+    test('custom emoji still keyed by name, not resolved to a glyph', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      n.state = [_msg()];
+
+      // Custom emoji: id is non-null.
+      n.applyReaction('m1', 'bonk', added: true, isOwn: true, emojiId: '99');
+
+      final reactions = messages(c)!.first.reactions!;
+      expect(reactions.length, 1);
+      // Custom emoji keys on name, not glyph.
+      expect(reactions.first.emoji['name'], 'bonk');
+      expect(reactions.first.emoji['id'], '99');
+
+      // Gateway echo with same name+id merges.
+      n.applyReaction('m1', 'bonk', added: true, isOwn: true, emojiId: '99');
+      expect(messages(c)!.first.reactions!.length, 1,
+          reason: 'custom echo merges via includesMe guard');
+    });
+  });
+
+  group('clearReactionEmoji — canonicalised match', () {
+    test('clears a glyph-stored reaction when given a shortcode', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      // After the PR fix, reactions are stored with the glyph as their name.
+      n.state = [_msg(reactions: [_reaction('🍔', count: 2)])];
+
+      // Gateway clear_emoji sends the shortcode (the bug scenario).
+      n.clearReactionEmoji('m1', 'hamburger');
+
+      expect(messages(c)!.first.reactions, isEmpty,
+          reason: 'shortcode must resolve to glyph before matching');
+    });
+
+    test('clears a glyph-stored reaction when given the glyph', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      n.state = [_msg(reactions: [_reaction('🍔', count: 2)])];
+
+      n.clearReactionEmoji('m1', '🍔');
+
+      expect(messages(c)!.first.reactions, isEmpty);
+    });
+
+    test('clears a shortcode-stored reaction when given a shortcode', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      // Older REST-loaded reactions might still be stored with the shortcode.
+      n.state = [_msg(reactions: [_reaction('hamburger', count: 1)])];
+
+      n.clearReactionEmoji('m1', 'hamburger');
+
+      expect(messages(c)!.first.reactions, isEmpty);
+    });
+
+    test('does not clear a different emoji', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      n.state = [
+        _msg(reactions: [_reaction('🍔', count: 1), _reaction('👍', count: 3)]),
+      ];
+
+      n.clearReactionEmoji('m1', '🍔');
+
+      final remaining = messages(c)!.first.reactions!;
+      expect(remaining.length, 1);
+      expect(remaining.first.emoji['name'], '👍');
+    });
+  });
+
+  group('applyReaction — remove path', () {
+    test('removes pill when count reaches zero', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      n.state = [_msg(reactions: [_reaction('👍', count: 1, me: true)])];
+
+      n.applyReaction('m1', '👍', added: false, isOwn: true);
+
+      expect(messages(c)!.first.reactions, isEmpty);
+    });
+
+    test('decrement by another user leaves includesMe unchanged', () {
+      final c = makeContainer();
+      final n = notifier(c);
+
+      n.state = [_msg(reactions: [_reaction('👍', count: 3, me: true)])];
+
+      n.applyReaction('m1', '👍', added: false, isOwn: false);
+
+      final r = messages(c)!.first.reactions!.first;
+      expect(r.count, 2);
+      expect(r.includesMe, isTrue);
+    });
+  });
+}

--- a/test/features/messaging/accord_messages_reactions_test.dart
+++ b/test/features/messaging/accord_messages_reactions_test.dart
@@ -92,7 +92,9 @@ void main() {
       final n = notifier(c);
 
       // A reaction loaded from REST might still have the shortcode as its name.
-      n.state = [_msg(reactions: [_reaction('hamburger', count: 1)])];
+      // It's ours (includesMe) so the own-remove guard lets the toggle proceed —
+      // the point under test is that the glyph still matches the shortcode pill.
+      n.state = [_msg(reactions: [_reaction('hamburger', count: 1, me: true)])];
 
       // Toggle off via glyph (what toggleReaction builds the token from).
       n.applyReaction('m1', '🍔', added: false, isOwn: true, emojiId: null);


### PR DESCRIPTION
## What

Adding a unicode emoji reaction from the emoji picker showed up **twice** (two pills). This fixes it to show a single pill at the correct count.

## Why

The emoji picker passes `toggleReaction` a unicode emoji's **shortcode** name (e.g. `hamburger`), so the optimistic pill was stored/keyed by that shortcode. The gateway's `reaction.add` echo arrives keyed by the **glyph** (`🍔`) — what the server actually stored. The dedup key (`_emojiName`) returned the shortcode for the optimistic pill and the glyph for the echo, so they never matched: the echo created a **second pill** instead of merging, and the `includesMe` double-count guard never fired.

Tapping an *existing* pill didn't double, because that path already passes the glyph — only the picker path passed a shortcode.

## How

Introduce a canonical `_emojiKey(name, id)` helper that resolves unicode emoji to their glyph (custom emoji still key on name, with the id carried separately). All three reaction touchpoints now route through it:

- `toggleReaction` — the "do I already have this reaction?" lookup
- `applyReaction` — the match-or-create index, and it now **stores** the canonical key as the reaction's name
- `_emojiName` — delegates to `_emojiKey`

So `hamburger` (optimistic) and `🍔` (gateway echo) both normalize to `🍔` and collapse to one pill.

## Notes for reviewers

- The pill renderer already resolves names to glyphs via `resolveEmojiGlyph`, so storing the glyph as the reaction name renders unchanged.
- I couldn't run `flutter analyze` locally (the toolchain requires macOS 14+; this machine is on 13.0) — relying on CI. The change is self-contained; `resolveEmojiGlyph`/`parseEmojiToken` were already imported and used in the file.
- Worth a manual check: react with a standard unicode emoji from the picker and confirm a single pill at count 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)