### PR TITLE
feat(forum): traditional forum layout with post actions (#130)

### DIFF
--- a/lib/features/messaging/components/forum_view.dart
+++ b/lib/features/messaging/components/forum_view.dart
@@ -177,7 +177,12 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
         ? await client.messages.unpin(widget.channelId, post.id)
         : await client.messages.pin(widget.channelId, post.id);
     if (!mounted || !result.ok) return;
-    setState(() => post.pinned = !post.pinned);
+    setState(() {
+      final list = [...?_posts];
+      final i = list.indexWhere((m) => m.id == post.id);
+      if (i >= 0) list[i].pinned = !post.pinned;
+      _posts = list;
+    });
   }
 
   void _showPostMenu(AccordMessage post, [Offset? position]) {
@@ -211,7 +216,7 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     showAccordContextMenu(context,
         entries: entries,
         globalPosition: position,
-        title: _postTitle(post));
+        title: resolveForumPostTitle(post));
   }
 
   @override
@@ -219,6 +224,9 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
     final posts = _posts;
+    // Compute once and capture in the itemBuilder closure so _sorted is not
+    // invoked O(n) times as items scroll into view.
+    final sorted = _sorted;
     final members = widget.spaceId == null
         ? null
         : ref.watch(accordMembersControllerProvider(widget.spaceId!));
@@ -247,11 +255,11 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
                           onRefresh: _load,
                           child: ListView.separated(
                             padding: const EdgeInsets.fromLTRB(12, 12, 12, 88),
-                            itemCount: _sorted.length,
+                            itemCount: sorted.length,
                             separatorBuilder: (_, _) =>
                                 const SizedBox(height: 8),
                             itemBuilder: (context, index) {
-                              final post = _sorted[index];
+                              final post = sorted[index];
                               return _PostRow(
                                 post: post,
                                 colors: colors,
@@ -403,7 +411,7 @@ class _PostRow extends StatelessWidget {
                             const SizedBox(width: 4),
                           ],
                           Expanded(
-                            child: Text(_postTitle(post),
+                            child: Text(resolveForumPostTitle(post),
                                 style: theme.textTheme.titleSmall,
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis),
@@ -481,7 +489,7 @@ class _PostRow extends StatelessWidget {
 
 /// A post's display title: its title if set, else the first line of its body,
 /// else a neutral fallback (never the raw "(untitled)" leak).
-String _postTitle(AccordMessage post) {
+String resolveForumPostTitle(AccordMessage post) {
   final title = post.title;
   if (title is String && title.trim().isNotEmpty) return title.trim();
   final firstLine = post.content.split('\n').firstWhere(

--- a/lib/features/messaging/components/forum_view.dart
+++ b/lib/features/messaging/components/forum_view.dart
@@ -5,22 +5,48 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/features/messaging/components/thread_view.dart';
+import 'package:bonfire/features/spaces/utils/message_time.dart';
+import 'package:bonfire/shared/components/context_menu.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// A forum channel's body: a list of top-level posts (each a thread root) with
-/// a "New post" action. Replaces the message stream for `forum`-type channels.
+/// How the forum index orders its posts.
+enum ForumSort { latestActivity, newest, mostReplies }
+
+extension on ForumSort {
+  String get label => switch (this) {
+        ForumSort.latestActivity => 'Latest activity',
+        ForumSort.newest => 'Newest',
+        ForumSort.mostReplies => 'Most replies',
+      };
+}
+
+/// A forum channel's body: a traditional forum board of top-level posts (each a
+/// thread root) with a sort control and a "New post" action. Each row shows the
+/// author, created/last-activity times, reply count, and pinned badge, and
+/// exposes per-post actions (reply / edit / pin / delete). Replaces the message
+/// stream for `forum`-type channels.
 class ForumChannelView extends ConsumerStatefulWidget {
   const ForumChannelView({
     super.key,
     required this.channelId,
     required this.spaceId,
     required this.canPost,
+    this.canManageMessages = false,
+    this.currentUserId,
   });
 
   final String channelId;
   final String? spaceId;
   final bool canPost;
+
+  /// Whether the current user can manage others' posts (pin, delete).
+  final bool canManageMessages;
+
+  /// The signed-in user's id, used to gate edit/delete of own posts.
+  final String? currentUserId;
 
   @override
   ConsumerState<ForumChannelView> createState() => _ForumChannelViewState();
@@ -28,6 +54,7 @@ class ForumChannelView extends ConsumerStatefulWidget {
 
 class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
   List<AccordMessage>? _posts;
+  ForumSort _sort = ForumSort.latestActivity;
 
   @override
   void initState() {
@@ -60,6 +87,28 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     });
   }
 
+  /// Posts ordered by the active sort. Pinned posts always float to the top.
+  List<AccordMessage> get _sorted {
+    final posts = [...?_posts];
+    int byNewest(AccordMessage a, AccordMessage b) =>
+        _instant(b.timestamp).compareTo(_instant(a.timestamp));
+    int cmp(AccordMessage a, AccordMessage b) {
+      if (a.pinned != b.pinned) return a.pinned ? -1 : 1;
+      switch (_sort) {
+        case ForumSort.newest:
+          return byNewest(a, b);
+        case ForumSort.mostReplies:
+          final c = b.replyCount.compareTo(a.replyCount);
+          return c != 0 ? c : byNewest(a, b);
+        case ForumSort.latestActivity:
+          return _lastActivity(b).compareTo(_lastActivity(a));
+      }
+    }
+
+    posts.sort(cmp);
+    return posts;
+  }
+
   Future<void> _newPost() async {
     final created = await showDialog<AccordMessage>(
       context: context,
@@ -70,9 +119,105 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     }
   }
 
+  Future<void> _openPost(AccordMessage post) async {
+    final result = await showAccordThread(
+      context,
+      channelId: widget.channelId,
+      spaceId: widget.spaceId,
+      root: post,
+      canManageMessages: widget.canManageMessages,
+    );
+    if (result == null || !mounted) return;
+    setState(() {
+      final list = [...?_posts];
+      final index = list.indexWhere((m) => m.id == post.id);
+      if (index < 0) return;
+      if (result.deleted) {
+        list.removeAt(index);
+      } else if (result.root != null) {
+        list[index] = result.root!;
+      }
+      _posts = list;
+    });
+  }
+
+  bool _isOwn(AccordMessage post) =>
+      widget.currentUserId != null && post.authorId == widget.currentUserId;
+
+  Future<void> _editPost(AccordMessage post) async {
+    final updated = await showPostEditor(
+      context,
+      channelId: widget.channelId,
+      post: post,
+      withTitle: true,
+    );
+    if (updated == null || !mounted) return;
+    setState(() {
+      final list = [...?_posts];
+      final index = list.indexWhere((m) => m.id == post.id);
+      if (index >= 0) list[index] = updated;
+      _posts = list;
+    });
+  }
+
+  Future<void> _deletePost(AccordMessage post) async {
+    final client = _client;
+    if (client == null) return;
+    final confirmed = await confirmDeletePost(context, isPost: true);
+    if (confirmed != true) return;
+    final result = await client.messages.delete(widget.channelId, post.id);
+    if (!mounted || !result.ok) return;
+    setState(() => _posts = [...?_posts]..removeWhere((m) => m.id == post.id));
+  }
+
+  Future<void> _togglePin(AccordMessage post) async {
+    final client = _client;
+    if (client == null) return;
+    final result = post.pinned
+        ? await client.messages.unpin(widget.channelId, post.id)
+        : await client.messages.pin(widget.channelId, post.id);
+    if (!mounted || !result.ok) return;
+    setState(() => post.pinned = !post.pinned);
+  }
+
+  void _showPostMenu(AccordMessage post, [Offset? position]) {
+    final isOwn = _isOwn(post);
+    final entries = <AccordMenuEntry>[
+      AccordMenuEntry(
+        label: 'Open',
+        icon: Icons.open_in_new,
+        onSelected: () => _openPost(post),
+      ),
+      if (isOwn)
+        AccordMenuEntry(
+          label: 'Edit',
+          icon: Icons.edit_outlined,
+          onSelected: () => _editPost(post),
+        ),
+      if (widget.canManageMessages)
+        AccordMenuEntry(
+          label: post.pinned ? 'Unpin' : 'Pin',
+          icon: post.pinned ? Icons.push_pin_outlined : Icons.push_pin,
+          onSelected: () => _togglePin(post),
+        ),
+      if (isOwn || widget.canManageMessages)
+        AccordMenuEntry(
+          label: 'Delete',
+          icon: Icons.delete_outline,
+          destructive: true,
+          onSelected: () => _deletePost(post),
+        ),
+    ];
+    showAccordContextMenu(context,
+        entries: entries,
+        globalPosition: position,
+        title: _postTitle(post));
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
     final posts = _posts;
     final members = widget.spaceId == null
         ? null
@@ -80,48 +225,58 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     final users = ref.watch(accordUsersControllerProvider);
     final ensureUser =
         ref.read(accordUsersControllerProvider.notifier).ensure;
+    final cdnUrl = ref.watch(accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
     return Stack(
       children: [
-        if (posts == null)
-          const Center(child: CircularProgressIndicator())
-        else if (posts.isEmpty)
-          Center(
-              child: Text('No posts yet', style: theme.textTheme.bodyMedium))
-        else
-          ListView.separated(
-            padding: const EdgeInsets.all(12),
-            itemCount: posts.length,
-            separatorBuilder: (_, _) => const SizedBox(height: 8),
-            itemBuilder: (context, index) {
-              final post = posts[index];
-              final title = post.title;
-              final titleText =
-                  title is String && title.isNotEmpty ? title : '(untitled)';
-              final author = accordAuthorName(post.authorId,
-                  members: members, users: users, ensure: ensureUser);
-              return Card(
-                child: ListTile(
-                  leading: const Icon(Icons.article_outlined),
-                  title: Text(titleText, style: theme.textTheme.titleSmall),
-                  subtitle: Text(
-                    post.content.isEmpty ? 'by $author' : post.content,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  trailing: post.replyCount > 0
-                      ? Text('${post.replyCount}',
-                          style: theme.textTheme.labelMedium)
-                      : null,
-                  onTap: () => showAccordThread(
-                    context,
-                    channelId: widget.channelId,
-                    spaceId: widget.spaceId,
-                    root: post,
-                  ),
-                ),
-              );
-            },
-          ),
+        Column(
+          children: [
+            _SortBar(
+              sort: _sort,
+              onChanged: (s) => setState(() => _sort = s),
+              count: posts?.length ?? 0,
+            ),
+            Expanded(
+              child: posts == null
+                  ? const Center(child: CircularProgressIndicator())
+                  : posts.isEmpty
+                      ? Center(
+                          child: Text('No posts yet',
+                              style: theme.textTheme.bodyMedium))
+                      : RefreshIndicator(
+                          onRefresh: _load,
+                          child: ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(12, 12, 12, 88),
+                            itemCount: _sorted.length,
+                            separatorBuilder: (_, _) =>
+                                const SizedBox(height: 8),
+                            itemBuilder: (context, index) {
+                              final post = _sorted[index];
+                              return _PostRow(
+                                post: post,
+                                colors: colors,
+                                author: accordAuthorName(post.authorId,
+                                    members: members,
+                                    users: users,
+                                    ensure: ensureUser),
+                                avatarUrl: accordAuthorAvatarUrl(post.authorId,
+                                    members: members,
+                                    users: users,
+                                    cdnUrl: cdnUrl),
+                                avatarBg: accordAvatarColor(
+                                  members?[post.authorId]?.user ??
+                                      users[post.authorId],
+                                  post.authorId,
+                                ),
+                                onTap: () => _openPost(post),
+                                onMenu: (pos) => _showPostMenu(post, pos),
+                              );
+                            },
+                          ),
+                        ),
+            ),
+          ],
+        ),
         if (widget.canPost)
           Positioned(
             right: 16,
@@ -135,6 +290,239 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
       ],
     );
   }
+}
+
+/// The sort selector + post count strip above the board.
+class _SortBar extends StatelessWidget {
+  const _SortBar({
+    required this.sort,
+    required this.onChanged,
+    required this.count,
+  });
+
+  final ForumSort sort;
+  final ValueChanged<ForumSort> onChanged;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+      child: Row(
+        children: [
+          Text('$count ${count == 1 ? 'post' : 'posts'}',
+              style: theme.textTheme.labelMedium!
+                  .copyWith(color: colors.gray)),
+          const Spacer(),
+          Icon(Icons.sort, size: 16, color: colors.gray),
+          const SizedBox(width: 6),
+          PopupMenuButton<ForumSort>(
+            initialValue: sort,
+            tooltip: 'Sort posts',
+            onSelected: onChanged,
+            itemBuilder: (context) => [
+              for (final s in ForumSort.values)
+                PopupMenuItem(value: s, child: Text(s.label)),
+            ],
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(sort.label, style: theme.textTheme.labelMedium),
+                Icon(Icons.arrow_drop_down, size: 18, color: colors.gray),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single forum post row: avatar, title (+ pinned badge), author and
+/// created/last-activity metadata, reply count, and an overflow menu.
+class _PostRow extends StatelessWidget {
+  const _PostRow({
+    required this.post,
+    required this.colors,
+    required this.author,
+    required this.avatarUrl,
+    required this.avatarBg,
+    required this.onTap,
+    required this.onMenu,
+  });
+
+  final AccordMessage post;
+  final BonfireThemeExtension colors;
+  final String author;
+  final String? avatarUrl;
+  final Color avatarBg;
+  final VoidCallback onTap;
+  final void Function(Offset position) onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final initial =
+        author.trim().isEmpty ? '?' : author.trim()[0].toUpperCase();
+    final replies = post.replyCount;
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: EdgeInsets.zero,
+      child: GestureDetector(
+        onLongPressStart: (d) => onMenu(d.globalPosition),
+        onSecondaryTapUp: (d) => onMenu(d.globalPosition),
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 12, 4, 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 20,
+                  backgroundColor: avatarBg,
+                  foregroundImage: avatarUrl == null
+                      ? null
+                      : CachedNetworkImageProvider(avatarUrl!),
+                  child: Text(initial,
+                      style: theme.textTheme.titleMedium!
+                          .copyWith(color: accordOnColor(avatarBg))),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          if (post.pinned) ...[
+                            Icon(Icons.push_pin,
+                                size: 14, color: colors.primary),
+                            const SizedBox(width: 4),
+                          ],
+                          Expanded(
+                            child: Text(_postTitle(post),
+                                style: theme.textTheme.titleSmall,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(_metaLine(),
+                          style: theme.textTheme.labelMedium!
+                              .copyWith(color: colors.gray),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                      if (post.content.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(post.content,
+                            style: theme.textTheme.bodySmall!
+                                .copyWith(color: colors.gray),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    IconButton(
+                      tooltip: 'Post actions',
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () {
+                        final box = context.findRenderObject() as RenderBox?;
+                        final pos = box == null
+                            ? Offset.zero
+                            : box.localToGlobal(box.size.center(Offset.zero));
+                        onMenu(pos);
+                      },
+                      icon: Icon(Icons.more_horiz,
+                          size: 18, color: colors.gray),
+                    ),
+                    if (replies > 0)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8, top: 2),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.forum_outlined,
+                                size: 14, color: colors.gray),
+                            const SizedBox(width: 4),
+                            Text('$replies',
+                                style: theme.textTheme.labelMedium!
+                                    .copyWith(color: colors.gray)),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _metaLine() {
+    final created = _relativeOrDate(post.timestamp);
+    final parts = <String>['by $author'];
+    if (created.isNotEmpty) parts.add(created);
+    final last = _lastReplyText(post);
+    if (last != null) parts.add(last);
+    return parts.join(' · ');
+  }
+}
+
+/// A post's display title: its title if set, else the first line of its body,
+/// else a neutral fallback (never the raw "(untitled)" leak).
+String _postTitle(AccordMessage post) {
+  final title = post.title;
+  if (title is String && title.trim().isNotEmpty) return title.trim();
+  final firstLine = post.content.split('\n').firstWhere(
+        (l) => l.trim().isNotEmpty,
+        orElse: () => '',
+      );
+  if (firstLine.trim().isNotEmpty) return firstLine.trim();
+  return 'Untitled post';
+}
+
+/// Parses an ISO timestamp to a comparable instant, or epoch for unparseable
+/// values (so they sort last under a descending order).
+DateTime _instant(String iso) =>
+    DateTime.tryParse(iso)?.toUtc() ??
+    DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+
+/// A post's last-activity instant: its newest reply, falling back to creation.
+DateTime _lastActivity(AccordMessage post) {
+  final last = post.lastReplyAt;
+  if (last is String && last.isNotEmpty) {
+    final dt = DateTime.tryParse(last);
+    if (dt != null) return dt.toUtc();
+  }
+  return _instant(post.timestamp);
+}
+
+/// A "last reply ..." label for a post with replies, else null.
+String? _lastReplyText(AccordMessage post) {
+  if (post.replyCount <= 0) return null;
+  final last = post.lastReplyAt;
+  if (last is! String || last.isEmpty) return null;
+  final when = _relativeOrDate(last);
+  return when.isEmpty ? null : 'last reply $when';
+}
+
+/// A short date-aware label for an ISO timestamp (reusing the message-time
+/// formatter), or empty when unparseable.
+String _relativeOrDate(String iso) {
+  final dt = DateTime.tryParse(iso);
+  if (dt == null) return '';
+  return messageTimeString(dt.toLocal());
 }
 
 class _NewPostDialog extends ConsumerStatefulWidget {

--- a/lib/features/messaging/components/thread_view.dart
+++ b/lib/features/messaging/components/thread_view.dart
@@ -5,23 +5,52 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/features/messaging/components/box/accord_message_content.dart';
+import 'package:bonfire/features/spaces/utils/message_time.dart';
+import 'package:bonfire/shared/components/context_menu.dart';
 import 'package:bonfire/theme/theme.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Opens a thread/forum-post view: the [root] message at the top, its replies
 /// below, and a composer that posts replies into the thread (`thread_id`).
-Future<void> showAccordThread(
+///
+/// [canManageMessages] gates moderator actions (delete others' replies). When
+/// the root post is edited or deleted from inside the view the returned future
+/// completes with a [ThreadResult] so the caller (the forum index) can refresh
+/// its row; `null` means nothing changed.
+Future<ThreadResult?> showAccordThread(
   BuildContext context, {
   required String channelId,
   String? spaceId,
   required AccordMessage root,
+  bool canManageMessages = false,
 }) {
-  return showDialog<void>(
+  return showDialog<ThreadResult>(
     context: context,
-    builder: (_) =>
-        _ThreadView(channelId: channelId, spaceId: spaceId, root: root),
+    builder: (_) => _ThreadView(
+      channelId: channelId,
+      spaceId: spaceId,
+      root: root,
+      canManageMessages: canManageMessages,
+    ),
   );
+}
+
+/// The outcome of a thread view, reported back to the forum index so it can
+/// reflect a root-post edit or removal without a full reload.
+class ThreadResult {
+  const ThreadResult.edited(this.root) : deleted = false;
+  const ThreadResult.deleted()
+      : root = null,
+        deleted = true;
+
+  /// The updated root post (when edited), else null.
+  final AccordMessage? root;
+
+  /// Whether the root post was deleted.
+  final bool deleted;
 }
 
 class _ThreadView extends ConsumerStatefulWidget {
@@ -29,11 +58,13 @@ class _ThreadView extends ConsumerStatefulWidget {
     required this.channelId,
     required this.spaceId,
     required this.root,
+    required this.canManageMessages,
   });
 
   final String channelId;
   final String? spaceId;
   final AccordMessage root;
+  final bool canManageMessages;
 
   @override
   ConsumerState<_ThreadView> createState() => _ThreadViewState();
@@ -41,6 +72,7 @@ class _ThreadView extends ConsumerStatefulWidget {
 
 class _ThreadViewState extends ConsumerState<_ThreadView> {
   final TextEditingController _input = TextEditingController();
+  late AccordMessage _root = widget.root;
   List<AccordMessage>? _replies;
   bool _sending = false;
 
@@ -59,18 +91,21 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
   AccordClient? get _client => ref.read(accordAuthProvider
       .select((s) => s is AccordAuthLoggedIn ? s.client : null));
 
+  String? get _currentUserId => ref.read(accordAuthProvider
+      .select((s) => s is AccordAuthLoggedIn ? s.session.userId : null));
+
   Future<void> _load() async {
     final client = _client;
     if (client == null) return;
     final result =
-        await client.messages.listThread(widget.channelId, widget.root.id);
+        await client.messages.listThread(widget.channelId, _root.id);
     if (!mounted) return;
     final data = result.data;
     setState(() {
       _replies = result.ok && data is List
           ? data
               .whereType<AccordMessage>()
-              .where((m) => m.id != widget.root.id)
+              .where((m) => m.id != _root.id)
               .toList()
           : const [];
     });
@@ -84,7 +119,7 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
     setState(() => _sending = true);
     final result = await client.messages.create(widget.channelId, {
       'content': text,
-      'thread_id': widget.root.id,
+      'thread_id': _root.id,
     });
     if (!mounted) return;
     setState(() => _sending = false);
@@ -95,8 +130,44 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
     }
   }
 
+  /// Removes a deleted reply from the list. The root is handled separately
+  /// (it pops the view) since it can't disappear while its replies remain.
+  void _onReplyChanged(AccordMessage updated, {required bool deleted}) {
+    setState(() {
+      final list = [...?_replies];
+      final index = list.indexWhere((m) => m.id == updated.id);
+      if (index < 0) return;
+      if (deleted) {
+        list.removeAt(index);
+      } else {
+        list[index] = updated;
+      }
+      _replies = list;
+    });
+  }
+
+  Future<void> _editRoot() async {
+    final updated = await showPostEditor(
+      context,
+      channelId: widget.channelId,
+      post: _root,
+      withTitle: true,
+    );
+    if (updated != null && mounted) setState(() => _root = updated);
+  }
+
+  Future<void> _deleteRoot() async {
+    final client = _client;
+    if (client == null) return;
+    final confirmed = await confirmDeletePost(context, isPost: true);
+    if (confirmed != true) return;
+    final result = await client.messages.delete(widget.channelId, _root.id);
+    if (!mounted || !result.ok) return;
+    Navigator.of(context).pop(const ThreadResult.deleted());
+  }
+
   String _title() {
-    final title = widget.root.title;
+    final title = _root.title;
     if (title is String && title.isNotEmpty) return title;
     return 'Thread';
   }
@@ -111,8 +182,13 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
     final users = ref.watch(accordUsersControllerProvider);
     final ensureUser =
         ref.read(accordUsersControllerProvider.notifier).ensure;
+    final cdnUrl = ref.watch(accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
     final replies = _replies;
+    final currentUserId = _currentUserId;
     return Dialog(
+      // When the root is edited it returns via [_editRoot] state; a back/scrim
+      // dismiss should still surface that edit to the caller.
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 560, maxHeight: 680),
         child: Column(
@@ -131,7 +207,11 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
                         overflow: TextOverflow.ellipsis),
                   ),
                   IconButton(
-                    onPressed: () => Navigator.of(context).maybePop(),
+                    onPressed: () => Navigator.of(context).pop(
+                      identical(_root, widget.root)
+                          ? null
+                          : ThreadResult.edited(_root),
+                    ),
                     icon: const Icon(Icons.close, size: 18),
                   ),
                 ],
@@ -143,11 +223,21 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
                 padding: const EdgeInsets.all(12),
                 children: [
                   _MessageLine(
-                      message: widget.root,
-                      members: members,
-                      users: users,
-                      ensure: ensureUser,
-                      spaceId: widget.spaceId),
+                    message: _root,
+                    isRoot: true,
+                    members: members,
+                    users: users,
+                    ensure: ensureUser,
+                    cdnUrl: cdnUrl,
+                    spaceId: widget.spaceId,
+                    channelId: widget.channelId,
+                    isOwn: currentUserId != null &&
+                        _root.authorId == currentUserId,
+                    canManageMessages: widget.canManageMessages,
+                    onEdit: _editRoot,
+                    onDelete: _deleteRoot,
+                    onChanged: (_, {required deleted}) {},
+                  ),
                   const Divider(height: 16),
                   if (replies == null)
                     const Padding(
@@ -164,11 +254,19 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
                   else
                     for (final reply in replies)
                       _MessageLine(
-                          message: reply,
-                          members: members,
-                          users: users,
-                          ensure: ensureUser,
-                          spaceId: widget.spaceId),
+                        message: reply,
+                        isRoot: false,
+                        members: members,
+                        users: users,
+                        ensure: ensureUser,
+                        cdnUrl: cdnUrl,
+                        spaceId: widget.spaceId,
+                        channelId: widget.channelId,
+                        isOwn: currentUserId != null &&
+                            reply.authorId == currentUserId,
+                        canManageMessages: widget.canManageMessages,
+                        onChanged: _onReplyChanged,
+                      ),
                 ],
               ),
             ),
@@ -205,36 +303,376 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
   }
 }
 
-/// A compact author + content row used inside the thread view.
-class _MessageLine extends StatelessWidget {
+/// An author + content row used inside the thread view, with an actions menu
+/// (edit/delete/copy) mirroring the main message view. The root post and
+/// replies share this; [isRoot] only changes the edit affordance (title-aware)
+/// and is reported to the parent via [onEdit]/[onDelete] callbacks.
+class _MessageLine extends ConsumerStatefulWidget {
   const _MessageLine({
     required this.message,
+    required this.isRoot,
     required this.members,
     required this.users,
     required this.ensure,
+    required this.cdnUrl,
     required this.spaceId,
+    required this.channelId,
+    required this.isOwn,
+    required this.canManageMessages,
+    required this.onChanged,
+    this.onEdit,
+    this.onDelete,
   });
 
   final AccordMessage message;
+  final bool isRoot;
   final Map<String, AccordMember>? members;
   final Map<String, AccordUser> users;
   final void Function(String userId) ensure;
+  final String? cdnUrl;
   final String? spaceId;
+  final String channelId;
+  final bool isOwn;
+  final bool canManageMessages;
+
+  /// Reports a reply edit (deleted: false) or removal (deleted: true) to the
+  /// thread so it can update its list. Unused for the root.
+  final void Function(AccordMessage updated, {required bool deleted}) onChanged;
+
+  /// Root-only handlers (the root edits its title and pops on delete).
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+
+  @override
+  ConsumerState<_MessageLine> createState() => _MessageLineState();
+}
+
+class _MessageLineState extends ConsumerState<_MessageLine> {
+  bool _hovered = false;
+  bool _busy = false;
+
+  AccordMessage get _message => widget.message;
+
+  AccordClient? get _client => ref.read(accordAuthProvider
+      .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+
+  bool get _canDelete => widget.isOwn || widget.canManageMessages;
+
+  String get _time {
+    final dt = DateTime.tryParse(_message.timestamp);
+    if (dt == null) return '';
+    return messageTimeString(dt.toLocal());
+  }
+
+  Future<void> _edit() async {
+    if (widget.isRoot) {
+      widget.onEdit?.call();
+      return;
+    }
+    final updated = await showPostEditor(
+      context,
+      channelId: widget.channelId,
+      post: _message,
+      withTitle: false,
+    );
+    if (updated != null) widget.onChanged(updated, deleted: false);
+  }
+
+  Future<void> _delete() async {
+    if (widget.isRoot) {
+      widget.onDelete?.call();
+      return;
+    }
+    final client = _client;
+    if (client == null || _busy) return;
+    final confirmed = await confirmDeletePost(context, isPost: false);
+    if (confirmed != true || !mounted) return;
+    setState(() => _busy = true);
+    final result = await client.messages.delete(widget.channelId, _message.id);
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (result.ok) widget.onChanged(_message, deleted: true);
+  }
+
+  void _showMenu([Offset? position]) {
+    final name = accordAuthorName(_message.authorId,
+        members: widget.members, users: widget.users, ensure: widget.ensure);
+    final entries = <AccordMenuEntry>[
+      if (_message.content.isNotEmpty)
+        AccordMenuEntry(
+          label: 'Copy text',
+          icon: Icons.copy_outlined,
+          onSelected: () =>
+              Clipboard.setData(ClipboardData(text: _message.content)),
+        ),
+      if (widget.isOwn)
+        AccordMenuEntry(
+          label: 'Edit',
+          icon: Icons.edit_outlined,
+          onSelected: _edit,
+        ),
+      if (_canDelete)
+        AccordMenuEntry(
+          label: 'Delete',
+          icon: Icons.delete_outline,
+          destructive: true,
+          onSelected: _delete,
+        ),
+    ];
+    if (entries.isEmpty) return;
+    showAccordContextMenu(context,
+        entries: entries, globalPosition: position, title: name);
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final name = accordAuthorName(message.authorId,
-        members: members, users: users, ensure: ensure);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(name, style: theme.textTheme.titleSmall),
-          const SizedBox(height: 2),
-          AccordMessageContent(content: message.content, spaceId: spaceId),
-        ],
+    final colors = BonfireThemeExtension.of(context);
+    final name = accordAuthorName(_message.authorId,
+        members: widget.members, users: widget.users, ensure: widget.ensure);
+    final avatarUrl = accordAuthorAvatarUrl(_message.authorId,
+        members: widget.members, users: widget.users, cdnUrl: widget.cdnUrl);
+    final avatarBg = accordAvatarColor(
+      widget.members?[_message.authorId]?.user ??
+          widget.users[_message.authorId],
+      _message.authorId,
+    );
+    final initial = name.trim().isEmpty ? '?' : name.trim()[0].toUpperCase();
+    final showActions = widget.isOwn || _canDelete;
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        onLongPressStart: (d) => _showMenu(d.globalPosition),
+        onSecondaryTapUp: (d) => _showMenu(d.globalPosition),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundColor: avatarBg,
+                foregroundImage: avatarUrl == null
+                    ? null
+                    : CachedNetworkImageProvider(avatarUrl),
+                child: Text(initial,
+                    style: theme.textTheme.labelLarge!
+                        .copyWith(color: accordOnColor(avatarBg))),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(name,
+                              style: theme.textTheme.titleSmall,
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(_time,
+                            style: theme.textTheme.labelSmall!
+                                .copyWith(color: colors.gray)),
+                        if (_message.editedAt != null) ...[
+                          const SizedBox(width: 6),
+                          Text('(edited)',
+                              style: theme.textTheme.labelSmall!
+                                  .copyWith(color: colors.gray)),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    if (_message.content.isNotEmpty)
+                      AccordMessageContent(
+                          content: _message.content, spaceId: widget.spaceId),
+                  ],
+                ),
+              ),
+              if (showActions)
+                Opacity(
+                  opacity: _hovered ? 1 : 0,
+                  child: IconButton(
+                    tooltip: 'Actions',
+                    onPressed: _busy ? null : () => _showMenu(),
+                    icon: Icon(Icons.more_horiz, size: 18, color: colors.gray),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Confirms deletion of a post or reply. Shared by the forum index and the
+/// thread view so the wording stays consistent.
+Future<bool?> confirmDeletePost(BuildContext context, {required bool isPost}) {
+  final what = isPost ? 'post' : 'reply';
+  return showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text('Delete $what'),
+      content: Text('This $what will be permanently deleted.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Opens an editor for an existing post/reply and PATCHes it. With [withTitle]
+/// the title field is shown (forum root posts); without, only the body (replies
+/// and plain messages). Returns the updated [AccordMessage], or null if
+/// cancelled or the request failed.
+Future<AccordMessage?> showPostEditor(
+  BuildContext context, {
+  required String channelId,
+  required AccordMessage post,
+  required bool withTitle,
+}) {
+  return showDialog<AccordMessage>(
+    context: context,
+    builder: (_) =>
+        _PostEditorDialog(channelId: channelId, post: post, withTitle: withTitle),
+  );
+}
+
+class _PostEditorDialog extends ConsumerStatefulWidget {
+  const _PostEditorDialog({
+    required this.channelId,
+    required this.post,
+    required this.withTitle,
+  });
+
+  final String channelId;
+  final AccordMessage post;
+  final bool withTitle;
+
+  @override
+  ConsumerState<_PostEditorDialog> createState() => _PostEditorDialogState();
+}
+
+class _PostEditorDialogState extends ConsumerState<_PostEditorDialog> {
+  late final TextEditingController _title = TextEditingController(
+      text: widget.post.title is String ? widget.post.title as String : '');
+  late final TextEditingController _body =
+      TextEditingController(text: widget.post.content);
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _body.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final title = _title.text.trim();
+    final body = _body.text.trim();
+    if (widget.withTitle && title.isEmpty) {
+      setState(() => _error = 'Title is required');
+      return;
+    }
+    final client = ref.read(accordAuthProvider
+        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    if (client == null) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final result =
+        await client.messages.edit(widget.channelId, widget.post.id, {
+      if (widget.withTitle) 'title': title,
+      'content': body,
+    });
+    if (!mounted) return;
+    final message = result.data;
+    if (result.ok && message is AccordMessage) {
+      Navigator.of(context).pop(message);
+    } else {
+      setState(() {
+        _busy = false;
+        _error = 'Failed to save changes';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 460),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(widget.withTitle ? 'Edit post' : 'Edit reply',
+                  style: theme.textTheme.titleMedium),
+              const SizedBox(height: 16),
+              if (widget.withTitle) ...[
+                TextField(
+                  controller: _title,
+                  enabled: !_busy,
+                  decoration: const InputDecoration(
+                    labelText: 'Title',
+                    isDense: true,
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
+              TextField(
+                controller: _body,
+                autofocus: !widget.withTitle,
+                enabled: !_busy,
+                minLines: 3,
+                maxLines: 8,
+                decoration: InputDecoration(
+                  labelText: widget.withTitle ? 'Body' : 'Message',
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Text(_error!,
+                    style: theme.textTheme.bodySmall!
+                        .copyWith(color: theme.colorScheme.error)),
+              ],
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed:
+                        _busy ? null : () => Navigator.of(context).maybePop(),
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _busy ? null : _submit,
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/messaging/components/thread_view.dart
+++ b/lib/features/messaging/components/thread_view.dart
@@ -146,6 +146,12 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
     });
   }
 
+  void _popWithResult() {
+    Navigator.of(context).pop(
+      identical(_root, widget.root) ? null : ThreadResult.edited(_root),
+    );
+  }
+
   Future<void> _editRoot() async {
     final updated = await showPostEditor(
       context,
@@ -186,10 +192,16 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
         (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
     final replies = _replies;
     final currentUserId = _currentUserId;
-    return Dialog(
-      // When the root is edited it returns via [_editRoot] state; a back/scrim
-      // dismiss should still surface that edit to the caller.
-      child: ConstrainedBox(
+    return PopScope(
+      canPop: false,
+      // Ensures back-nav and scrim taps surface any root edit to the caller,
+      // matching the close-button path.
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _popWithResult();
+      },
+      child: Dialog(
+        child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 560, maxHeight: 680),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -207,11 +219,7 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
                         overflow: TextOverflow.ellipsis),
                   ),
                   IconButton(
-                    onPressed: () => Navigator.of(context).pop(
-                      identical(_root, widget.root)
-                          ? null
-                          : ThreadResult.edited(_root),
-                    ),
+                    onPressed: _popWithResult,
                     icon: const Icon(Icons.close, size: 18),
                   ),
                 ],
@@ -297,6 +305,7 @@ class _ThreadViewState extends ConsumerState<_ThreadView> {
               ),
             ),
           ],
+        ),
         ),
       ),
     );
@@ -438,7 +447,6 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
       _message.authorId,
     );
     final initial = name.trim().isEmpty ? '?' : name.trim()[0].toUpperCase();
-    final showActions = widget.isOwn || _canDelete;
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
@@ -491,7 +499,7 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
                   ],
                 ),
               ),
-              if (showActions)
+              if (_canDelete)
                 Opacity(
                   opacity: _hovered ? 1 : 0,
                   child: IconButton(
@@ -523,6 +531,9 @@ Future<bool?> confirmDeletePost(BuildContext context, {required bool isPost}) {
           child: const Text('Cancel'),
         ),
         TextButton(
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(context).colorScheme.error,
+          ),
           onPressed: () => Navigator.of(context).pop(true),
           child: const Text('Delete'),
         ),

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -477,6 +477,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     channelId: widget.channelId,
     spaceId: widget.spaceId,
     root: _message,
+    canManageMessages: widget.canManageMessages,
   );
 
   void _report() {

--- a/lib/features/spaces/views/accord_home_messages.dart
+++ b/lib/features/spaces/views/accord_home_messages.dart
@@ -231,6 +231,8 @@ class _MessagePaneState extends ConsumerState<_MessagePane> {
                 channelId: channelId,
                 spaceId: spaceId,
                 canPost: canSend || canManageMessages,
+                canManageMessages: canManageMessages,
+                currentUserId: currentUserId,
               ),
             ),
           ],

--- a/test/features/messaging/forum_view_logic_test.dart
+++ b/test/features/messaging/forum_view_logic_test.dart
@@ -1,0 +1,64 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/components/forum_view.dart';
+import 'package:bonfire/features/messaging/components/thread_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveForumPostTitle', () {
+    test('uses title when present', () {
+      final m = AccordMessage(title: 'My title', content: 'body text');
+      expect(resolveForumPostTitle(m), 'My title');
+    });
+
+    test('trims whitespace from title', () {
+      final m = AccordMessage(title: '  trimmed  ', content: 'body');
+      expect(resolveForumPostTitle(m), 'trimmed');
+    });
+
+    test('falls back to first non-empty content line when title absent', () {
+      final m = AccordMessage(title: null, content: '\nfirst line\nsecond');
+      expect(resolveForumPostTitle(m), 'first line');
+    });
+
+    test('falls back to first non-empty content line when title is empty', () {
+      final m = AccordMessage(title: '', content: 'only line');
+      expect(resolveForumPostTitle(m), 'only line');
+    });
+
+    test('falls back to first non-empty content line when title is whitespace', () {
+      final m = AccordMessage(title: '   ', content: 'body');
+      expect(resolveForumPostTitle(m), 'body');
+    });
+
+    test('returns "Untitled post" when title and content are both empty', () {
+      final m = AccordMessage(title: null, content: '');
+      expect(resolveForumPostTitle(m), 'Untitled post');
+    });
+
+    test('returns "Untitled post" when content has only blank lines', () {
+      final m = AccordMessage(title: null, content: '\n  \n');
+      expect(resolveForumPostTitle(m), 'Untitled post');
+    });
+
+    test('non-String title (e.g. null object field) falls back to content', () {
+      // AccordMessage.title is Object? — a non-String value should fall through
+      final m = AccordMessage(title: 42, content: 'body');
+      expect(resolveForumPostTitle(m), 'body');
+    });
+  });
+
+  group('ThreadResult', () {
+    test('edited carries the updated root', () {
+      final msg = AccordMessage(id: 'abc', content: 'hi');
+      final result = ThreadResult.edited(msg);
+      expect(result.root, same(msg));
+      expect(result.deleted, isFalse);
+    });
+
+    test('deleted has no root and deleted=true', () {
+      const result = ThreadResult.deleted();
+      expect(result.root, isNull);
+      expect(result.deleted, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #130.

Revamps the forum channel UI from a bare `ListTile` list into a traditional forum board with the post-management affordances people expect.

## Forum index (`forum_view.dart`)
- **Richer rows**: author avatar, post title with a pinned 📌 badge, a metadata line (`by Author · created · last reply …`), a content preview, and a reply-count chip.
- **Sort control**: *Latest activity* (default), *Newest*, *Most replies* — pinned posts always float to the top — plus a live post count and pull-to-refresh.
- **Per-post actions** via overflow button / long-press / right-click: Open, Edit (author), Pin/Unpin (mods), Delete (author or mods), all permission-gated.
- **Fixes the `(untitled)` leak**: falls back to the first body line, then "Untitled post".

## Thread view (`thread_view.dart`)
- **Per-message actions** (Copy / Edit / Delete) for both the editable root post and replies, mirroring the main message view.
- `showAccordThread` now returns a `ThreadResult` so a root edit/delete inside the thread refreshes the forum row without a full reload.

## Wiring
- `accord_home_messages.dart` passes `canManageMessages` + `currentUserId` into `ForumChannelView`.
- `accord_home_message_row.dart` passes `canManageMessages` into `showAccordThread`.

Permissions reuse the existing `manage_messages` computation and `isOwn` checks; the edit/delete/pin endpoints already existed in `MessagesApi`.

## Acceptance criteria
- [x] Forum index uses a richer, forum-style row (author, timestamps, reply count, badges).
- [x] Posts have working actions including edit and delete (permission-gated).
- [x] Thread view exposes per-message actions consistent with the main message view.
- [x] Sort/filter affordance for the post list.

**Not included:** tag/category filtering and a locked badge — `AccordMessage`/`AccordChannel` have no tag or per-post lock fields yet, so there's no data to drive them.

## Testing
- `flutter analyze --no-fatal-infos` — clean on changed files.
- `flutter test` — all 274 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)