### PR TITLE
QR-code 2FA setup and consolidated account settings

### DIFF
--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:bonfire/features/settings/views/settings_backup.dart';
 import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/views/accord_account_settings.dart';
 import 'package:bonfire/features/user/views/accord_profile_edit.dart';
 import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
@@ -233,6 +234,15 @@ class AccordSettingsScreen extends ConsumerWidget {
             subtitle: const Text('Display name, bio, avatar'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () => showAccordProfileEdit(context),
+          ),
+          ListTile(
+            leading: Icon(Icons.lock_outline, color: colors.dirtyWhite),
+            title: const Text('Password & Security'),
+            subtitle: const Text(
+              'Password, two-factor authentication, delete account',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => showAccordAccountSettings(context),
           ),
           if (ref.watch(connectionsControllerProvider).hasMultiple)
             ListTile(

--- a/lib/features/user/components/self_status_button.dart
+++ b/lib/features/user/components/self_status_button.dart
@@ -3,7 +3,6 @@ import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
-import 'package:bonfire/features/user/views/accord_account_settings.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,8 +45,6 @@ class SelfStatusButton extends ConsumerWidget {
       tooltip: customStatus ?? 'Set status',
       onSelected: (value) {
         switch (value) {
-          case _accountValue:
-            showAccordAccountSettings(context);
           case _customValue:
             _showCustomStatusDialog(context, ref, userId, status, customStatus);
           case _clearCustomValue:
@@ -94,23 +91,11 @@ class SelfStatusButton extends ConsumerWidget {
               ],
             ),
           ),
-        const PopupMenuDivider(),
-        PopupMenuItem(
-          value: _accountValue,
-          child: Row(
-            children: [
-              Icon(Icons.manage_accounts, size: 16, color: colors.gray),
-              const SizedBox(width: 10),
-              const Text('Account settings'),
-            ],
-          ),
-        ),
       ],
       icon: Icon(Icons.circle, size: 16, color: dotColor),
     );
   }
 
-  static const String _accountValue = '__account__';
   static const String _customValue = '__custom__';
   static const String _clearCustomValue = '__clear_custom__';
 

--- a/lib/features/user/views/accord_account_settings.dart
+++ b/lib/features/user/views/accord_account_settings.dart
@@ -8,6 +8,19 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
+/// Extracts the bare TOTP secret from an `otpauth://` URI, or returns the
+/// input unchanged when it is not an otpauth URI (e.g. already a plain secret).
+///
+/// `otpauth://totp/label?secret=BASE32SECRET&issuer=…` → `BASE32SECRET`
+String? extractTotpSecret(String? uri) {
+  if (uri == null) return null;
+  final match = RegExp(
+    r'[?&]secret=([^&]+)',
+    caseSensitive: false,
+  ).firstMatch(uri);
+  return match?.group(1) ?? uri;
+}
+
 /// Opens the account settings dialog: change password and manage two-factor
 /// authentication. The Accord analogue of Discord's "My Account" panel.
 Future<void> showAccordAccountSettings(BuildContext context) {
@@ -617,6 +630,7 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
                   data: _otpauth!,
                   size: 180,
                   backgroundColor: Colors.white,
+                  errorCorrectionLevel: QrErrorCorrectLevel.M,
                 ),
               ),
             ),
@@ -633,7 +647,7 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
               children: [
                 Expanded(
                   child: SelectableText(
-                    _secret ?? _otpauth ?? '',
+                    _secret ?? extractTotpSecret(_otpauth) ?? '',
                     style: theme.textTheme.bodyMedium,
                   ),
                 ),
@@ -641,7 +655,9 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
                   tooltip: 'Copy secret',
                   icon: const Icon(Icons.copy, size: 16),
                   onPressed: () => Clipboard.setData(
-                    ClipboardData(text: _secret ?? _otpauth ?? ''),
+                    ClipboardData(
+                      text: _secret ?? extractTotpSecret(_otpauth) ?? '',
+                    ),
                   ),
                 ),
               ],
@@ -652,10 +668,14 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
             controller: _code,
             enabled: !_busy,
             keyboardType: TextInputType.number,
+            maxLength: 6,
+            textInputAction: TextInputAction.done,
+            onSubmitted: (_) { if (!_busy) _verify(); },
             decoration: const InputDecoration(
               labelText: '6-digit code',
               isDense: true,
               border: OutlineInputBorder(),
+              counterText: '',
             ),
           ),
           if (_error != null) ...[

--- a/lib/features/user/views/accord_account_settings.dart
+++ b/lib/features/user/views/accord_account_settings.dart
@@ -6,6 +6,7 @@ import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 
 /// Opens the account settings dialog: change password and manage two-factor
 /// authentication. The Accord analogue of Discord's "My Account" panel.
@@ -68,7 +69,7 @@ class _AccountSettingsDialogState
                 children: [
                   Expanded(
                     child: Text(
-                      'Account settings',
+                      'Password & Security',
                       style: theme.textTheme.titleMedium,
                     ),
                   ),
@@ -598,9 +599,28 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
           ),
         ] else ...[
           Text(
-            'Add this secret to your authenticator app, then enter the code:',
+            'Scan this QR code with your authenticator app, or enter the '
+            'secret manually, then type the 6-digit code:',
             style: theme.textTheme.bodySmall!.copyWith(color: colors.gray),
           ),
+          if (_otpauth != null) ...[
+            const SizedBox(height: 12),
+            Center(
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                // White quiet zone so scanners read the code regardless of theme.
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: QrImageView(
+                  data: _otpauth!,
+                  size: 180,
+                  backgroundColor: Colors.white,
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
           Container(
             width: double.infinity,
@@ -609,9 +629,22 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
               color: colors.darkGray,
               borderRadius: BorderRadius.circular(8),
             ),
-            child: SelectableText(
-              _secret ?? _otpauth ?? '',
-              style: theme.textTheme.bodyMedium,
+            child: Row(
+              children: [
+                Expanded(
+                  child: SelectableText(
+                    _secret ?? _otpauth ?? '',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Copy secret',
+                  icon: const Icon(Icons.copy, size: 16),
+                  onPressed: () => Clipboard.setData(
+                    ClipboardData(text: _secret ?? _otpauth ?? ''),
+                  ),
+                ),
+              ],
             ),
           ),
           const SizedBox(height: 10),

--- a/test/features/user/totp_uri_test.dart
+++ b/test/features/user/totp_uri_test.dart
@@ -1,0 +1,37 @@
+import 'package:bonfire/features/user/views/accord_account_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('extractTotpSecret', () {
+    test('returns null for null input', () {
+      expect(extractTotpSecret(null), isNull);
+    });
+
+    test('extracts secret from a standard otpauth URI', () {
+      const uri =
+          'otpauth://totp/user%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=ExampleServer';
+      expect(extractTotpSecret(uri), 'JBSWY3DPEHPK3PXP');
+    });
+
+    test('extracts secret when it is not the first query param', () {
+      const uri =
+          'otpauth://totp/label?issuer=Foo&secret=BASE32ABC&digits=6';
+      expect(extractTotpSecret(uri), 'BASE32ABC');
+    });
+
+    test('is case-insensitive for the secret key', () {
+      const uri = 'otpauth://totp/label?Secret=MIXEDCASE123';
+      expect(extractTotpSecret(uri), 'MIXEDCASE123');
+    });
+
+    test('returns the input unchanged when there is no secret param', () {
+      const plain = 'JBSWY3DPEHPK3PXP';
+      expect(extractTotpSecret(plain), plain);
+    });
+
+    test('returns the input unchanged for a plain secret (no otpauth scheme)', () {
+      const plain = 'ABC123DEF456';
+      expect(extractTotpSecret(plain), plain);
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Two related account/security UX improvements.

### 1. QR-code 2FA enrollment
The 2FA setup previously showed only the TOTP secret as plain text, forcing users to type it into their authenticator app by hand. Now it renders the server's `otpauth` URI as a scannable **QR code** (using `qr_flutter`, already a dependency).

- QR sits on a white quiet-zone background so it scans reliably regardless of the app theme.
- The secret remains as copyable text (with a copy button) as a manual-entry fallback for servers that only return a bare secret.

### 2. Consolidated account settings
Account security (password, 2FA, delete account) was only reachable from a "Account settings" item buried in the avatar/status popup menu — separate from every other profile/account setting, which all live in **Settings → Account**.

- Added a **"Password & Security"** tile to Settings → Account (under "Edit profile") that opens the same dialog.
- Removed the "Account settings" item from the status popup, so the avatar button is now a **pure status picker** (online/idle/dnd/invisible + custom status).
- Retitled the dialog from "Account settings" to "Password & Security" to match its new entry point.

**New end-to-end path:** Settings → Account → Password & Security → Enable 2FA → scan the QR code.

## Why
- Manual secret entry is error-prone; QR scanning is the expected 2FA enrollment flow.
- One predictable home for account management instead of two divergent entry points.

## Reviewer notes
- No new dependencies — `qr_flutter` was already in `pubspec.yaml`/`pubspec.lock`.
- `flutter analyze --no-fatal-infos` passes clean on all three changed files.
- Not yet exercised in a running app (no device booted in this environment); changes are UI-only and analyzer-verified.

## Files
- `lib/features/user/views/accord_account_settings.dart` — QR code + copy button; dialog retitle
- `lib/features/settings/views/accord_settings_screen.dart` — "Password & Security" tile
- `lib/features/user/components/self_status_button.dart` — remove account item; status-picker only

🤖 Generated with [Claude Code](https://claude.com/claude-code)