### PR TITLE
fix(channels): use ReorderableListView.onReorder; gate CI on stable too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # The repo pins the Flutter channel in .fvmrc; keep this in sync with it.
+  # Channel used by the *build* job below. The *analyze* job now matrix-tests
+  # both beta and stable (see strategy.matrix.channel), so it ignores this.
+  # Keep in sync with .fvmrc and release.yml.
   FLUTTER_CHANNEL: beta
   # Workspace-local pub cache so actions/cache can persist it (incl. the
   # flutter_webrtc git checkout + its downloaded libwebrtc binary).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,19 @@ env:
 
 jobs:
   analyze:
-    name: Analyze & Test
+    name: Analyze & Test (${{ matrix.channel }})
     runs-on: ubuntu-latest
+    strategy:
+      # Run every channel even if one fails, so a stable-only break and a
+      # beta-only break are both reported in the same run.
+      fail-fast: false
+      matrix:
+        # Gate on both the pinned dev channel (.fvmrc) AND stable. A widget/SDK
+        # API that diverges between channels — e.g. ReorderableListView's
+        # onReorder vs onReorderItem (#138, #107) — is a hard error on one and
+        # silently tolerated on the other; analyzing a single channel lets that
+        # land on master. Catching it here is the cheap smoke test.
+        channel: [beta, stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,23 +55,24 @@ jobs:
       - name: Cache pub + native deps
         uses: actions/cache@v4
         with:
+          # Channel in the key so beta/stable don't clobber each other's cache.
+          key: pub-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('pubspec.lock') }}
           path: ${{ github.workspace }}/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-${{ runner.os }}-${{ matrix.channel }}-
 
       - name: Cache codegen (build_runner)
         uses: actions/cache@v4
         with:
           path: .dart_tool/build
-          key: codegen-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          key: codegen-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
-            codegen-${{ runner.os }}-
+            codegen-${{ runner.os }}-${{ matrix.channel }}-
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          channel: ${{ matrix.channel }}
           cache: true
 
       - name: Install dependencies

--- a/lib/features/spaces/views/accord_home_channels.dart
+++ b/lib/features/spaces/views/accord_home_channels.dart
@@ -726,10 +726,12 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
     moved.parentId = null;
   }
 
-  // [newIndex] is already adjusted for the item removed at [oldIndex]
-  // (ReorderableListView.onReorderItem semantics): it's the target index within
-  // the post-removal list, so no manual decrement is needed.
+  // [ReorderableListView.onReorder] reports [newIndex] in pre-removal
+  // coordinates (the slot is counted as if the dragged item were still
+  // present), so apply the canonical decrement to convert it to the target
+  // index within the post-removal list that the logic below expects.
   void _onReorder(int oldIndex, int newIndex) {
+    if (newIndex > oldIndex) newIndex -= 1;
     final visible = _visible;
     final moved = visible[oldIndex];
     final newVisible = [...visible]..removeAt(oldIndex);
@@ -856,7 +858,7 @@ class _ChannelDragListState extends ConsumerState<_ChannelDragList> {
       padding: const EdgeInsets.symmetric(vertical: 8),
       buildDefaultDragHandles: false,
       itemCount: visible.length,
-      onReorderItem: _onReorder,
+      onReorder: _onReorder,
       itemBuilder: (context, index) {
         final entry = visible[index];
         return ReorderableDelayedDragStartListener(

--- a/test/features/channels/channel_sort_test.dart
+++ b/test/features/channels/channel_sort_test.dart
@@ -13,6 +13,23 @@ AccordChannel _ch(String id, {Object? position, String? parentId}) {
   );
 }
 
+// Applies the canonical ReorderableListView.onReorder index adjustment:
+// newIndex is in pre-removal coordinates (the dragged slot still counted),
+// so subtract 1 when dragging down to get the post-removal insertion point.
+int _adjustReorder(int oldIndex, int newIndex) =>
+    newIndex > oldIndex ? newIndex - 1 : newIndex;
+
+// Simulates one reorder operation on a simple list of strings and returns the
+// result. Mirrors the pattern used in _ChannelReorderState._onReorder and
+// _ChannelDragListState._onReorder.
+List<T> _applyReorder<T>(List<T> items, int oldIndex, int newIndex) {
+  newIndex = _adjustReorder(oldIndex, newIndex);
+  final result = [...items];
+  final item = result.removeAt(oldIndex);
+  result.insert(newIndex, item);
+  return result;
+}
+
 void main() {
   group('parseChannelPosition', () {
     test('int value returned as-is', () {
@@ -57,6 +74,55 @@ void main() {
       final before = [_ch('1', position: 0, parentId: null)];
       final after = [_ch('1', position: 0, parentId: 'cat1')];
       expect(channelListSignature(before), isNot(channelListSignature(after)));
+    });
+  });
+
+  // Tests for the canonical ReorderableListView.onReorder index adjustment.
+  // Flutter's onReorder reports newIndex in pre-removal coordinates (the dragged
+  // slot is still counted), so subtracting 1 when dragging down is required to
+  // convert to the post-removal insertion point. This is the fix from #138.
+  group('reorder index adjustment', () {
+    test('drag down by one slot', () {
+      // oldIndex=0, newIndex=1 pre-removal → adjusted to 0 → no-op (can't move
+      // to the slot immediately below itself). After adjust: item stays at 0.
+      expect(_applyReorder(['A', 'B', 'C'], 0, 1), ['A', 'B', 'C']);
+    });
+
+    test('drag down two slots', () {
+      // A [0] dragged to position 2 (pre-removal). After decrement: insert at 1.
+      expect(_applyReorder(['A', 'B', 'C'], 0, 2), ['B', 'A', 'C']);
+    });
+
+    test('drag down to last position', () {
+      // Flutter passes newIndex == itemCount when dragging to the very end.
+      // After decrement: last index in the post-removal list.
+      expect(_applyReorder(['A', 'B', 'C', 'D'], 0, 4), ['B', 'C', 'D', 'A']);
+    });
+
+    test('drag up by one slot', () {
+      // newIndex < oldIndex → no decrement.
+      expect(_applyReorder(['A', 'B', 'C'], 2, 1), ['A', 'C', 'B']);
+    });
+
+    test('drag up to first position', () {
+      expect(_applyReorder(['A', 'B', 'C', 'D'], 3, 0), ['D', 'A', 'B', 'C']);
+    });
+
+    test('drag up multiple slots', () {
+      expect(_applyReorder(['A', 'B', 'C', 'D'], 3, 1), ['A', 'D', 'B', 'C']);
+    });
+
+    test('without adjustment drag-down lands one slot too low (regression guard)', () {
+      // Without the decrement a drag from 0 to newIndex=2 would insert at 2,
+      // placing the item one position further down than intended.
+      final list = ['A', 'B', 'C', 'D'];
+      final bugged = [...list];
+      final item = bugged.removeAt(0);
+      bugged.insert(2, item); // no adjustment
+      expect(bugged, ['B', 'C', 'A', 'D']); // A is one slot too low
+
+      final fixed = _applyReorder(list, 0, 2); // with adjustment
+      expect(fixed, ['B', 'A', 'C', 'D']); // A is in the correct position
     });
   });
 }


### PR DESCRIPTION
Fixes #138.

## Problem
`lib/features/spaces/views/accord_home_channels.dart` called `ReorderableListView.builder` with `onReorderItem:`, which is not a parameter on Flutter's built-in `ReorderableListView` — it requires `onReorder:`. On stable this is two hard `flutter analyze` errors (`missing_required_argument` + `undefined_named_parameter`), so `flutter analyze` is non-clean on `master` and any build touching the file fails.

## Fix
- Renamed `onReorderItem:` → `onReorder:`.
- The two APIs differ in `newIndex` semantics: `onReorderItem` reported the target index in **post-removal** coordinates, while Flutter's `onReorder` reports it **pre-removal** (the dragged slot is still counted). Added the canonical `if (newIndex > oldIndex) newIndex -= 1;` at the top of `_onReorder` so the existing logic — which indexes into the post-removal list — stays correct and drag-**down** moves don't land one slot too low.
- Updated the now-inaccurate comment.

Verified clean with stable 3.38.1 (the toolchain in the issue):
```
Analyzing accord_home_channels.dart...
No issues found!
```

## Why it reached master, and the CI guard
The error landed in #107 and CI was **green** — because the analyze gate only ran the pinned **`beta`** channel, which tolerated `onReorderItem`. A channel-skew break sailed through.

This PR matrixes the `analyze` job over **`[beta, stable]`** (`fail-fast: false`), so a widget/SDK API that's valid on one channel but a hard error on the other now fails the merge gate. Cache keys include the channel so the legs don't clobber each other.

**Note:** this makes `stable` a hard blocker, including for releases (`release.yml` reuses this gate via `workflow_call`). The tree is currently clean on stable. If you'd prefer `stable` be advisory (report-only) until the port settles, that's a one-line `continue-on-error` change — shout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)