### PR TITLE
refactor: DRY sweep — shared helpers & components (net -116 LOC)

### DIFF
--- a/lib/features/admin/views/admin_reports_tab.dart
+++ b/lib/features/admin/views/admin_reports_tab.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
@@ -118,7 +119,7 @@ class _AdminReportsTabState extends ConsumerState<AdminReportsTab> {
     });
     if (!mounted) return;
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to resolve');
+      setState(() => _error = result.errorOr('Failed to resolve'));
       return;
     }
     setState(() => _reports.removeWhere((e) => e['id']?.toString() == id));
@@ -148,7 +149,7 @@ class _AdminReportsTabState extends ConsumerState<AdminReportsTab> {
     if (!mounted) return;
     setState(() => _busy = false);
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to kick');
+      setState(() => _error = result.errorOr('Failed to kick'));
       return;
     }
     await _resolve(r, 'actioned', actionTaken: 'kick_member');
@@ -168,7 +169,7 @@ class _AdminReportsTabState extends ConsumerState<AdminReportsTab> {
     if (!mounted) return;
     setState(() => _busy = false);
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to ban');
+      setState(() => _error = result.errorOr('Failed to ban'));
       return;
     }
     await _resolve(r, 'actioned', actionTaken: 'ban_member');
@@ -189,7 +190,7 @@ class _AdminReportsTabState extends ConsumerState<AdminReportsTab> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to delete message');
+          _error = result.errorOr('Failed to delete message'));
       return;
     }
     await _resolve(r, 'actioned', actionTaken: 'delete_message');

--- a/lib/features/admin/views/admin_settings_tab.dart
+++ b/lib/features/admin/views/admin_settings_tab.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
@@ -65,7 +66,7 @@ class _AdminSettingsTabState extends ConsumerState<AdminSettingsTab> {
     if (!result.ok) {
       setState(() {
         _loading = false;
-        _error = result.error?.toString() ?? 'Failed to load settings';
+        _error = result.errorOr('Failed to load settings');
       });
       return;
     }
@@ -113,7 +114,7 @@ class _AdminSettingsTabState extends ConsumerState<AdminSettingsTab> {
     setState(() => _saving = false);
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to save settings');
+          _error = result.errorOr('Failed to save settings'));
       return;
     }
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(

--- a/lib/features/admin/views/admin_spaces_tab.dart
+++ b/lib/features/admin/views/admin_spaces_tab.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
@@ -53,7 +54,7 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to load spaces';
+        _error = result.errorOr('Failed to load spaces');
       });
       return;
     }
@@ -96,7 +97,7 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to create space');
+          _error = result.errorOr('Failed to create space'));
       return;
     }
     _load();
@@ -117,7 +118,7 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to delete space';
+        _error = result.errorOr('Failed to delete space');
       });
       return;
     }
@@ -147,7 +148,7 @@ class _AdminSpacesTabState extends ConsumerState<AdminSpacesTab> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to transfer ownership';
+        _error = result.errorOr('Failed to transfer ownership');
       });
       return;
     }

--- a/lib/features/admin/views/admin_users_tab.dart
+++ b/lib/features/admin/views/admin_users_tab.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -60,7 +61,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     if (!result.ok) {
       setState(() {
         _loading = false;
-        _error = result.error?.toString() ?? 'Failed to load users';
+        _error = result.errorOr('Failed to load users');
       });
       return;
     }
@@ -85,7 +86,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     if (!result.ok) {
       setState(() {
         _loadingMore = false;
-        _error = result.error?.toString() ?? 'Failed to load more';
+        _error = result.errorOr('Failed to load more');
       });
       return;
     }
@@ -119,7 +120,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     if (!mounted) return;
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to update user');
+          _error = result.errorOr('Failed to update user'));
       return;
     }
     setState(() => user.isAdmin = value);
@@ -144,7 +145,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to update user');
+          _error = result.errorOr('Failed to update user'));
       return;
     }
     setState(() => user.disabled = disable);
@@ -165,7 +166,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(() =>
-          _error = result.error?.toString() ?? 'Failed to reset password');
+          _error = result.errorOr('Failed to reset password'));
       return;
     }
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
@@ -189,7 +190,7 @@ class _AdminUsersTabState extends ConsumerState<AdminUsersTab> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to delete user';
+        _error = result.errorOr('Failed to delete user');
       });
       return;
     }

--- a/lib/features/channels/components/channel_permissions.dart
+++ b/lib/features/channels/components/channel_permissions.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
@@ -324,7 +325,7 @@ class _ChannelPermissionsDialogState
       if (active.contains(id)) continue;
       final res = await client.channels.deleteOverwrite(widget.channel.id, id);
       if (!res.ok) {
-        err = res.error?.toString() ?? 'Failed to update permissions';
+        err = res.errorOr('Failed to update permissions');
         break;
       }
     }
@@ -336,7 +337,7 @@ class _ChannelPermissionsDialogState
           {'type': p.$2, 'allow': p.$3, 'deny': p.$4},
         );
         if (!res.ok) {
-          err = res.error?.toString() ?? 'Failed to update permissions';
+          err = res.errorOr('Failed to update permissions');
           break;
         }
       }

--- a/lib/features/developer/views/developer_settings_page.dart
+++ b/lib/features/developer/views/developer_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/developer/controllers/mcp_server_controller.dart';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
@@ -36,16 +37,8 @@ class DeveloperSettingsPage extends ConsumerWidget {
     final controller = ref.read(settingsControllerProvider.notifier);
     final server = ref.watch(mcpServerControllerProvider);
 
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Developer'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
+    return SettingsScaffold(
+      title: 'Developer',
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [

--- a/lib/features/developer/views/developer_settings_page.dart
+++ b/lib/features/developer/views/developer_settings_page.dart
@@ -78,7 +78,15 @@ class DeveloperSettingsPage extends ConsumerWidget {
                     controller.setMcpGroupAllowed(group, v ?? false),
               ),
             const Divider(height: 24),
-            _ActivityHeader(),
+            SectionHeader(
+              'Recent activity',
+              trailing: TextButton(
+                onPressed: () => ref
+                    .read(mcpServerControllerProvider.notifier)
+                    .clearActivity(),
+                child: const Text('Clear'),
+              ),
+            ),
             if (server.activity.isEmpty)
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
@@ -216,34 +224,6 @@ class _TokenTile extends ConsumerWidget {
             onPressed: () => ref
                 .read(settingsControllerProvider.notifier)
                 .regenerateMcpToken(),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ActivityHeader extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = BonfireThemeExtension.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 8, 4),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              'RECENT ACTIVITY',
-              style: Theme.of(context)
-                  .textTheme
-                  .labelMedium!
-                  .copyWith(color: colors.gray, letterSpacing: 0.6),
-            ),
-          ),
-          TextButton(
-            onPressed: () =>
-                ref.read(mcpServerControllerProvider.notifier).clearActivity(),
-            child: const Text('Clear'),
           ),
         ],
       ),

--- a/lib/features/member/utils/permissions.dart
+++ b/lib/features/member/utils/permissions.dart
@@ -50,6 +50,14 @@ Set<String> accordEffectivePermissions({
 bool accordHasPermission(Set<String> perms, String perm) =>
     perms.contains(AccordPermission.administrator) || perms.contains(perm);
 
+/// Whether [perms] should reveal the space settings affordance: any of
+/// manage-space, manage-roles or view-audit-log. The gate shared by the space
+/// header menu and the channel list's settings gear.
+bool canManageSpaceSettings(Set<String> perms) =>
+    accordHasPermission(perms, AccordPermission.manageSpace) ||
+    accordHasPermission(perms, AccordPermission.manageRoles) ||
+    accordHasPermission(perms, AccordPermission.viewAuditLog);
+
 /// A sentinel "above everyone" position returned for instance admins and the
 /// space owner, so hierarchy checks treat them as outranking every real role.
 const int kAccordMaxRolePosition = 999999;

--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/events/controllers/connection.dart';
@@ -62,10 +63,7 @@ class _Roster extends ConsumerWidget {
             const <AccordRole>[],
       ),
     );
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-          (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null),
-    );
+    final cdnUrl = ref.watchCdnUrl();
     final presences = ref.watch(presenceControllerProvider);
 
     if (members == null) {
@@ -286,11 +284,7 @@ Future<void> _showMemberContextMenu(
   final overlay = Overlay.of(context).context.findRenderObject() as RenderBox?;
   if (overlay == null) return;
   final anchor = globalPos ?? overlay.size.center(Offset.zero);
-  final currentUserId = ref.read(
-    accordAuthProvider.select(
-      (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-    ),
-  );
+  final currentUserId = ref.readUserId();
   final isSelf = currentUserId != null && currentUserId == member.userId;
   final username = member.user?.username;
   final selected = await showMenu<String>(

--- a/lib/features/member/views/accord_member_popout.dart
+++ b/lib/features/member/views/accord_member_popout.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
@@ -84,7 +85,7 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
     } else {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? failure;
+        _error = result.errorOr(failure);
       });
     }
   }

--- a/lib/features/member/views/accord_member_popout.dart
+++ b/lib/features/member/views/accord_member_popout.dart
@@ -1,8 +1,6 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
@@ -282,16 +280,8 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
         (p) => accordCustomStatus(p, widget.userId),
       ),
     );
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
-    final currentUserId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
+    final currentUserId = ref.watchUserId();
 
     final name = member != null
         ? accordMemberName(member)

--- a/lib/features/messaging/components/box/accord_message_content.dart
+++ b/lib/features/messaging/components/box/accord_message_content.dart
@@ -1,6 +1,5 @@
 import 'package:accordkit/accordkit.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/channels/controllers/open_tabs.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
@@ -38,11 +37,7 @@ class AccordMessageContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
 
     final id = spaceId;
     if (id == null) {

--- a/lib/features/messaging/components/emoji_picker.dart
+++ b/lib/features/messaging/components/emoji_picker.dart
@@ -1,6 +1,5 @@
 import 'package:accordkit/accordkit.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
@@ -78,11 +77,7 @@ class _EmojiPickerSheetState extends ConsumerState<_EmojiPickerSheet> {
     super.dispose();
   }
 
-  String? get _cdnUrl => ref.read(
-    accordAuthProvider.select(
-      (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-    ),
-  );
+  String? get _cdnUrl => ref.readCdnUrl();
 
   List<AccordEmoji> get _customEmoji {
     final spaceId = widget.spaceId;

--- a/lib/features/messaging/components/forum_view.dart
+++ b/lib/features/messaging/components/forum_view.dart
@@ -251,8 +251,7 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
     final users = ref.watch(accordUsersControllerProvider);
     final ensureUser =
         ref.read(accordUsersControllerProvider.notifier).ensure;
-    final cdnUrl = ref.watch(accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
+    final cdnUrl = ref.watchCdnUrl();
     return Stack(
       children: [
         Column(

--- a/lib/features/messaging/components/thread_view.dart
+++ b/lib/features/messaging/components/thread_view.dart
@@ -115,8 +115,7 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
 
   AccordClient? get _client => ref.accordClient;
 
-  String? get _currentUserId => ref.read(accordAuthProvider
-      .select((s) => s is AccordAuthLoggedIn ? s.session.userId : null));
+  String? get _currentUserId => ref.readUserId();
 
   Future<void> _load() async {
     final client = _client;
@@ -271,8 +270,7 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     final users = ref.watch(accordUsersControllerProvider);
     final ensureUser =
         ref.read(accordUsersControllerProvider.notifier).ensure;
-    final cdnUrl = ref.watch(accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
+    final cdnUrl = ref.watchCdnUrl();
     final replies = _replies;
     final currentUserId = _currentUserId;
     final dialog = widget.dialog;

--- a/lib/features/profiles/views/profiles_page.dart
+++ b/lib/features/profiles/views/profiles_page.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/profiles/controllers/profiles_controller.dart';
+import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/features/profiles/models/device_profile.dart';
 import 'package:bonfire/features/profiles/views/app_restart.dart';
@@ -92,28 +93,14 @@ class ProfilesScreen extends ConsumerWidget {
     WidgetRef ref,
     DeviceProfile p,
   ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete profile'),
-        content: Text(
+    final confirmed = await showConfirmDialog(
+      context,
+      title: 'Delete profile',
+      message:
           "Delete '${p.name}' and all its accounts and settings? This cannot "
           'be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-            ),
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Delete',
+      danger: true,
     );
     if (confirmed != true) return;
     await ref.read(profilesControllerProvider.notifier).delete(p.id);

--- a/lib/features/profiles/views/profiles_page.dart
+++ b/lib/features/profiles/views/profiles_page.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/profiles/controllers/profiles_controller.dart';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/features/profiles/models/device_profile.dart';
 import 'package:bonfire/features/profiles/views/app_restart.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -24,16 +25,8 @@ class ProfilesScreen extends ConsumerWidget {
     final notifier = ref.read(profilesControllerProvider.notifier);
     final activeId = notifier.activeId;
 
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Device Profiles'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
+    return SettingsScaffold(
+      title: 'Device Profiles',
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _createProfile(context, ref),
         icon: const Icon(Icons.add),

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
+import 'package:bonfire/shared/components/color_swatch_chip.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/developer/views/developer_settings_page.dart';
@@ -24,17 +25,6 @@ import 'package:go_router/go_router.dart';
 /// Client settings: appearance (theme preset + accent), notifications, account.
 class AccordSettingsScreen extends ConsumerWidget {
   const AccordSettingsScreen({super.key});
-
-  static const _accentSwatches = <(int, String)>[
-    (0xFF2448BE, 'Blue'),
-    (0xFF5865F2, 'Blurple'),
-    (0xFF57F287, 'Green'),
-    (0xFFEB459E, 'Pink'),
-    (0xFFFEE75C, 'Yellow'),
-    (0xFFED4245, 'Red'),
-    (0xFF88C0D0, 'Cyan'),
-    (0xFFFF7A45, 'Orange'),
-  ];
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -90,14 +80,14 @@ class AccordSettingsScreen extends ConsumerWidget {
               spacing: 10,
               runSpacing: 10,
               children: [
-                _AccentSwatch(
+                ColorSwatchChip(
                   color: defaultAccentFor(settings.themePreset),
                   selected: settings.accentColor == null,
                   label: 'Default',
                   onTap: () => controller.setAccentColor(null),
                 ),
-                for (final (argb, name) in _accentSwatches)
-                  _AccentSwatch(
+                for (final (argb, name) in avatarColorPalette)
+                  ColorSwatchChip(
                     color: Color(argb),
                     selected: settings.accentColor == argb,
                     label: name,
@@ -499,44 +489,3 @@ class _MasterServerFieldState extends ConsumerState<_MasterServerField> {
   }
 }
 
-class _AccentSwatch extends StatelessWidget {
-  const _AccentSwatch({
-    required this.color,
-    required this.selected,
-    required this.onTap,
-    this.label,
-  });
-
-  final Color color;
-  final bool selected;
-  final VoidCallback onTap;
-  final String? label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    final checkColor =
-        ThemeData.estimateBrightnessForColor(color) == Brightness.light
-        ? Colors.black
-        : Colors.white;
-    final swatch = GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: 36,
-        height: 36,
-        decoration: BoxDecoration(
-          color: color,
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? colors.dirtyWhite : Colors.transparent,
-            width: 3,
-          ),
-        ),
-        child: selected ? Icon(Icons.check, size: 18, color: checkColor) : null,
-      ),
-    );
-    final label = this.label;
-    if (label == null || label.isEmpty) return swatch;
-    return Tooltip(message: label, child: swatch);
-  }
-}

--- a/lib/features/settings/views/connections_settings_page.dart
+++ b/lib/features/settings/views/connections_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -138,23 +139,15 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Connections'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
+    return SettingsScaffold(
+      title: 'Connections',
+      actions: [
+        IconButton(
+          tooltip: 'Refresh',
+          onPressed: _loading ? null : _load,
+          icon: const Icon(Icons.refresh),
         ),
-        actions: [
-          IconButton(
-            tooltip: 'Refresh',
-            onPressed: _loading ? null : _load,
-            icon: const Icon(Icons.refresh),
-          ),
-        ],
-      ),
+      ],
       body: _body(colors),
     );
   }

--- a/lib/features/settings/views/connections_settings_page.dart
+++ b/lib/features/settings/views/connections_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
@@ -123,9 +124,7 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
     if (!mounted) return;
     setState(() => _disconnecting.remove(conn.id));
     if (!result.ok) {
-      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-        SnackBar(content: Text('Failed: ${result.error ?? 'unknown error'}')),
-      );
+      showErrorSnack(context, result, prefix: 'Failed');
       return;
     }
     setState(() {

--- a/lib/features/settings/views/connections_settings_page.dart
+++ b/lib/features/settings/views/connections_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
@@ -94,27 +95,13 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
     if (client == null || conn.id.isEmpty || _disconnecting.contains(conn.id)) {
       return;
     }
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Disconnect'),
-        content: Text(
+    final confirmed = await showConfirmDialog(
+      context,
+      title: 'Disconnect',
+      message:
           'Disconnect ${conn.type}${conn.name.isNotEmpty ? ' (${conn.name})' : ''}?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-            ),
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Disconnect'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Disconnect',
+      danger: true,
     );
     if (confirmed != true || !mounted) return;
     setState(() => _disconnecting.add(conn.id));

--- a/lib/features/settings/views/privacy_settings_page.dart
+++ b/lib/features/settings/views/privacy_settings_page.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/components/section_header.dart';
@@ -127,16 +128,8 @@ class _PrivacySettingsScreenState extends ConsumerState<PrivacySettingsScreen> {
     final spaces = ref.watch(spacesControllerProvider) ?? const <AccordSpace>[];
     final userId = ref.watchUserId();
 
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Privacy & Data'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
+    return SettingsScaffold(
+      title: 'Privacy & Data',
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [

--- a/lib/features/settings/views/privacy_settings_page.dart
+++ b/lib/features/settings/views/privacy_settings_page.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
@@ -109,9 +110,7 @@ class _PrivacySettingsScreenState extends ConsumerState<PrivacySettingsScreen> {
     if (!mounted) return;
     setState(() => _leaving.remove(space.id));
     if (!result.ok) {
-      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-        SnackBar(content: Text('Failed: ${result.error ?? 'unknown error'}')),
-      );
+      showErrorSnack(context, result, prefix: 'Failed');
       return;
     }
     // Drop the space from the cache immediately; the gateway member.leave echo

--- a/lib/features/settings/views/privacy_settings_page.dart
+++ b/lib/features/settings/views/privacy_settings_page.dart
@@ -5,8 +5,6 @@ import 'package:bonfire/shared/utils/client_access.dart';
 import 'dart:typed_data';
 
 import 'package:accordkit/accordkit.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:file_picker/file_picker.dart';
@@ -128,11 +126,7 @@ class _PrivacySettingsScreenState extends ConsumerState<PrivacySettingsScreen> {
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
     final spaces = ref.watch(spacesControllerProvider) ?? const <AccordSpace>[];
-    final userId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final userId = ref.watchUserId();
 
     return Scaffold(
       backgroundColor: colors.background,

--- a/lib/features/spaces/views/accord_ban_list.dart
+++ b/lib/features/spaces/views/accord_ban_list.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
@@ -70,7 +71,7 @@ class _BanListState extends ConsumerState<_BanList> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to load bans';
+        _error = result.errorOr('Failed to load bans');
       });
       return;
     }
@@ -103,7 +104,7 @@ class _BanListState extends ConsumerState<_BanList> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to unban';
+        _error = result.errorOr('Failed to unban');
       });
       return;
     }

--- a/lib/features/spaces/views/accord_channel_reorder.dart
+++ b/lib/features/spaces/views/accord_channel_reorder.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/channels/utils/channel_sort.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
@@ -147,7 +148,7 @@ class _ChannelReorderState extends ConsumerState<_ChannelReorder> {
         if (!mounted) return;
         setState(() {
           _busy = false;
-          _error = result.error?.toString() ?? 'Failed to reorder';
+          _error = result.errorOr('Failed to reorder');
         });
         return;
       }

--- a/lib/features/spaces/views/accord_discovery.dart
+++ b/lib/features/spaces/views/accord_discovery.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 
 import 'package:accordkit/accordkit.dart';
@@ -183,7 +184,7 @@ class _AccordDiscoveryBodyState extends ConsumerState<AccordDiscoveryBody> {
 
     setState(() {
       if (!result.ok) {
-        _error = result.error?.toString() ?? 'Failed to load directory';
+        _error = result.errorOr('Failed to load directory');
         _listings = const [];
         return;
       }
@@ -247,7 +248,7 @@ class _AccordDiscoveryBodyState extends ConsumerState<AccordDiscoveryBody> {
     if ((result.ok || result.statusCode == 409) && space is AccordSpace) {
       ref.read(spacesControllerProvider.notifier).upsertSpace(space);
     } else if (!result.ok && result.statusCode != 409) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to join');
+      setState(() => _error = result.errorOr('Failed to join'));
       return;
     }
     if (mounted) Navigator.of(context).maybePop();

--- a/lib/features/spaces/views/accord_emoji_management.dart
+++ b/lib/features/spaces/views/accord_emoji_management.dart
@@ -2,8 +2,6 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -182,11 +180,7 @@ class _EmojiManagementState extends ConsumerState<_EmojiManagement> {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
     final emojis = ref.watch(accordEmojisControllerProvider(widget.spaceId));
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
 
     return Dialog(
       child: ConstrainedBox(

--- a/lib/features/spaces/views/accord_emoji_management.dart
+++ b/lib/features/spaces/views/accord_emoji_management.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
@@ -62,7 +63,7 @@ class _EmojiManagementState extends ConsumerState<_EmojiManagement> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to upload emoji',
+        () => _error = result.errorOr('Failed to upload emoji'),
       );
       return;
     }
@@ -92,7 +93,7 @@ class _EmojiManagementState extends ConsumerState<_EmojiManagement> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to rename emoji',
+        () => _error = result.errorOr('Failed to rename emoji'),
       );
       return;
     }
@@ -126,7 +127,7 @@ class _EmojiManagementState extends ConsumerState<_EmojiManagement> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to delete emoji',
+        () => _error = result.errorOr('Failed to delete emoji'),
       );
       return;
     }

--- a/lib/features/spaces/views/accord_home_channels.dart
+++ b/lib/features/spaces/views/accord_home_channels.dart
@@ -76,9 +76,7 @@ class _ChannelListState extends ConsumerState<_ChannelList> {
         currentUserIsAdmin: isAdmin,
         previewRoleId: preview?.spaceId == id ? preview?.roleId : null,
       );
-      canManage = accordHasPermission(perms, AccordPermission.manageSpace) ||
-          accordHasPermission(perms, AccordPermission.manageRoles) ||
-          accordHasPermission(perms, AccordPermission.viewAuditLog);
+      canManage = canManageSpaceSettings(perms);
       canManageChannels =
           accordHasPermission(perms, AccordPermission.manageChannels);
       canInvite =

--- a/lib/features/spaces/views/accord_home_channels.dart
+++ b/lib/features/spaces/views/accord_home_channels.dart
@@ -47,10 +47,7 @@ class _ChannelListState extends ConsumerState<_ChannelList> {
             spacesControllerProvider
                 .select((s) => s?.firstWhereOrNull((sp) => sp.id == id)),
           );
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-          (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null),
-    );
+    final cdnUrl = ref.watchCdnUrl();
     final bannerUrl =
         space == null ? null : accordSpaceBannerUrl(space, cdnUrl);
 
@@ -67,14 +64,8 @@ class _ChannelListState extends ConsumerState<_ChannelList> {
     var canManageChannels = false;
     var canInvite = false;
     if (id != null) {
-      final currentUserId = ref.watch(
-        accordAuthProvider.select(
-            (s) => s is AccordAuthLoggedIn ? s.session.userId : null),
-      );
-      final isAdmin = ref.watch(
-        accordAuthProvider.select(
-            (s) => s is AccordAuthLoggedIn ? s.session.isAdmin : false),
-      );
+      final currentUserId = ref.watchUserId();
+      final isAdmin = ref.watchIsAdmin();
       final members = ref.watch(accordMembersControllerProvider(id));
       final preview = ref.watch(rolePreviewControllerProvider);
       final perms = accordEffectivePermissions(

--- a/lib/features/spaces/views/accord_home_message_row.dart
+++ b/lib/features/spaces/views/accord_home_message_row.dart
@@ -268,11 +268,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     final bottomGap = compact ? 3.0 : 6.0;
     final avatarRadius = compact ? 14.0 : 18.0;
     final gutter = compact ? 8.0 : 12.0;
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
     final avatarUrl = widget.author != null
         ? accordMemberAvatarUrl(widget.author, cdnUrl)
         : accordAvatarUrl(widget.authorUser, cdnUrl);

--- a/lib/features/spaces/views/accord_home_messages.dart
+++ b/lib/features/spaces/views/accord_home_messages.dart
@@ -173,14 +173,8 @@ class _MessagePaneState extends ConsumerState<_MessagePane> {
         : ref.watch(spacesControllerProvider
             .select((s) => s?.firstWhereOrNull((sp) => sp.id == spaceId)));
     final roles = space?.roles ?? const <AccordRole>[];
-    final currentUserId = ref.watch(
-      accordAuthProvider.select(
-          (s) => s is AccordAuthLoggedIn ? s.session.userId : null),
-    );
-    final isAdmin = ref.watch(
-      accordAuthProvider.select(
-          (s) => s is AccordAuthLoggedIn ? s.session.isAdmin : false),
-    );
+    final currentUserId = ref.watchUserId();
+    final isAdmin = ref.watchIsAdmin();
     final myRoles = (currentUserId == null ? null : members?[currentUserId])
             ?.roles ??
         const <String>[];

--- a/lib/features/spaces/views/accord_home_reactions.dart
+++ b/lib/features/spaces/views/accord_home_reactions.dart
@@ -150,11 +150,7 @@ class _ReactorsDialogState extends ConsumerState<_ReactorsDialog> {
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
     final users = _users;
     return AlertDialog(
       title: Text(

--- a/lib/features/spaces/views/accord_home_space_actions.dart
+++ b/lib/features/spaces/views/accord_home_space_actions.dart
@@ -23,10 +23,7 @@ List<AccordMenuEntry> _serverActionEntries(
     previewRoleId: preview?.spaceId == space.id ? preview?.roleId : null,
   );
   final canInvite = accordHasPermission(perms, AccordPermission.createInvites);
-  final canManage =
-      accordHasPermission(perms, AccordPermission.manageSpace) ||
-      accordHasPermission(perms, AccordPermission.manageRoles) ||
-      accordHasPermission(perms, AccordPermission.viewAuditLog);
+  final canManage = canManageSpaceSettings(perms);
   final isOwner = userId != null && space.ownerId == userId;
   final settingsCtl = ref.read(settingsControllerProvider.notifier);
   final muted = ref.read(settingsControllerProvider).isSpaceMuted(space.id);

--- a/lib/features/spaces/views/accord_reports.dart
+++ b/lib/features/spaces/views/accord_reports.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
@@ -93,7 +94,7 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
       if (result.ok) {
         _done = true;
       } else {
-        _error = result.error?.toString() ?? 'Failed to submit report';
+        _error = result.errorOr('Failed to submit report');
       }
     });
   }
@@ -276,7 +277,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     if (!result.ok) {
       setState(() {
         _loading = false;
-        _error = result.error?.toString() ?? 'Failed to load';
+        _error = result.errorOr('Failed to load');
       });
       return;
     }
@@ -308,7 +309,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     if (!result.ok) {
       setState(() {
         _loadingMore = false;
-        _error = result.error?.toString() ?? 'Failed to load more';
+        _error = result.errorOr('Failed to load more');
       });
       return;
     }
@@ -357,7 +358,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     });
     if (!mounted) return;
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to resolve');
+      setState(() => _error = result.errorOr('Failed to resolve'));
       return;
     }
     setState(
@@ -405,7 +406,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to delete message',
+        () => _error = result.errorOr('Failed to delete message'),
       );
       return;
     }
@@ -429,7 +430,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     if (!mounted) return;
     setState(() => _busy = false);
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to kick');
+      setState(() => _error = result.errorOr('Failed to kick'));
       return;
     }
     await _resolve(id, 'actioned', actionTaken: 'kick_member');
@@ -452,7 +453,7 @@ class _ReportsPanelState extends ConsumerState<_ReportsPanel> {
     if (!mounted) return;
     setState(() => _busy = false);
     if (!result.ok) {
-      setState(() => _error = result.error?.toString() ?? 'Failed to ban');
+      setState(() => _error = result.errorOr('Failed to ban'));
       return;
     }
     await _resolve(id, 'actioned', actionTaken: 'ban_member');

--- a/lib/features/spaces/views/accord_role_management.dart
+++ b/lib/features/spaces/views/accord_role_management.dart
@@ -1,8 +1,6 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/member/utils/permissions.dart';
@@ -78,16 +76,8 @@ class _RoleManagementState extends ConsumerState<_RoleManagement> {
     final space = ref
         .read(spacesControllerProvider)
         ?.firstWhereOrNull((s) => s.id == widget.spaceId);
-    final currentUserId = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
-    final isAdmin = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.isAdmin : false,
-      ),
-    );
+    final currentUserId = ref.readUserId();
+    final isAdmin = ref.readIsAdmin();
     final members = ref.read(accordMembersControllerProvider(widget.spaceId));
     return accordMyHighestRolePosition(
       space: space,

--- a/lib/features/spaces/views/accord_role_management.dart
+++ b/lib/features/spaces/views/accord_role_management.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
@@ -108,7 +109,7 @@ class _RoleManagementState extends ConsumerState<_RoleManagement> {
     if (!mounted) return null;
     setState(() {
       _busy = false;
-      if (!result.ok) _error = result.error?.toString() ?? failure;
+      if (!result.ok) _error = result.errorOr(failure);
     });
     return result.ok ? result.data as T? : null;
   }

--- a/lib/features/spaces/views/accord_space_settings.dart
+++ b/lib/features/spaces/views/accord_space_settings.dart
@@ -1,8 +1,6 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/permissions.dart';
@@ -156,16 +154,8 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     final space = ref
         .read(spacesControllerProvider)
         ?.firstWhereOrNull((s) => s.id == widget.spaceId);
-    final currentUserId = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
-    final isAdmin = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.isAdmin : false,
-      ),
-    );
+    final currentUserId = ref.readUserId();
+    final isAdmin = ref.readIsAdmin();
     final members = ref.read(accordMembersControllerProvider(widget.spaceId));
     final preview = ref.read(rolePreviewControllerProvider);
     return accordEffectivePermissions(
@@ -359,11 +349,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
   /// member cache so every roster/message row picks it up immediately.
   Future<void> _editOwnNickname() async {
     final client = _client;
-    final currentUserId = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final currentUserId = ref.readUserId();
     if (client == null || currentUserId == null) return;
     final members = ref.read(accordMembersControllerProvider(widget.spaceId));
     final me = members?[currentUserId];
@@ -450,11 +436,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
         (s) => s?.firstWhereOrNull((sp) => sp.id == widget.spaceId),
       ),
     );
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
     final perms = _perms();
     final canManageSpace = accordHasPermission(
       perms,
@@ -468,11 +450,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
       perms,
       AccordPermission.viewAuditLog,
     );
-    final currentUserId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final currentUserId = ref.watchUserId();
     final isOwner =
         space != null &&
         currentUserId != null &&

--- a/lib/features/spaces/views/accord_space_settings.dart
+++ b/lib/features/spaces/views/accord_space_settings.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
@@ -181,7 +182,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     if (!mounted) return;
     setState(() {
       _busy = false;
-      if (!result.ok) _error = result.error?.toString() ?? failure;
+      if (!result.ok) _error = result.errorOr(failure);
     });
     final space = result.data;
     if (result.ok && space is AccordSpace) {
@@ -336,7 +337,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to delete space';
+        _error = result.errorOr('Failed to delete space');
       });
       return;
     }
@@ -396,7 +397,7 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to update nickname',
+        () => _error = result.errorOr('Failed to update nickname'),
       );
       return;
     }

--- a/lib/features/spaces/views/accord_transfer_ownership.dart
+++ b/lib/features/spaces/views/accord_transfer_ownership.dart
@@ -2,8 +2,6 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/spaces/controllers/space.dart';
@@ -48,11 +46,7 @@ class _TransferOwnershipDialogState
   }
 
   Future<void> _submit() async {
-    final client = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.client : null,
-      ),
-    );
+    final client = ref.accordClient;
     final target = _selectedId;
     if (client == null || target == null) return;
     setState(() {

--- a/lib/features/spaces/views/accord_transfer_ownership.dart
+++ b/lib/features/spaces/views/accord_transfer_ownership.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
@@ -78,11 +79,7 @@ class _TransferOwnershipDialogState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
-    final currentUserId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final currentUserId = ref.watchUserId();
     final members = ref.watch(accordMembersControllerProvider(widget.spaceId));
     final candidates =
         (members?.values ?? const <AccordMember>[])

--- a/lib/features/spaces/views/accord_transfer_ownership.dart
+++ b/lib/features/spaces/views/accord_transfer_ownership.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
@@ -70,7 +71,7 @@ class _TransferOwnershipDialogState
     } else {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to transfer ownership';
+        _error = result.errorOr('Failed to transfer ownership');
       });
     }
   }

--- a/lib/features/updates/views/update_banner.dart
+++ b/lib/features/updates/views/update_banner.dart
@@ -1,7 +1,7 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
-import 'package:bonfire/theme/theme.dart';
+import 'package:bonfire/shared/components/app_banner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -32,9 +32,10 @@ class UpdateBanner extends ConsumerWidget {
 
     // A verified build is staged → offer the one-click apply.
     if (update.updateReady) {
-      return _Banner(
-        label: 'Update ready — ${release.name}. Tap to restart & install.',
-        onTap: update.installing ? null : () => notifier.applyUpdate(),
+      return AppBanner(
+        icon: Icons.system_update,
+        message: 'Update ready — ${release.name}. Tap to restart & install.',
+        onTap: update.installing ? () {} : () => notifier.applyUpdate(),
         onDismiss: () => notifier.dismissCurrent(),
       );
     }
@@ -48,59 +49,11 @@ class UpdateBanner extends ConsumerWidget {
         (!notifier.canInstallInPlace || update.phase == UpdatePhase.failed);
     if (!showViewBanner) return const SizedBox.shrink();
 
-    return _Banner(
-      label: 'Update available — ${release.name}. Tap to view.',
+    return AppBanner(
+      icon: Icons.system_update,
+      message: 'Update available — ${release.name}. Tap to view.',
       onTap: () => showUpdatesSettings(context),
       onDismiss: () => notifier.dismissCurrent(),
-    );
-  }
-}
-
-class _Banner extends StatelessWidget {
-  const _Banner({
-    required this.label,
-    required this.onTap,
-    required this.onDismiss,
-  });
-
-  final String label;
-  final VoidCallback? onTap;
-  final VoidCallback onDismiss;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    return Material(
-      color: colors.primary,
-      child: SafeArea(
-        bottom: false,
-        child: InkWell(
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: Row(
-              children: [
-                const Icon(Icons.system_update, size: 16, color: Colors.white),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    label,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(color: Colors.white, fontSize: 13),
-                  ),
-                ),
-                InkWell(
-                  onTap: onDismiss,
-                  child: const Padding(
-                    padding: EdgeInsets.all(4),
-                    child: Icon(Icons.close, size: 16, color: Colors.white),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/features/updates/views/updates_page.dart
+++ b/lib/features/updates/views/updates_page.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -33,16 +34,8 @@ class UpdatesScreen extends ConsumerWidget {
     final release = update.latest;
     final available = update.updateAvailable;
 
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Updates'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
+    return SettingsScaffold(
+      title: 'Updates',
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [

--- a/lib/features/updates/views/web_update_prompt.dart
+++ b/lib/features/updates/views/web_update_prompt.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:bonfire/features/updates/services/web_update.dart';
-import 'package:bonfire/theme/theme.dart';
+import 'package:bonfire/shared/components/app_banner.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 
@@ -46,45 +46,17 @@ class _WebUpdatePromptState extends State<WebUpdatePrompt> {
   @override
   Widget build(BuildContext context) {
     if (!kIsWeb || !_available || _dismissed) return const SizedBox.shrink();
-    final colors = BonfireThemeExtension.of(context);
-    return Material(
-      color: colors.primary,
-      child: SafeArea(
-        bottom: false,
-        child: InkWell(
-          onTap: applyWebUpdate,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: Row(
-              children: [
-                const Icon(Icons.refresh, size: 16, color: Colors.white),
-                const SizedBox(width: 8),
-                const Expanded(
-                  child: Text(
-                    'A new version is available — reload to update.',
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(color: Colors.white, fontSize: 13),
-                  ),
-                ),
-                TextButton(
-                  onPressed: applyWebUpdate,
-                  child: const Text(
-                    'Reload',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                ),
-                InkWell(
-                  onTap: () => setState(() => _dismissed = true),
-                  child: const Padding(
-                    padding: EdgeInsets.all(4),
-                    child: Icon(Icons.close, size: 16, color: Colors.white),
-                  ),
-                ),
-              ],
-            ),
-          ),
+    return AppBanner(
+      icon: Icons.refresh,
+      message: 'A new version is available — reload to update.',
+      onTap: applyWebUpdate,
+      onDismiss: () => setState(() => _dismissed = true),
+      actions: [
+        TextButton(
+          onPressed: applyWebUpdate,
+          child: const Text('Reload', style: TextStyle(color: Colors.white)),
         ),
-      ),
+      ],
     );
   }
 }

--- a/lib/features/user/components/self_status_button.dart
+++ b/lib/features/user/components/self_status_button.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
@@ -24,11 +25,7 @@ class SelfStatusButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = BonfireThemeExtension.of(context);
-    final userId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final userId = ref.watchUserId();
     final status = ref.watch(
       presenceControllerProvider.select(
         (p) => userId == null ? 'offline' : accordPresenceStatus(p, userId),

--- a/lib/features/user/components/self_status_button.dart
+++ b/lib/features/user/components/self_status_button.dart
@@ -1,7 +1,5 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/events/controllers/presence.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -119,11 +117,7 @@ class SelfStatusButton extends ConsumerWidget {
     String status,
     String text,
   ) {
-    final client = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.client : null,
-      ),
-    );
+    final client = ref.accordClient;
     if (client == null) return;
     final trimmed = text.trim();
     client.gateway.updatePresence(
@@ -148,11 +142,7 @@ class SelfStatusButton extends ConsumerWidget {
   }
 
   void _setStatus(WidgetRef ref, String? userId, String status) {
-    final client = ref.read(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.client : null,
-      ),
-    );
+    final client = ref.accordClient;
     if (client == null) return;
     // Preserve any custom status when only the status dot changes.
     final custom = userId == null

--- a/lib/features/user/views/accord_account_settings.dart
+++ b/lib/features/user/views/accord_account_settings.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
@@ -190,7 +191,7 @@ class _DangerZoneSectionState extends ConsumerState<_DangerZoneSection> {
     if (!result.ok) {
       setState(() {
         _busy = false;
-        _error = result.error?.toString() ?? 'Failed to delete account';
+        _error = result.errorOr('Failed to delete account');
       });
       return;
     }
@@ -314,7 +315,7 @@ class _PasswordSectionState extends ConsumerState<_PasswordSection> {
       _success = result.ok;
       _message = result.ok
           ? 'Password updated'
-          : result.error?.toString() ?? 'Failed to change password';
+          : result.errorOr('Failed to change password');
       if (result.ok) {
         _old.clear();
         _new.clear();
@@ -423,7 +424,7 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
         _secret = data['secret']?.toString();
         _otpauth = data['otpauth_uri']?.toString() ?? data['uri']?.toString();
       } else {
-        _error = result.error?.toString() ?? 'Failed to start 2FA setup';
+        _error = result.errorOr('Failed to start 2FA setup');
       }
     });
   }
@@ -454,7 +455,7 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
         _code.clear();
         widget.onChanged(true);
       } else {
-        _error = result.error?.toString() ?? 'Invalid code';
+        _error = result.errorOr('Invalid code');
       }
     });
   }
@@ -479,7 +480,7 @@ class _TwoFactorSectionState extends ConsumerState<_TwoFactorSection> {
         _backupCodes = null;
         widget.onChanged(false);
       } else {
-        _error = result.error?.toString() ?? 'Failed to disable 2FA';
+        _error = result.errorOr('Failed to disable 2FA');
       }
     });
   }

--- a/lib/features/user/views/accord_direct_messages.dart
+++ b/lib/features/user/views/accord_direct_messages.dart
@@ -2,8 +2,6 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/messaging/components/box/accord_message_content.dart';
 import 'package:bonfire/features/voice/controllers/call.dart';
@@ -116,11 +114,7 @@ class _DirectMessagesDialogState extends ConsumerState<_DirectMessagesDialog>
     super.dispose();
   }
 
-  String? get _selfId => ref.read(
-    accordAuthProvider.select(
-      (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-    ),
-  );
+  String? get _selfId => ref.readUserId();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/user/views/accord_profile_edit.dart
+++ b/lib/features/user/views/accord_profile_edit.dart
@@ -9,6 +9,7 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/shared/components/color_swatch_chip.dart';
 import 'package:bonfire/shared/components/image_crop_dialog.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -57,18 +58,6 @@ class _ProfileEditState extends ConsumerState<_ProfileEdit> {
   /// `accent_color`). `null` means "transparent" — the avatar falls back to the
   /// deterministic [accordAvatarColor] derived from the user ID.
   int? _accentColor;
-
-  /// Preset background swatches for the imageless avatar.
-  static const _avatarSwatches = <int>[
-    0xFF2448BE, // blue
-    0xFF5865F2, // blurple
-    0xFF57F287, // green
-    0xFFEB459E, // pink
-    0xFFFEE75C, // yellow
-    0xFFED4245, // red
-    0xFF88C0D0, // cyan
-    0xFFFF7A45, // orange
-  ];
 
   /// The profile loaded from the targeted server (drives the avatar preview).
   AccordUser? _loadedUser;
@@ -343,7 +332,7 @@ class _ProfileEditState extends ConsumerState<_ProfileEdit> {
                   spacing: 8,
                   runSpacing: 8,
                   children: [
-                    _ColorSwatch(
+                    ColorSwatchChip(
                       color: accordIdColor(session?.userId ?? ''),
                       selected: _accentColor == null,
                       transparent: true,
@@ -352,8 +341,8 @@ class _ProfileEditState extends ConsumerState<_ProfileEdit> {
                           ? null
                           : () => setState(() => _accentColor = null),
                     ),
-                    for (final argb in _avatarSwatches)
-                      _ColorSwatch(
+                    for (final (argb, _) in avatarColorPalette)
+                      ColorSwatchChip(
                         color: Color(argb),
                         selected: _accentColor == argb,
                         label: null,
@@ -410,50 +399,3 @@ Uint8List _toUint8(List<int> bytes) =>
     bytes is Uint8List ? bytes : Uint8List.fromList(bytes);
 
 /// A selectable avatar-background swatch. The [transparent] variant marks the
-/// "no chosen color" option (the avatar falls back to its auto color), drawn
-/// with a slash over the preview tint.
-class _ColorSwatch extends StatelessWidget {
-  const _ColorSwatch({
-    required this.color,
-    required this.selected,
-    required this.onTap,
-    this.label,
-    this.transparent = false,
-  });
-
-  final Color color;
-  final bool selected;
-  final VoidCallback? onTap;
-  final String? label;
-  final bool transparent;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    return Tooltip(
-      message: label ?? '',
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            border: Border.all(
-              color: selected ? colors.dirtyWhite : Colors.transparent,
-              width: 3,
-            ),
-          ),
-          child: Icon(
-            transparent
-                ? Icons.format_color_reset_outlined
-                : (selected ? Icons.check : null),
-            size: 18,
-            color: accordOnColor(color),
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/user/views/accord_profile_edit.dart
+++ b/lib/features/user/views/accord_profile_edit.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 
 import 'package:accordkit/accordkit.dart';
@@ -183,7 +184,7 @@ class _ProfileEditState extends ConsumerState<_ProfileEdit> {
     setState(() => _busy = false);
     if (!result.ok) {
       setState(
-        () => _error = result.error?.toString() ?? 'Failed to save profile',
+        () => _error = result.errorOr('Failed to save profile'),
       );
       return;
     }

--- a/lib/features/voice/views/incoming_call_overlay.dart
+++ b/lib/features/voice/views/incoming_call_overlay.dart
@@ -1,5 +1,4 @@
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
@@ -38,8 +37,7 @@ class IncomingCallOverlay extends ConsumerWidget {
     // Backfill the caller's profile if it isn't cached yet.
     ref.read(accordUsersControllerProvider.notifier).ensure(incoming.callerId);
     final users = ref.watch(accordUsersControllerProvider);
-    final cdnUrl = ref.watch(accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
+    final cdnUrl = ref.watchCdnUrl();
 
     final caller = users[incoming.callerId];
     final callerName = accordUserName(caller, fallback: 'Someone');

--- a/lib/features/voice/views/voice_participants.dart
+++ b/lib/features/voice/views/voice_participants.dart
@@ -1,6 +1,5 @@
 import 'package:accordkit/accordkit.dart';
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
@@ -49,8 +48,7 @@ class VoiceParticipantList extends ConsumerWidget {
         : ref.watch(spacesControllerProvider.select((s) =>
                 s?.firstWhereOrNull((sp) => sp.id == spaceId)?.roles)) ??
             const <AccordRole>[];
-    final cdnUrl = ref.watch(accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
+    final cdnUrl = ref.watchCdnUrl();
 
     final sorted = [...states]..sort((a, b) => _nameFor(a.userId, members, users)
         .toLowerCase()

--- a/lib/features/voice/views/voice_pip_overlay.dart
+++ b/lib/features/voice/views/voice_pip_overlay.dart
@@ -1,5 +1,4 @@
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/controllers/voice_states.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -139,8 +138,7 @@ class _VoicePipOverlayState extends ConsumerState<VoicePipOverlay> {
     final session = ref.read(voiceControllerProvider.notifier).session;
     if (session == null) return null;
     final voice = ref.read(voiceControllerProvider);
-    final myId = ref.read(accordAuthProvider
-        .select((s) => s is AccordAuthLoggedIn ? s.session.userId : null));
+    final myId = ref.readUserId();
 
     if (voice.selfStream && session.localScreenTrack != null) {
       return session.localScreenTrack;

--- a/lib/features/voice/views/voice_settings_screen.dart
+++ b/lib/features/voice/views/voice_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/shared/components/settings_scaffold.dart';
 import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
@@ -64,16 +65,8 @@ class _VoiceSettingsScreenState extends ConsumerState<VoiceSettingsScreen> {
       voiceControllerProvider.select((v) => v.isConnected),
     );
 
-    return Scaffold(
-      backgroundColor: colors.background,
-      appBar: AppBar(
-        backgroundColor: colors.foreground,
-        title: const Text('Voice & Video'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
+    return SettingsScaffold(
+      title: 'Voice & Video',
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [

--- a/lib/features/voice/views/voice_text_panel.dart
+++ b/lib/features/voice/views/voice_text_panel.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/features/authentication/models/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
@@ -99,8 +100,7 @@ class _VoiceTextPanelState extends ConsumerState<VoiceTextPanel> {
         ? null
         : ref.watch(accordMembersControllerProvider(widget.spaceId!));
     final users = ref.watch(accordUsersControllerProvider);
-    final cdnUrl = ref.watch(accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null));
+    final cdnUrl = ref.watchCdnUrl();
 
     String nameOf(String userId) => members?[userId] != null
         ? accordMemberName(members![userId], fallback: userId)

--- a/lib/features/voice/views/voice_text_panel.dart
+++ b/lib/features/voice/views/voice_text_panel.dart
@@ -1,6 +1,4 @@
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
@@ -77,8 +75,7 @@ class _VoiceTextPanelState extends ConsumerState<VoiceTextPanel> {
   Future<void> _send() async {
     final text = _input.text;
     if (text.trim().isEmpty || _sending) return;
-    final client = ref.read(accordAuthProvider
-        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    final client = ref.accordClient;
     if (client == null) return;
     setState(() => _sending = true);
     final ok = await ref

--- a/lib/features/voice/views/voice_view.dart
+++ b/lib/features/voice/views/voice_view.dart
@@ -1,5 +1,4 @@
-import 'package:bonfire/features/authentication/models/accord_auth.dart';
-import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
@@ -286,11 +285,7 @@ class _LobbyBody extends ConsumerWidget {
         ? null
         : ref.watch(accordMembersControllerProvider(spaceId!));
     final users = ref.watch(accordUsersControllerProvider);
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
 
     return Center(
       child: Column(
@@ -441,16 +436,8 @@ class _ConnectedBody extends ConsumerWidget {
         ? null
         : ref.watch(accordMembersControllerProvider(spaceId!));
     final users = ref.watch(accordUsersControllerProvider);
-    final cdnUrl = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null,
-      ),
-    );
-    final myId = ref.watch(
-      accordAuthProvider.select(
-        (s) => s is AccordAuthLoggedIn ? s.session.userId : null,
-      ),
-    );
+    final cdnUrl = ref.watchCdnUrl();
+    final myId = ref.watchUserId();
     final session = ref.read(voiceControllerProvider.notifier).session;
 
     String nameOf(String userId) => members?[userId] != null

--- a/lib/shared/components/app_banner.dart
+++ b/lib/shared/components/app_banner.dart
@@ -1,0 +1,63 @@
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// A slim, full-width banner across the top of the app (update prompts and the
+/// like): a primary-tinted [Material] bar with a leading [icon], a single-line
+/// [message], optional trailing [actions], and a dismiss ✕.
+///
+/// Consolidates the identical banner chrome shared by `UpdateBanner` and
+/// `WebUpdatePrompt`.
+class AppBanner extends StatelessWidget {
+  const AppBanner({
+    super.key,
+    required this.icon,
+    required this.message,
+    required this.onTap,
+    required this.onDismiss,
+    this.actions = const [],
+  });
+
+  final IconData icon;
+  final String message;
+  final VoidCallback onTap;
+  final VoidCallback onDismiss;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Material(
+      color: colors.primary,
+      child: SafeArea(
+        bottom: false,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              children: [
+                Icon(icon, size: 16, color: Colors.white),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    message,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white, fontSize: 13),
+                  ),
+                ),
+                ...actions,
+                InkWell(
+                  onTap: onDismiss,
+                  child: const Padding(
+                    padding: EdgeInsets.all(4),
+                    child: Icon(Icons.close, size: 16, color: Colors.white),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/components/color_swatch_chip.dart
+++ b/lib/shared/components/color_swatch_chip.dart
@@ -1,0 +1,68 @@
+import 'package:bonfire/features/member/utils/member_display.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// The shared accent / imageless-avatar color palette (ARGB value + name).
+const avatarColorPalette = <(int, String)>[
+  (0xFF2448BE, 'Blue'),
+  (0xFF5865F2, 'Blurple'),
+  (0xFF57F287, 'Green'),
+  (0xFFEB459E, 'Pink'),
+  (0xFFFEE75C, 'Yellow'),
+  (0xFFED4245, 'Red'),
+  (0xFF88C0D0, 'Cyan'),
+  (0xFFFF7A45, 'Orange'),
+];
+
+/// A 36×36 circular color swatch used by the accent and avatar color pickers.
+/// A selected swatch gets a light ring and a check icon; [transparent] swaps the
+/// check for a "no color" glyph (the avatar then falls back to its auto color).
+///
+/// Consolidates the identical `_AccentSwatch`/`_ColorSwatch` widgets that were
+/// copy-pasted into the settings and profile-edit screens.
+class ColorSwatchChip extends StatelessWidget {
+  const ColorSwatchChip({
+    super.key,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+    this.label,
+    this.transparent = false,
+  });
+
+  final Color color;
+  final bool selected;
+  final VoidCallback? onTap;
+  final String? label;
+  final bool transparent;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    final swatch = GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: selected ? colors.dirtyWhite : Colors.transparent,
+            width: 3,
+          ),
+        ),
+        child: Icon(
+          transparent
+              ? Icons.format_color_reset_outlined
+              : (selected ? Icons.check : null),
+          size: 18,
+          color: accordOnColor(color),
+        ),
+      ),
+    );
+    final label = this.label;
+    if (label == null || label.isEmpty) return swatch;
+    return Tooltip(message: label, child: swatch);
+  }
+}

--- a/lib/shared/components/section_header.dart
+++ b/lib/shared/components/section_header.dart
@@ -6,22 +6,34 @@ import 'package:flutter/material.dart';
 /// Consolidates the identical private `_SectionHeader`/`_Header` widgets that
 /// were copy-pasted across the settings, developer, voice and privacy screens.
 class SectionHeader extends StatelessWidget {
-  const SectionHeader(this.title, {super.key});
+  const SectionHeader(this.title, {super.key, this.trailing});
 
   final String title;
+
+  /// Optional widget pinned to the trailing edge of the header (e.g. a "Clear"
+  /// action). When present the title flexes and the right padding tightens.
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
+    final label = Text(
+      title.toUpperCase(),
+      style: Theme.of(context).textTheme.labelMedium!.copyWith(
+            color: colors.gray,
+            letterSpacing: 0.6,
+          ),
+    );
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-      child: Text(
-        title.toUpperCase(),
-        style: Theme.of(context).textTheme.labelMedium!.copyWith(
-              color: colors.gray,
-              letterSpacing: 0.6,
+      padding: EdgeInsets.fromLTRB(16, 12, trailing != null ? 8 : 16, 4),
+      child: trailing == null
+          ? label
+          : Row(
+              children: [
+                Expanded(child: label),
+                trailing!,
+              ],
             ),
-      ),
     );
   }
 }

--- a/lib/shared/components/settings_scaffold.dart
+++ b/lib/shared/components/settings_scaffold.dart
@@ -1,0 +1,42 @@
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// Standard chrome for a pushed settings sub-page: themed [Scaffold] +
+/// [AppBar] with a back button that calls `Navigator.maybePop`.
+///
+/// Consolidates the identical `Scaffold(backgroundColor → AppBar(…, leading:
+/// back))` shell that was copy-pasted into the connections, privacy, profiles,
+/// voice, updates and developer settings screens.
+class SettingsScaffold extends StatelessWidget {
+  const SettingsScaffold({
+    super.key,
+    required this.title,
+    required this.body,
+    this.actions,
+    this.floatingActionButton,
+  });
+
+  final String title;
+  final Widget body;
+  final List<Widget>? actions;
+  final Widget? floatingActionButton;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Scaffold(
+      backgroundColor: colors.background,
+      appBar: AppBar(
+        backgroundColor: colors.foreground,
+        title: Text(title),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        actions: actions,
+      ),
+      floatingActionButton: floatingActionButton,
+      body: body,
+    );
+  }
+}

--- a/lib/shared/utils/client_access.dart
+++ b/lib/shared/utils/client_access.dart
@@ -6,17 +6,47 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 AccordClient? _clientFromState(AccordAuthState s) =>
     s is AccordAuthLoggedIn ? s.client : null;
 
+String? _userIdFromState(AccordAuthState s) =>
+    s is AccordAuthLoggedIn ? s.session.userId : null;
+
+String? _cdnUrlFromState(AccordAuthState s) =>
+    s is AccordAuthLoggedIn ? s.session.server.cdnUrl : null;
+
+bool _isAdminFromState(AccordAuthState s) =>
+    s is AccordAuthLoggedIn && s.session.isAdmin;
+
 /// The currently authenticated [AccordClient], or `null` when logged out.
 ///
 /// Centralizes the `accordAuthProvider.select(...)` lookup that was otherwise
-/// copy-pasted into ~20 `ConsumerState` getters across the app.
+/// copy-pasted into ~20 `ConsumerState` getters across the app. The
+/// `watch*`/`read*` pairs cover the same authenticated-session fields (user id,
+/// CDN base, instance-admin flag) that were likewise inlined at ~40 sites; use
+/// the `watch*` variant in `build`/widgets and the `read*` variant in callbacks.
 extension AccordClientWidgetRef on WidgetRef {
   AccordClient? get accordClient =>
       read(accordAuthProvider.select(_clientFromState));
+
+  String? watchUserId() => watch(accordAuthProvider.select(_userIdFromState));
+  String? readUserId() => read(accordAuthProvider.select(_userIdFromState));
+
+  String? watchCdnUrl() => watch(accordAuthProvider.select(_cdnUrlFromState));
+  String? readCdnUrl() => read(accordAuthProvider.select(_cdnUrlFromState));
+
+  bool watchIsAdmin() => watch(accordAuthProvider.select(_isAdminFromState));
+  bool readIsAdmin() => read(accordAuthProvider.select(_isAdminFromState));
 }
 
 /// Same as [AccordClientWidgetRef], for provider/notifier `Ref` contexts.
 extension AccordClientRef on Ref {
   AccordClient? get accordClient =>
       read(accordAuthProvider.select(_clientFromState));
+
+  String? watchUserId() => watch(accordAuthProvider.select(_userIdFromState));
+  String? readUserId() => read(accordAuthProvider.select(_userIdFromState));
+
+  String? watchCdnUrl() => watch(accordAuthProvider.select(_cdnUrlFromState));
+  String? readCdnUrl() => read(accordAuthProvider.select(_cdnUrlFromState));
+
+  bool watchIsAdmin() => watch(accordAuthProvider.select(_isAdminFromState));
+  bool readIsAdmin() => read(accordAuthProvider.select(_isAdminFromState));
 }

--- a/lib/shared/utils/rest_result_ext.dart
+++ b/lib/shared/utils/rest_result_ext.dart
@@ -1,0 +1,23 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:flutter/material.dart';
+
+/// Error-message helpers for accordkit's [RestResult].
+///
+/// Consolidates the `result.error?.toString() ?? 'Failed to …'` idiom and the
+/// `'Failed: ${result.error ?? 'unknown error'}'` SnackBar that were repeated at
+/// ~50 call sites across the admin, moderation, settings and DM screens.
+extension RestResultErrorText on RestResult {
+  /// The error rendered as text, or [fallback] when there is none.
+  String errorOr(String fallback) => error?.toString() ?? fallback;
+}
+
+/// Shows a SnackBar reporting a failed [result] as `'<prefix>: <error>'`.
+void showErrorSnack(
+  BuildContext context,
+  RestResult result, {
+  required String prefix,
+}) {
+  ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+    SnackBar(content: Text('$prefix: ${result.error ?? 'unknown error'}')),
+  );
+}

--- a/test/features/member/permissions_test.dart
+++ b/test/features/member/permissions_test.dart
@@ -1,0 +1,49 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/member/utils/permissions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('canManageSpaceSettings', () {
+    test('returns false when perms is empty', () {
+      expect(canManageSpaceSettings({}), isFalse);
+    });
+
+    test('returns true when manageSpace is granted', () {
+      expect(
+        canManageSpaceSettings({AccordPermission.manageSpace}),
+        isTrue,
+      );
+    });
+
+    test('returns true when manageRoles is granted', () {
+      expect(
+        canManageSpaceSettings({AccordPermission.manageRoles}),
+        isTrue,
+      );
+    });
+
+    test('returns true when viewAuditLog is granted', () {
+      expect(
+        canManageSpaceSettings({AccordPermission.viewAuditLog}),
+        isTrue,
+      );
+    });
+
+    test('returns true when administrator is granted (implies all)', () {
+      expect(
+        canManageSpaceSettings({AccordPermission.administrator}),
+        isTrue,
+      );
+    });
+
+    test('returns false when only unrelated permissions are present', () {
+      expect(
+        canManageSpaceSettings({
+          AccordPermission.sendMessages,
+          AccordPermission.createInvites,
+        }),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/shared/app_banner_test.dart
+++ b/test/shared/app_banner_test.dart
@@ -1,0 +1,91 @@
+import 'package:bonfire/shared/components/app_banner.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget banner) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: banner),
+    );
+
+void main() {
+  group('AppBanner', () {
+    testWidgets('renders message text', (tester) async {
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.info,
+          message: 'Hello banner',
+          onTap: () {},
+          onDismiss: () {},
+        )),
+      );
+      expect(find.text('Hello banner'), findsOneWidget);
+    });
+
+    testWidgets('renders leading icon', (tester) async {
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.system_update,
+          message: 'Update',
+          onTap: () {},
+          onDismiss: () {},
+        )),
+      );
+      expect(find.byIcon(Icons.system_update), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.info,
+          message: 'Tap me',
+          onTap: () => tapped = true,
+          onDismiss: () {},
+        )),
+      );
+      await tester.tap(find.text('Tap me'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('calls onDismiss when close icon tapped', (tester) async {
+      var dismissed = false;
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.info,
+          message: 'msg',
+          onTap: () {},
+          onDismiss: () => dismissed = true,
+        )),
+      );
+      await tester.tap(find.byIcon(Icons.close));
+      expect(dismissed, isTrue);
+    });
+
+    testWidgets('renders optional actions', (tester) async {
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.info,
+          message: 'msg',
+          onTap: () {},
+          onDismiss: () {},
+          actions: [TextButton(onPressed: () {}, child: const Text('Reload'))],
+        )),
+      );
+      expect(find.text('Reload'), findsOneWidget);
+    });
+
+    testWidgets('wraps in SafeArea with bottom=false', (tester) async {
+      await tester.pumpWidget(
+        _host(AppBanner(
+          icon: Icons.info,
+          message: 'msg',
+          onTap: () {},
+          onDismiss: () {},
+        )),
+      );
+      final safeArea = tester.widget<SafeArea>(find.byType(SafeArea));
+      expect(safeArea.bottom, isFalse);
+    });
+  });
+}

--- a/test/shared/color_swatch_chip_test.dart
+++ b/test/shared/color_swatch_chip_test.dart
@@ -1,0 +1,110 @@
+import 'package:bonfire/shared/components/color_swatch_chip.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  group('avatarColorPalette', () {
+    test('has 8 entries', () {
+      expect(avatarColorPalette.length, 8);
+    });
+
+    test('all entries have a non-empty name', () {
+      for (final (_, name) in avatarColorPalette) {
+        expect(name, isNotEmpty);
+      }
+    });
+  });
+
+  group('ColorSwatchChip', () {
+    testWidgets('renders a 36x36 circle', (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.blue,
+          selected: false,
+          onTap: () {},
+        )),
+      );
+      final container = tester.widget<Container>(find.byType(Container).first);
+      expect(container.constraints?.maxWidth, 36);
+      expect(container.constraints?.maxHeight, 36);
+    });
+
+    testWidgets('shows check icon when selected and not transparent',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.blue,
+          selected: true,
+          onTap: () {},
+        )),
+      );
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('shows no icon when not selected and not transparent',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.blue,
+          selected: false,
+          onTap: () {},
+        )),
+      );
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('shows format_color_reset icon when transparent', (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.blue,
+          selected: false,
+          onTap: () {},
+          transparent: true,
+        )),
+      );
+      expect(find.byIcon(Icons.format_color_reset_outlined), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.red,
+          selected: false,
+          onTap: () => tapped = true,
+        )),
+      );
+      await tester.tap(find.byType(GestureDetector));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('wraps in Tooltip when label is provided', (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.green,
+          selected: false,
+          onTap: () {},
+          label: 'Green',
+        )),
+      );
+      expect(find.byType(Tooltip), findsOneWidget);
+    });
+
+    testWidgets('does not wrap in Tooltip when label is null', (tester) async {
+      await tester.pumpWidget(
+        _host(ColorSwatchChip(
+          color: Colors.green,
+          selected: false,
+          onTap: () {},
+        )),
+      );
+      expect(find.byType(Tooltip), findsNothing);
+    });
+  });
+}

--- a/test/shared/rest_result_ext_test.dart
+++ b/test/shared/rest_result_ext_test.dart
@@ -1,0 +1,83 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _theme = BonfireThemeExtension(
+  foreground: Colors.white,
+  background: Color(0xFF1e1f22),
+  dirtyWhite: Color(0xFFdcddde),
+  gray: Color(0xFF949ba4),
+  darkGray: Color(0xFF4e5058),
+  primary: Color(0xFF5865f2),
+  red: Color(0xFFed4245),
+  green: Color(0xFF23a55a),
+  yellow: Color(0xFFf0b232),
+);
+
+RestResult _ok() => RestResult(ok: true, statusCode: 200);
+RestResult _err(String msg) => RestResult(
+      ok: false,
+      statusCode: 500,
+      error: AccordError(message: msg),
+    );
+
+void main() {
+  group('RestResult.errorOr', () {
+    test('returns fallback when error is null', () {
+      expect(_ok().errorOr('default'), 'default');
+    });
+
+    test('returns error.toString() when error is non-null', () {
+      final result = _err('boom');
+      expect(result.errorOr('default'), result.error!.toString());
+    });
+  });
+
+  group('showErrorSnack', () {
+    testWidgets('shows snack bar with prefix and error', (tester) async {
+      final err = AccordError(message: 'server error');
+      final result = RestResult(ok: false, statusCode: 500, error: err);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [_theme]),
+          home: Builder(builder: (ctx) {
+            return Scaffold(
+              body: ElevatedButton(
+                onPressed: () =>
+                    showErrorSnack(ctx, result, prefix: 'Failed'),
+                child: const Text('trigger'),
+              ),
+            );
+          }),
+        ),
+      );
+      await tester.tap(find.text('trigger'));
+      await tester.pump();
+
+      expect(find.text('Failed: ${err.toString()}'), findsOneWidget);
+    });
+
+    testWidgets('falls back to "unknown error" when error is null',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [_theme]),
+          home: Builder(builder: (ctx) {
+            return Scaffold(
+              body: ElevatedButton(
+                onPressed: () => showErrorSnack(ctx, _ok(), prefix: 'Oops'),
+                child: const Text('trigger'),
+              ),
+            );
+          }),
+        ),
+      );
+      await tester.tap(find.text('trigger'));
+      await tester.pump();
+
+      expect(find.text('Oops: unknown error'), findsOneWidget);
+    });
+  });
+}

--- a/test/shared/section_header_test.dart
+++ b/test/shared/section_header_test.dart
@@ -27,17 +27,39 @@ void main() {
       expect(find.text('HELLO WORLD'), findsOneWidget);
     });
 
-    testWidgets('has fromLTRB(16,12,16,4) padding', (tester) async {
+    testWidgets('has fromLTRB(16,12,16,4) padding without trailing',
+        (tester) async {
       await tester.pumpWidget(_wrap(const SectionHeader('Test')));
       final padding = tester.widget<Padding>(find.byType(Padding).first);
-      expect(padding.padding,
-          const EdgeInsets.fromLTRB(16, 12, 16, 4));
+      expect(padding.padding, const EdgeInsets.fromLTRB(16, 12, 16, 4));
     });
 
     testWidgets('accepts a key', (tester) async {
       const k = Key('hdr');
       await tester.pumpWidget(_wrap(const SectionHeader('X', key: k)));
       expect(find.byKey(k), findsOneWidget);
+    });
+
+    testWidgets('renders trailing widget when provided', (tester) async {
+      await tester.pumpWidget(
+        _wrap(SectionHeader('Foo', trailing: const Text('action'))),
+      );
+      expect(find.text('action'), findsOneWidget);
+    });
+
+    testWidgets('trailing layout uses tighter right padding', (tester) async {
+      await tester.pumpWidget(
+        _wrap(SectionHeader('Foo', trailing: const SizedBox())),
+      );
+      final padding = tester.widget<Padding>(find.byType(Padding).first);
+      expect(padding.padding, const EdgeInsets.fromLTRB(16, 12, 8, 4));
+    });
+
+    testWidgets('trailing layout uses a Row', (tester) async {
+      await tester.pumpWidget(
+        _wrap(SectionHeader('Foo', trailing: const Text('btn'))),
+      );
+      expect(find.byType(Row), findsOneWidget);
     });
   });
 }

--- a/test/shared/settings_scaffold_test.dart
+++ b/test/shared/settings_scaffold_test.dart
@@ -1,0 +1,73 @@
+import 'package:bonfire/shared/components/settings_scaffold.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: child,
+    );
+
+void main() {
+  group('SettingsScaffold', () {
+    testWidgets('renders title in AppBar', (tester) async {
+      await tester.pumpWidget(
+        _host(const SettingsScaffold(
+          title: 'My Settings',
+          body: SizedBox(),
+        )),
+      );
+      expect(find.text('My Settings'), findsOneWidget);
+    });
+
+    testWidgets('renders body content', (tester) async {
+      await tester.pumpWidget(
+        _host(SettingsScaffold(
+          title: 'X',
+          body: const Text('body content'),
+        )),
+      );
+      expect(find.text('body content'), findsOneWidget);
+    });
+
+    testWidgets('renders optional actions in AppBar', (tester) async {
+      await tester.pumpWidget(
+        _host(SettingsScaffold(
+          title: 'X',
+          body: const SizedBox(),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: () {},
+            ),
+          ],
+        )),
+      );
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+    });
+
+    testWidgets('renders back button', (tester) async {
+      await tester.pumpWidget(
+        _host(SettingsScaffold(
+          title: 'X',
+          body: const SizedBox(),
+        )),
+      );
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+
+    testWidgets('renders floatingActionButton when provided', (tester) async {
+      await tester.pumpWidget(
+        _host(SettingsScaffold(
+          title: 'X',
+          body: const SizedBox(),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+        )),
+      );
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

A codebase-wide DRY sweep (run via parallel subagents) consolidating duplicated/WET code into shared helpers and components. Each logical group is a separate commit; net **−116 lines** across 49 files. No behavior changes intended; `flutter analyze --no-fatal-infos` stays clean (only pre-existing infos remain).

### Staged commits
- **auth-select ref extensions** — `watch/readUserId`, `watchCdnUrl`, `watchIsAdmin` on `WidgetRef`/`Ref`, replacing ~40 inline `accordAuthProvider.select(...)` lambdas.
- **`RestResult.errorOr` + `showErrorSnack`** — dedupe ~45 ad-hoc error-snack / error-text sites.
- **`SettingsScaffold`** — single themed Scaffold+AppBar chrome shared by the settings pages.
- **`canManageSpaceSettings`** — extract the identical permission triad (only where genuinely identical; divergent permission sites left untouched).
- **`showConfirmDialog`** — route inline destructive `AlertDialog`s through the shared confirm helper.
- **`AppBanner`** — shared slim top banner for the update / web-update prompts.
- **`SectionHeader` trailing slot + `ColorSwatchChip`** — drop the developer panel's bespoke `_ActivityHeader`; consolidate the duplicated accent/avatar swatch widgets + palette.

### Scope notes (deliberately *not* changed)
- BusyButton consolidation skipped — 38 sites too heterogeneous to merge without visual verification.
- Full permission-block unification skipped — call sites diverge (admin flags, per-connection vs active session, read vs watch).

## Test plan
- [x] `flutter analyze --no-fatal-infos` clean (no new warnings/errors)
- [ ] Smoke-test settings pages (appearance/accent picker, profile avatar color, developer panel, connections, profiles, privacy)
- [ ] Verify update banner + web-update prompt still render/dismiss
- [ ] Confirm destructive dialogs (disconnect, delete profile) still gate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)