### PR TITLE
fix(windows): silence experimental/coroutine deprecation (STL1011)

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,13 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# Newer MSVC toolchains (VS 2022 17.14+ / VS 18) promote the
+# <experimental/coroutine> deprecation to a hard error (C2338 / STL1011).
+# Several Flutter plugins (audioplayers_windows, permission_handler_windows,
+# flutter_local_notifications_windows) still include that header, so silence the
+# deprecation across all targets and plugin subdirectories added below.
+add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -37,7 +37,9 @@ add_definitions(-DUNICODE -D_UNICODE)
 # Several Flutter plugins (audioplayers_windows, permission_handler_windows,
 # flutter_local_notifications_windows) still include that header, so silence the
 # deprecation across all targets and plugin subdirectories added below.
-add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+if(MSVC)
+  add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+endif()
 
 # Compilation settings that should be applied to most targets.
 #


### PR DESCRIPTION
## Problem
The latest Release run failed at **CI / Build Windows**, which (being gated) skipped the **Google Play** deploy job and blocked the Play release.

The GitHub Windows runner image updated to a new MSVC toolchain (VS 18 / MSVC 14.51). That compiler promotes the `<experimental/coroutine>` deprecation to a **hard error** (`C2338` / `STL1011`). Three Flutter plugins still include that header and fail to compile:
- `audioplayers_windows`
- `permission_handler_windows`
- `flutter_local_notifications_windows`

This is an upstream toolchain regression, not a code change in this repo.

## Fix
Add `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` as a project-wide compile definition in `windows/CMakeLists.txt`, alongside the existing `UNICODE` definition, so it propagates to all targets and plugin subdirectories.

## Verification
Can't build Windows on the maintainer's macOS 13 machine; this is the standard MSVC-recommended remedy for STL1011. The Windows build leg of the Release run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)