### PR TITLE
ci(play): upload signed AAB artifact for manual first upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -701,6 +701,18 @@ jobs:
             --dart-define=APP_STORE=true \
             --dart-define=SENTRY_DSN="${SENTRY_DSN:-}"
 
+      - name: Upload signed AAB artifact
+        # Keep the exact signed bundle even if the Play API upload fails, so the
+        # first-ever release can be uploaded manually via the Play Console (a
+        # brand-new app rejects API uploads with an opaque 500 until its first
+        # release is created by hand).
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daccord-playstore-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: warn
+
       - name: Upload to Google Play
         env:
           PLAY_JSON_KEY_PATH: ${{ runner.temp }}/play-service-account.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -706,12 +706,13 @@ jobs:
         # first-ever release can be uploaded manually via the Play Console (a
         # brand-new app rejects API uploads with an opaque 500 until its first
         # release is created by hand).
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: daccord-playstore-aab
           path: build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: warn
+          retention-days: 30
 
       - name: Upload to Google Play
         env:


### PR DESCRIPTION
## Why
The Google Play deploy job builds a valid signed AAB but the upload fails repeatedly with:

```
Google Api Error: Server error - Internal error encountered.
```

Two consecutive runs failed identically, the second failing even earlier (during "Preparing aab"). This is the well-known symptom of a **brand-new Play app with no first release** — the Play Developer API rejects uploads with an opaque 500 until the app's first release is created manually in the Console.

## Change
- Save the signed AAB as a workflow artifact (`daccord-playstore-aab`, `if: always()`) so we can grab the exact signed bundle and do the one-time manual upload via the Play Console. API deploys work after that.
- Guard the `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` define (from #147) behind `if(MSVC)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)