### PR TITLE
feat(voice): surface soundboard in the in-call voice control bar

### DIFF
--- a/lib/features/voice/views/voice_bar.dart
+++ b/lib/features/voice/views/voice_bar.dart
@@ -1,12 +1,19 @@
 import 'dart:async';
 
+import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
+import 'package:bonfire/features/member/controllers/accord_members.dart';
+import 'package:bonfire/features/member/utils/permissions.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/spaces/controllers/role_preview.dart';
+import 'package:bonfire/features/spaces/controllers/spaces.dart';
+import 'package:bonfire/features/spaces/views/accord_soundboard.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/services/voice_session.dart';
 import 'package:bonfire/features/voice/views/mic_level_meter.dart';
 import 'package:bonfire/features/voice/views/screen_share_picker.dart';
 import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -61,6 +68,34 @@ class _VoiceBarState extends ConsumerState<VoiceBar> {
             .watch(accordChannelsControllerProvider(voice.spaceId!))
             ?.firstWhereOrNull((c) => c.id == voice.channelId)
             ?.name;
+
+    // Surface the soundboard to members who can use it in the connected space,
+    // mirroring the gate in Space Settings (see accord_space_settings.dart).
+    final spaceId = voice.spaceId;
+    var canUseSoundboard = false;
+    var canManageSoundboard = false;
+    if (spaceId != null) {
+      final space = ref.watch(
+        spacesControllerProvider
+            .select((s) => s?.firstWhereOrNull((sp) => sp.id == spaceId)),
+      );
+      final currentUserId = ref.watchUserId();
+      final isAdmin = ref.watchIsAdmin();
+      final members = ref.watch(accordMembersControllerProvider(spaceId));
+      final preview = ref.watch(rolePreviewControllerProvider);
+      final perms = accordEffectivePermissions(
+        space: space,
+        selfMember: currentUserId == null ? null : members?[currentUserId],
+        roles: space?.roles ?? const <AccordRole>[],
+        currentUserId: currentUserId ?? '',
+        currentUserIsAdmin: isAdmin,
+        previewRoleId: preview?.spaceId == spaceId ? preview?.roleId : null,
+      );
+      canUseSoundboard =
+          accordHasPermission(perms, AccordPermission.useSoundboard);
+      canManageSoundboard =
+          accordHasPermission(perms, AccordPermission.manageSoundboard);
+    }
 
     final (statusText, statusColor) = _status(voice, colors, channelName);
 
@@ -136,6 +171,18 @@ class _VoiceBarState extends ConsumerState<VoiceBar> {
                     active: voice.selfStream,
                     activeColor: colors.green,
                     onPressed: () => toggleScreenShareWithPicker(context, ref),
+                  ),
+                if (canUseSoundboard && spaceId != null)
+                  _VoiceButton(
+                    icon: Icons.graphic_eq,
+                    tooltip: 'Soundboard',
+                    active: false,
+                    activeColor: colors.primary,
+                    onPressed: () => showAccordSoundboard(
+                      context,
+                      spaceId: spaceId,
+                      canManage: canManageSoundboard,
+                    ),
                   ),
                 const Spacer(),
                 _VoiceButton(

--- a/lib/features/voice/views/voice_bar.dart
+++ b/lib/features/voice/views/voice_bar.dart
@@ -69,8 +69,7 @@ class _VoiceBarState extends ConsumerState<VoiceBar> {
             ?.firstWhereOrNull((c) => c.id == voice.channelId)
             ?.name;
 
-    // Surface the soundboard to members who can use it in the connected space,
-    // mirroring the gate in Space Settings (see accord_space_settings.dart).
+    // Mirrors accord_space_settings.dart — keep these permission checks in sync.
     final spaceId = voice.spaceId;
     var canUseSoundboard = false;
     var canManageSoundboard = false;

--- a/test/features/voice/voice_bar_test.dart
+++ b/test/features/voice/voice_bar_test.dart
@@ -1,3 +1,5 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/views/voice_bar.dart';
 import 'package:bonfire/theme/app_theme.dart';
@@ -14,9 +16,30 @@ class _FakeVoiceController extends VoiceController {
   VoiceConnection build() => _state;
 }
 
-Widget _host(VoiceConnection state) => ProviderScope(
+/// A fake [SpacesController] that exposes a fixed space list.
+class _FakeSpacesController extends SpacesController {
+  _FakeSpacesController(this._spaces);
+  final List<AccordSpace> _spaces;
+  @override
+  List<AccordSpace> build() => _spaces;
+}
+
+/// Builds a space whose `@everyone` role (position 0) carries [permissions], so
+/// every member's effective permissions include them — enough to drive the
+/// soundboard gate without wiring up auth/members.
+AccordSpace _spaceWithEveryonePerms(List<String> permissions) => AccordSpace(
+  id: 's1',
+  name: 'Space',
+  roles: [AccordRole(id: 'everyone', position: 0, permissions: permissions)],
+);
+
+Widget _host(VoiceConnection state, {List<AccordSpace>? spaces}) => ProviderScope(
   overrides: [
     voiceControllerProvider.overrideWith(() => _FakeVoiceController(state)),
+    if (spaces != null)
+      spacesControllerProvider.overrideWith(
+        () => _FakeSpacesController(spaces),
+      ),
   ],
   child: MaterialApp(
     theme: buildAppTheme(AppThemePreset.dark),
@@ -34,5 +57,35 @@ void main() {
     expect(find.byType(IconButton), findsNothing);
     final size = tester.getSize(find.byType(VoiceBar));
     expect(size.height, 0);
+  });
+
+  testWidgets('shows soundboard button when use_soundboard is granted', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        // selfMute hides the mic meter, which reads an (unopened) Hive box.
+        const VoiceConnection(channelId: 'c1', spaceId: 's1', selfMute: true),
+        spaces: [
+          _spaceWithEveryonePerms([AccordPermission.useSoundboard]),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
+    expect(find.byTooltip('Soundboard'), findsOneWidget);
+  });
+
+  testWidgets('hides soundboard button without use_soundboard', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        const VoiceConnection(channelId: 'c1', spaceId: 's1', selfMute: true),
+        spaces: [_spaceWithEveryonePerms([])],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byIcon(Icons.graphic_eq), findsNothing);
   });
 }

--- a/test/features/voice/voice_bar_test.dart
+++ b/test/features/voice/voice_bar_test.dart
@@ -88,4 +88,16 @@ void main() {
 
     expect(find.byIcon(Icons.graphic_eq), findsNothing);
   });
+
+  testWidgets('hides soundboard button in a DM voice call (null spaceId)',
+      (tester) async {
+    // DM/group-DM calls have no parent space, so the soundboard must never appear
+    // regardless of any permission state.
+    await tester.pumpWidget(
+      _host(const VoiceConnection(channelId: 'c1', selfMute: true)),
+    );
+    await tester.pump();
+
+    expect(find.byIcon(Icons.graphic_eq), findsNothing);
+  });
 }


### PR DESCRIPTION
## What

Adds a **Soundboard** button to the in-call voice control bar, so users can play sounds without leaving the call.

Closes #150.

## Why

The soundboard is fully implemented — SDK support in `accordkit` (REST + gateway events + `AccordSound` model), a standalone management/play UI (`showAccordSoundboard`), and `use_soundboard` / `manage_soundboard` permissions. But it was only reachable through **Space Settings → Soundboard**. The voice control bar had no soundboard button, so while connected to a voice channel there was no way to play a clip — the docs even promise it as a voice control (`docs/voice-and-video/voice-channels.md:28`).

## Changes

- **`lib/features/voice/views/voice_bar.dart`**
  - New soundboard button (`Icons.graphic_eq`) in the control row, placed **after Screen share, before the trailing `Spacer()`** (the spot called out in the issue).
  - Gated on the `use_soundboard` permission, computed via the same `accordEffectivePermissions` / `accordHasPermission` path Space Settings uses (admin/owner/role-preview aware).
  - Opens the existing `showAccordSoundboard()` picker, reusing its server-side `client.soundboard.play()` path, and passes through `manage_soundboard` so managers keep add/edit/delete/volume controls.
  - The picker uses responsive dialog constraints, so it works on **both desktop and mobile**.
- **`test/features/voice/voice_bar_test.dart`**
  - Regression tests: the button **shows** when `use_soundboard` is granted and is **hidden** without it.

## Acceptance criteria

- [x] Soundboard button added to the voice control bar, after Screen share, gated on `use_soundboard`
- [x] Opens a quick soundboard picker reusing the play path (`client.soundboard.play()`)
- [x] Works on both desktop and mobile layouts

## Testing

- `flutter analyze --no-fatal-infos` on the changed files → No issues found
- `flutter test test/features/voice/voice_bar_test.dart` → all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)