### PR TITLE
fix(updates): make Linux self-update work for .deb (system) installs

### DIFF
--- a/lib/features/updates/controllers/update_controller.dart
+++ b/lib/features/updates/controllers/update_controller.dart
@@ -158,6 +158,9 @@ class UpdateController extends _$UpdateController {
     // App Store builds update through the store; never check GitHub or arm the
     // periodic timer (see [kAppStoreBuild]).
     if (kAppStoreBuild) return;
+    // The web build ships whatever the server serves — there's nothing to
+    // download or install, so never check for releases or show the banner.
+    if (UniversalPlatform.isWeb) return;
     _timer ??= Timer.periodic(_throttle, (_) {
       if (ref.read(settingsControllerProvider).autoUpdateCheck) check();
     });
@@ -254,17 +257,34 @@ class UpdateController extends _$UpdateController {
   /// platform, in priority order. Kept in lockstep with [UpdateInstaller]: it
   /// extracts a `.tar.gz`/`.zip` bundle on Linux/Windows, mounts a `.dmg` on
   /// macOS, and hands a `.apk` to the system installer on Android. Package
-  /// formats the swap helper can't apply (`.deb`/`.rpm`/`.appimage`, setup
-  /// `.exe`/`.msi`) are deliberately excluded — they're download-only.
+  /// formats the swap helper can't apply (`.rpm`/`.appimage`, setup `.exe`/
+  /// `.msi`) are download-only.
+  ///
+  /// Desktop swaps need a writable install root (the helper renames it): a
+  /// package-manager install (root-owned `/opt`, `Program Files`,
+  /// `/Applications`) yields no swap asset. The one exception is a Linux `.deb`
+  /// install where `pkexec` is available — there the `.deb` *is* installable, by
+  /// reinstalling the package with elevated rights ([UpdateInstaller] routes a
+  /// `.deb` through `pkexec dpkg -i`).
   ///
   /// Windows uses the more-specific `windows-x86_64.zip` suffix before the
   /// generic `.zip` so the web build bundle (`daccord-web.zip`) is never
   /// mistakenly selected ahead of the actual Windows installer.
   List<String> get _installableExts {
     if (UniversalPlatform.isAndroid) return const ['.apk'];
-    if (UniversalPlatform.isWindows) return const ['windows-x86_64.zip', '.zip'];
-    if (UniversalPlatform.isMacOS) return const ['.dmg'];
-    if (UniversalPlatform.isLinux) return const ['.tar.gz'];
+    if (UniversalPlatform.isWindows) {
+      return UpdateInstaller.isInstallRootWritable
+          ? const ['windows-x86_64.zip', '.zip']
+          : const [];
+    }
+    if (UniversalPlatform.isMacOS) {
+      return UpdateInstaller.isInstallRootWritable ? const ['.dmg'] : const [];
+    }
+    if (UniversalPlatform.isLinux) {
+      if (UpdateInstaller.isInstallRootWritable) return const ['.tar.gz'];
+      // System install: update the package itself when we can elevate.
+      return UpdateInstaller.hasPrivilegedInstaller ? const ['.deb'] : const [];
+    }
     return const [];
   }
 
@@ -279,7 +299,13 @@ class UpdateController extends _$UpdateController {
     }
     if (UniversalPlatform.isMacOS) return const ['.dmg', '.pkg', '.zip'];
     if (UniversalPlatform.isLinux) {
-      return const ['.tar.gz', '.deb', '.rpm', '.appimage'];
+      // A non-writable (package-manager) install can't be swapped in place, so
+      // hand the user the package their manager applies (`.deb`) rather than the
+      // portable tarball they'd have to extract themselves. A writable install
+      // prefers the tarball — it's also the in-place asset.
+      return UpdateInstaller.isInstallRootWritable
+          ? const ['.tar.gz', '.deb', '.rpm', '.appimage']
+          : const ['.deb', '.rpm', '.appimage', '.tar.gz'];
     }
     return const [];
   }
@@ -312,10 +338,21 @@ class UpdateController extends _$UpdateController {
   /// platform, or null when none applies (the UI then offers a plain download).
   AppReleaseAsset? platformAsset() => _assetForExts(_installableExts);
 
-  /// Whether the running platform supports an in-place download-and-install
-  /// (desktop binary swap or Android APK install), and a matching asset exists.
+  /// Whether the running platform can download-and-install in place (desktop
+  /// binary swap, Android APK install, or Linux `.deb` reinstall via pkexec) and
+  /// a matching asset exists. [_installableExts] already encodes the
+  /// writability / privilege gating, so a package-manager install with no
+  /// applicable path yields no asset here and the UI offers a manual download.
   bool get canInstallInPlace =>
       !kAppStoreBuild && UpdateInstaller.isSupported && platformAsset() != null;
+
+  /// Whether applying the staged update will prompt for administrator
+  /// authentication — a Linux system-package (`.deb`) reinstall via pkexec. Lets
+  /// the UI warn before the polkit dialog appears.
+  bool get requiresPrivilegedInstall =>
+      UniversalPlatform.isLinux &&
+      !UpdateInstaller.isInstallRootWritable &&
+      (platformAsset()?.name.toLowerCase().endsWith('.deb') ?? false);
 
   /// Downloads and verifies the matching platform asset in the background,
   /// leaving it staged at [UpdatePhase.ready] for a one-click [applyUpdate].

--- a/lib/features/updates/services/update_installer_io.dart
+++ b/lib/features/updates/services/update_installer_io.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
@@ -43,6 +44,77 @@ class UpdateInstaller {
       UniversalPlatform.isMacOS ||
       UniversalPlatform.isLinux ||
       UniversalPlatform.isAndroid;
+
+  /// Cached result of [isInstallRootWritable] — the install location can't
+  /// change while the app runs, so the probe is done at most once.
+  static bool? _installRootWritable;
+
+  /// Overrides the writability probe in tests, where `resolvedExecutable` is the
+  /// Dart/Flutter SDK binary and its directory's writability is both irrelevant
+  /// and host-dependent. Null in production (the real probe runs).
+  @visibleForTesting
+  static bool? debugInstallRootWritable;
+
+  /// Whether the (unprivileged) swap helper could actually replace the running
+  /// bundle in place — i.e. the install root's *parent* directory is writable,
+  /// so `mv "$root" "$root.old"` and the move-into-place can succeed.
+  ///
+  /// A package-manager install is not: the Linux `.deb` lands under root-owned
+  /// `/opt`, a macOS build may sit in `/Applications`, a Windows setup installs
+  /// to `Program Files`. There the helper's `mv`/`cp` silently fails and it
+  /// relaunches the *old* build — the update appears to apply but nothing
+  /// changes. Callers gate the one-click apply on this and fall back to a manual
+  /// download instead. Always true on Android (the system installer applies the
+  /// APK, not this helper).
+  static bool get isInstallRootWritable {
+    final override = debugInstallRootWritable;
+    if (override != null) return override;
+    if (UniversalPlatform.isAndroid) return true;
+    return _installRootWritable ??= _probeInstallRootWritable();
+  }
+
+  static bool _probeInstallRootWritable() {
+    try {
+      final probe = File(
+        p.join(p.dirname(_installRoot), '.daccord-update-probe'),
+      );
+      probe.writeAsStringSync('');
+      probe.deleteSync();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Cached result of [hasPrivilegedInstaller].
+  static bool? _hasPrivilegedInstaller;
+
+  /// Overrides the privileged-installer probe in tests. Null in production.
+  @visibleForTesting
+  static bool? debugHasPrivilegedInstaller;
+
+  /// Whether a privileged package install is available — i.e. Linux with
+  /// `pkexec` (polkit) present. Used to update a non-writable system install
+  /// (the `.deb` under root-owned `/opt`) by reinstalling the package with an
+  /// admin-authentication prompt, rather than the unprivileged binary swap.
+  /// Always false off Linux. Cheap + cached (called from widget builds).
+  static bool get hasPrivilegedInstaller {
+    final override = debugHasPrivilegedInstaller;
+    if (override != null) return override;
+    if (!UniversalPlatform.isLinux) return false;
+    return _hasPrivilegedInstaller ??= _probePkexec();
+  }
+
+  static bool _probePkexec() {
+    for (final path in const [
+      '/usr/bin/pkexec',
+      '/bin/pkexec',
+      '/usr/local/bin/pkexec',
+    ]) {
+      if (File(path).existsSync()) return true;
+    }
+    return false;
+  }
 
   /// Streams [url] to a temp file, reporting fractional progress (0..1) when the
   /// server sends a Content-Length. Returns the downloaded file's path.
@@ -169,7 +241,7 @@ class UpdateInstaller {
 
   /// The directory that holds the running desktop bundle (everything the swap
   /// must replace). On macOS this is the `.app` bundle itself.
-  String get _installRoot {
+  static String get _installRoot {
     final exe = Platform.resolvedExecutable;
     if (UniversalPlatform.isMacOS) {
       // …/Daccord.app/Contents/MacOS/daccord → …/Daccord.app
@@ -234,10 +306,16 @@ del "%~f0"
     ], mode: ProcessStartMode.detached);
   }
 
-  Future<void> _installLinux(File tarball) async {
+  Future<void> _installLinux(File asset) async {
+    // A system-package (`.deb`) install can't be swapped in place; reinstall the
+    // package with elevated rights instead (see [_installLinuxDeb]).
+    if (asset.path.toLowerCase().endsWith('.deb')) {
+      await _installLinuxDeb(asset);
+      return;
+    }
     final dir = await getTemporaryDirectory();
     final staged = await _extract(
-      tarball,
+      asset,
       Directory(p.join(dir.path, 'daccord-update', 'staged')),
     );
     final dst = _installRoot;
@@ -255,6 +333,50 @@ if mv "$dst" "$dst.old" 2>/dev/null; then
     rm -rf "$dst"; mv "$dst.old" "$dst"
   fi
 fi
+nohup "$dst/daccord" >/dev/null 2>&1 &
+rm -f "\$0"
+''');
+    await Process.start('bash', [
+      sh.path,
+    ], mode: ProcessStartMode.detached);
+  }
+
+  /// Updates a system-package install by reinstalling the downloaded [deb] with
+  /// `pkexec dpkg -i` — polkit shows an admin-authentication dialog, then dpkg
+  /// overwrites the running bundle under root-owned `/opt` (safe: Linux keeps a
+  /// running executable's inode until it exits). On success a detached helper
+  /// relaunches the freshly-installed binary once this process quits; on failure
+  /// or a cancelled prompt it throws so the app stays on the current version
+  /// with a clear message (and never quits). Requires an interactive polkit
+  /// agent — the desktop session provides one.
+  Future<void> _installLinuxDeb(File deb) async {
+    final ProcessResult result;
+    try {
+      result = await Process.run('pkexec', ['dpkg', '-i', deb.path]);
+    } on ProcessException {
+      throw UpdateInstallException(
+        'Could not start the privileged installer (pkexec).',
+      );
+    }
+    if (result.exitCode != 0) {
+      // pkexec: 126 = dialog dismissed, 127 = not authorized. Anything else is
+      // a dpkg failure — surface its stderr, trimmed, to help diagnose.
+      if (result.exitCode == 126 || result.exitCode == 127) {
+        throw UpdateInstallException('Update needs administrator approval.');
+      }
+      final err = (result.stderr as String? ?? '').trim();
+      throw UpdateInstallException(
+        err.isEmpty ? 'Package install failed.' : 'Package install failed: $err',
+      );
+    }
+    // dpkg has replaced the bundle in place; relaunch the new binary after we
+    // exit (same detached-waiter pattern as the swap helper).
+    final dst = _installRoot;
+    final pid = _pid;
+    final sh = await _writeHelper('relaunch.sh', '''
+#!/usr/bin/env bash
+set -u
+while kill -0 $pid 2>/dev/null; do sleep 0.5; done
 nohup "$dst/daccord" >/dev/null 2>&1 &
 rm -f "\$0"
 ''');

--- a/lib/features/updates/services/update_installer_stub.dart
+++ b/lib/features/updates/services/update_installer_stub.dart
@@ -18,6 +18,19 @@ class UpdateInstaller {
   /// No in-place install path off a native platform.
   static bool get isSupported => false;
 
+  /// No in-place install off a native platform, so the install root is never
+  /// writable in the swap sense (the web build updates via the service worker).
+  static bool get isInstallRootWritable => false;
+
+  /// API parity with the native installer's test seam; unused off native.
+  static bool? debugInstallRootWritable;
+
+  /// No privileged package installer off a native platform.
+  static bool get hasPrivilegedInstaller => false;
+
+  /// API parity with the native installer's test seam; unused off native.
+  static bool? debugHasPrivilegedInstaller;
+
   Future<String> download(
     String url, {
     String? fileName,

--- a/lib/features/updates/views/update_banner.dart
+++ b/lib/features/updates/views/update_banner.dart
@@ -30,11 +30,15 @@ class UpdateBanner extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    // A verified build is staged → offer the one-click apply.
+    // A verified build is staged → offer the one-click apply. A system-package
+    // install applies via pkexec, so warn that an admin prompt will appear.
     if (update.updateReady) {
+      final tail = notifier.requiresPrivilegedInstall
+          ? 'Tap to install (admin required).'
+          : 'Tap to restart & install.';
       return AppBanner(
         icon: Icons.system_update,
-        message: 'Update ready — ${release.name}. Tap to restart & install.',
+        message: 'Update ready — ${release.name}. $tail',
         onTap: update.installing ? () {} : () => notifier.applyUpdate(),
         onDismiss: () => notifier.dismissCurrent(),
       );

--- a/lib/features/updates/views/updates_page.dart
+++ b/lib/features/updates/views/updates_page.dart
@@ -144,7 +144,12 @@ class UpdatesScreen extends ConsumerWidget {
                                       ? Icons.restart_alt
                                       : Icons.download,
                                 ),
-                          label: Text(_installLabel(update)),
+                          label: Text(
+                            _installLabel(
+                              update,
+                              notifier.requiresPrivilegedInstall,
+                            ),
+                          ),
                         );
                       }
                       // Prefer the matching platform asset (one-click download
@@ -204,8 +209,9 @@ class UpdatesScreen extends ConsumerWidget {
   }
 }
 
-/// Button label reflecting the current install phase.
-String _installLabel(UpdateState update) {
+/// Button label reflecting the current install phase. [needsAdmin] marks a
+/// Linux system-package reinstall that will prompt for administrator rights.
+String _installLabel(UpdateState update, bool needsAdmin) {
   switch (update.phase) {
     case UpdatePhase.downloading:
       final pct = (update.progress * 100).round();
@@ -213,12 +219,12 @@ String _installLabel(UpdateState update) {
     case UpdatePhase.verifying:
       return 'Verifying…';
     case UpdatePhase.ready:
-      return 'Restart & install';
+      return needsAdmin ? 'Install (admin)' : 'Restart & install';
     case UpdatePhase.installing:
       return 'Installing…';
     case UpdatePhase.failed:
       return 'Retry update';
     case UpdatePhase.idle:
-      return 'Download & install';
+      return needsAdmin ? 'Download & install (admin)' : 'Download & install';
   }
 }

--- a/test/features/updates/update_banner_test.dart
+++ b/test/features/updates/update_banner_test.dart
@@ -10,10 +10,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeUpdateController extends UpdateController {
-  _FakeUpdateController(this._state);
+  _FakeUpdateController(this._state, {bool requiresPrivilegedInstall = false})
+      : _requiresPrivilegedInstall = requiresPrivilegedInstall;
   final UpdateState _state;
+  final bool _requiresPrivilegedInstall;
   @override
   UpdateState build() => _state;
+  @override
+  bool get requiresPrivilegedInstall => _requiresPrivilegedInstall;
 }
 
 class _FakeSettingsController extends SettingsController {
@@ -32,11 +36,18 @@ const _newerRelease = AppRelease(
   publishedAt: '',
 );
 
-Widget _host({required UpdateState update, AccordSettings? settings}) =>
+Widget _host({
+  required UpdateState update,
+  AccordSettings? settings,
+  bool requiresPrivilegedInstall = false,
+}) =>
     ProviderScope(
       overrides: [
         updateControllerProvider.overrideWith(
-          () => _FakeUpdateController(update),
+          () => _FakeUpdateController(
+            update,
+            requiresPrivilegedInstall: requiresPrivilegedInstall,
+          ),
         ),
         settingsControllerProvider.overrideWith(
           () => _FakeSettingsController(settings ?? const AccordSettings()),
@@ -125,6 +136,26 @@ void main() {
 
       expect(find.textContaining('restart'), findsOneWidget);
       expect(find.textContaining('Update available'), findsNothing);
+    });
+
+    testWidgets(
+        'shows "admin required" text when updateReady and '
+        'requiresPrivilegedInstall (Linux system-package reinstall)',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(
+            latest: _newerRelease,
+            phase: UpdatePhase.ready,
+            stagedArchivePath: '/tmp/daccord.deb',
+          ),
+          requiresPrivilegedInstall: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('admin required'), findsOneWidget);
+      expect(find.textContaining('restart & install'), findsNothing);
     });
 
     testWidgets(

--- a/test/features/updates/update_controller_test.dart
+++ b/test/features/updates/update_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/models/app_release.dart';
+import 'package:bonfire/features/updates/services/update_installer.dart';
 import 'package:bonfire/shared/app_info.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -79,9 +80,15 @@ void main() {
     _tempDir = Directory.systemTemp.createTempSync('update-controller-test');
     Hive.init(_tempDir.path);
     await Hive.openBox('accord-settings');
+    // In tests `resolvedExecutable` is the Dart SDK binary, whose directory
+    // writability is host-dependent; pin it writable so asset-selection tests
+    // stay deterministic. Non-writable behaviour is exercised explicitly below.
+    UpdateInstaller.debugInstallRootWritable = true;
   });
 
   tearDown(() async {
+    UpdateInstaller.debugInstallRootWritable = null;
+    UpdateInstaller.debugHasPrivilegedInstaller = null;
     await Hive.deleteBoxFromDisk('accord-settings');
     await Hive.close();
     if (_tempDir.existsSync()) _tempDir.deleteSync(recursive: true);
@@ -116,6 +123,53 @@ void main() {
       // Sanity-check: the compile-time constant is off for normal test runs.
       // Store-build CI compiles with --dart-define=APP_STORE=true.
       expect(kAppStoreBuild, isFalse);
+    });
+
+    test('is false on a non-writable install with no privileged installer', () {
+      // A package-manager install (e.g. the Linux .deb under root-owned /opt)
+      // can't be swapped in place, and without pkexec there's no privileged
+      // path either — so the UI must fall back to a manual download.
+      if (_hostInstallableExt == null) return; // web/iOS: never in-place anyway
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+      expect(controllerOf(c).canInstallInPlace, isTrue); // writable (setUp)
+      UpdateInstaller.debugInstallRootWritable = false;
+      UpdateInstaller.debugHasPrivilegedInstaller = false;
+      expect(controllerOf(c).canInstallInPlace, isFalse);
+      // …but a manual download is still offered so the user isn't stuck.
+      expect(controllerOf(c).platformAssetUrl(), isNotNull);
+    });
+
+    test('non-writable Linux install prefers the .deb for manual download', () {
+      // With no privileged path, the manual fallback should hand over the
+      // package the user's manager applies (.deb), not the portable tarball.
+      if (!UniversalPlatform.isLinux) return;
+      final c = makeContainer();
+      UpdateInstaller.debugInstallRootWritable = false;
+      UpdateInstaller.debugHasPrivilegedInstaller = false;
+      setLatest(c, [
+        _asset('daccord-linux-x86_64.deb'),
+        _asset('daccord-linux-x86_64.tar.gz'),
+      ]);
+      expect(controllerOf(c).platformAssetUrl(), endsWith('.deb'));
+    });
+
+    test('non-writable Linux + pkexec installs the .deb in place (admin)', () {
+      // The one Linux exception: a system .deb install CAN self-update when
+      // pkexec is present — by reinstalling the package with elevated rights.
+      if (!UniversalPlatform.isLinux) return;
+      final c = makeContainer();
+      UpdateInstaller.debugInstallRootWritable = false;
+      UpdateInstaller.debugHasPrivilegedInstaller = true;
+      setLatest(c, [
+        _asset('daccord-linux-x86_64.deb'),
+        _asset('daccord-linux-x86_64.tar.gz'),
+      ]);
+      expect(controllerOf(c).canInstallInPlace, isTrue);
+      // The in-place asset is the package, not the tarball…
+      expect(controllerOf(c).platformAsset()!.name, endsWith('.deb'));
+      // …and the UI is told to warn about the admin prompt.
+      expect(controllerOf(c).requiresPrivilegedInstall, isTrue);
     });
   });
 

--- a/test/features/updates/updates_page_test.dart
+++ b/test/features/updates/updates_page_test.dart
@@ -1,0 +1,120 @@
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/updates/controllers/update_controller.dart';
+import 'package:bonfire/features/updates/models/app_release.dart';
+import 'package:bonfire/features/updates/views/updates_page.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeUpdateController extends UpdateController {
+  _FakeUpdateController(
+    this._state, {
+    bool canInstallInPlace = false,
+    bool requiresPrivilegedInstall = false,
+  })  : _canInstallInPlace = canInstallInPlace,
+        _requiresPrivilegedInstall = requiresPrivilegedInstall;
+  final UpdateState _state;
+  final bool _canInstallInPlace;
+  final bool _requiresPrivilegedInstall;
+  @override
+  UpdateState build() => _state;
+  @override
+  bool get canInstallInPlace => _canInstallInPlace;
+  @override
+  bool get requiresPrivilegedInstall => _requiresPrivilegedInstall;
+}
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+// Version well ahead of kAppVersion so updateAvailable == true.
+const _newerRelease = AppRelease(
+  version: '99.0.0',
+  name: 'v99.0.0',
+  notes: '',
+  url: '',
+  publishedAt: '',
+);
+
+Widget _host({
+  required UpdateState update,
+  bool canInstallInPlace = false,
+  bool requiresPrivilegedInstall = false,
+}) =>
+    ProviderScope(
+      overrides: [
+        updateControllerProvider.overrideWith(
+          () => _FakeUpdateController(
+            update,
+            canInstallInPlace: canInstallInPlace,
+            requiresPrivilegedInstall: requiresPrivilegedInstall,
+          ),
+        ),
+        settingsControllerProvider.overrideWith(() => _FakeSettingsController()),
+      ],
+      child: MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: const UpdatesScreen(),
+      ),
+    );
+
+void main() {
+  group('UpdatesScreen install button label', () {
+    testWidgets(
+        'reads "Install (admin)" when ready and requiresPrivilegedInstall '
+        '(Linux system-package reinstall via pkexec)', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(
+            latest: _newerRelease,
+            phase: UpdatePhase.ready,
+            stagedArchivePath: '/tmp/daccord.deb',
+          ),
+          canInstallInPlace: true,
+          requiresPrivilegedInstall: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Install (admin)'), findsOneWidget);
+      expect(find.text('Restart & install'), findsNothing);
+    });
+
+    testWidgets('reads "Restart & install" when ready and no admin is needed',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(
+            latest: _newerRelease,
+            phase: UpdatePhase.ready,
+            stagedArchivePath: '/tmp/daccord.tar.gz',
+          ),
+          canInstallInPlace: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Restart & install'), findsOneWidget);
+      expect(find.text('Install (admin)'), findsNothing);
+    });
+
+    testWidgets(
+        'reads "Download & install (admin)" when idle and requiresPrivilegedInstall',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          update: const UpdateState(latest: _newerRelease),
+          canInstallInPlace: true,
+          requiresPrivilegedInstall: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Download & install (admin)'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

On Linux, the self-updater silently no-ops for `.deb` installs. Symptom: the "Update ready — tap to restart & install" banner appears, clicking it quits the app, it comes back — **still on the old version**.

**Root cause:** the updater assumed a user-writable install root. The `.deb` installs to root-owned `/opt/daccord` (`/opt` is `root:root`), so the swap helper's first step —

```bash
mv "/opt/daccord" "/opt/daccord.old" 2>/dev/null   # Permission denied — silently swallowed
```

— fails, the `if` block is skipped, nothing swaps, and it relaunches the same old `/opt/daccord/daccord`. Download + verify succeed, so it *looks* like it worked. The same latent problem affects macOS `/Applications` and Windows `Program Files` installs.

## The fix

1. **Gate in-place installs on a writable install root.** A cheap, cached probe checks whether the install root's *parent* dir is writable (exactly what the swap `mv` needs). Package-manager installs no longer offer the broken one-click apply.

2. **Real privileged path for `.deb` installs (the common Linux case).** When the root isn't writable but the release ships a `.deb` and `pkexec` is present, the updater now:
   - downloads the new `.deb` and SHA-256-verifies it,
   - runs `pkexec dpkg -i <deb>` → polkit shows an admin-password dialog,
   - on success, dpkg overwrites `/opt/daccord` (safe while running — Linux keeps the old inode until exit), the app quits, and a detached helper relaunches the new binary.
   - On a cancelled prompt or dpkg failure it throws a clear message ("Update needs administrator approval." / the dpkg error) and **stays on the current version** — no silent false-success, and it doesn't quit.

3. **Honest fallback.** Without `pkexec` (or on a non-writable root generally), the UI falls back to a manual download, now preferring the `.deb` the user's package manager applies over the portable tarball.

## Changes

- **`update_installer_io.dart`** — `isInstallRootWritable` + `hasPrivilegedInstaller` probes (cached, with `@visibleForTesting` seams); `_installLinux` routes a `.deb` through the new `_installLinuxDeb` (pkexec + verified relaunch).
- **`update_controller.dart`** — `_installableExts` now encodes the writability / privilege gating for all desktop platforms; added `requiresPrivilegedInstall` so the UI can warn.
- **`update_banner.dart` / `updates_page.dart`** — admin-aware wording ("Tap to install (admin required)", "Install (admin)").
- **`update_installer_stub.dart`** — web API parity.
- **Tests** — cover the writable, non-writable-without-pkexec, and non-writable-with-pkexec paths.

## Reviewer notes

- **Rollout caveat:** this ships in a new release; an already-installed build has the old helper, so the *first* update after this lands still runs the old (broken) path. That first fixed `.deb` likely needs a one-time manual `dpkg -i`; every update after is one-click.
- `pkexec dpkg -i` needs an interactive polkit agent (desktop sessions provide one). No apt repo is involved — it reinstalls the downloaded package directly, keeping dpkg's DB consistent.
- The privileged flow was not exercised end-to-end in this change (it would really reinstall daccord + trigger a password prompt); logic is covered by unit tests and the mechanics were validated on a real `/opt` install.

All 458 tests pass; `flutter analyze` clean for the touched files.