### PR TITLE
fix(router): stop bouncing sub-routes home when logged in

### DIFF
--- a/lib/router/controller.dart
+++ b/lib/router/controller.dart
@@ -33,7 +33,12 @@ final rootNavigatorKey = GlobalKey<NavigatorState>();
 /// not the full incoming location. Using `matchedLocation` here would treat
 /// every sub-route (`/settings`, `/admin`, `/switcher`) as `/` and bounce it
 /// home while logged in.
-String? _redirectLoggedInToHome(BuildContext context, GoRouterState state) {
+///
+/// Public (not `_`-prefixed) and [visibleForTesting] so tests can exercise it
+/// against a real [GoRouter] instance without depending on the app's actual
+/// screen widgets.
+@visibleForTesting
+String? redirectLoggedInToHome(BuildContext context, GoRouterState state) {
   final location = state.uri.path;
   if (location != '/' && location != '/login' && location != '/register') {
     return null;
@@ -52,7 +57,7 @@ final routerController = GoRouter(
         routes: [
           GoRoute(
             path: '/',
-            redirect: _redirectLoggedInToHome,
+            redirect: redirectLoggedInToHome,
             builder: (context, state) => const AccordLoginScreen(),
             routes: [
               GoRoute(

--- a/lib/router/controller.dart
+++ b/lib/router/controller.dart
@@ -26,8 +26,15 @@ final rootNavigatorKey = GlobalKey<NavigatorState>();
 /// Attached to the `/` route, so it also runs for every sub-route match; the
 /// location guard keeps `/switcher`, `/spaces`, `/settings`, and `/admin`
 /// reachable while logged in.
+///
+/// Guard on the full destination (`state.uri.path`), not `state.matchedLocation`:
+/// this redirect lives on the `/` route, and for a parent-route redirect
+/// go_router sets `matchedLocation` to that route's own matched segment (`/`),
+/// not the full incoming location. Using `matchedLocation` here would treat
+/// every sub-route (`/settings`, `/admin`, `/switcher`) as `/` and bounce it
+/// home while logged in.
 String? _redirectLoggedInToHome(BuildContext context, GoRouterState state) {
-  final location = state.matchedLocation;
+  final location = state.uri.path;
   if (location != '/' && location != '/login' && location != '/register') {
     return null;
   }

--- a/test/router/controller_test.dart
+++ b/test/router/controller_test.dart
@@ -1,0 +1,111 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/router/controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+// Regression test for #179: a redirect attached to a parent route (here `/`)
+// sees `state.matchedLocation` pinned to that route's own segment for every
+// sub-route match, not the full incoming location — only `state.uri.path`
+// reflects where the user actually navigated. Reproduces the app's real route
+// nesting (see lib/router/controller.dart) with placeholder screens instead of
+// the real ones, so it doesn't drag in their provider dependencies.
+
+GoRouter _buildTestRouter() => GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          redirect: redirectLoggedInToHome,
+          builder: (context, state) => const Text('login'),
+          routes: [
+            GoRoute(
+              path: 'login',
+              builder: (context, state) => const Text('login'),
+            ),
+            GoRoute(
+              path: 'switcher',
+              builder: (context, state) => const Text('switcher'),
+            ),
+            GoRoute(
+              path: 'register',
+              builder: (context, state) => const Text('register'),
+            ),
+            GoRoute(
+              path: 'spaces',
+              builder: (context, state) => const Text('spaces'),
+            ),
+            GoRoute(
+              path: 'settings',
+              builder: (context, state) => const Text('settings'),
+            ),
+            GoRoute(
+              path: 'admin',
+              builder: (context, state) => const Text('admin'),
+            ),
+          ],
+        ),
+      ],
+    );
+
+AccordAuthState _loggedIn() {
+  final server = AccordServer.fromBaseUrl('https://example.test');
+  final session = AccordSession(
+    server: server,
+    token: 't',
+    userId: 'u1',
+    username: 'tester',
+  );
+  return AccordAuthLoggedIn(client: AccordClient(), session: session);
+}
+
+Future<GoRouter> _pumpAt(
+  WidgetTester tester,
+  String location, {
+  required AccordAuthState auth,
+}) async {
+  final router = _buildTestRouter();
+  addTearDown(router.dispose);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [accordAuthProvider.overrideWithValue(auth)],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  router.go(location);
+  await tester.pumpAndSettle();
+  return router;
+}
+
+void main() {
+  group('redirectLoggedInToHome', () {
+    for (final path in ['/settings', '/admin', '/switcher']) {
+      testWidgets('does not bounce $path home while logged in', (tester) async {
+        await _pumpAt(tester, path, auth: _loggedIn());
+
+        expect(find.text(path.substring(1)), findsOneWidget);
+        expect(find.text('spaces'), findsNothing);
+      });
+    }
+
+    for (final path in ['/', '/login', '/register']) {
+      testWidgets('redirects $path to /spaces while logged in', (tester) async {
+        await _pumpAt(tester, path, auth: _loggedIn());
+
+        expect(find.text('spaces'), findsOneWidget);
+      });
+    }
+
+    testWidgets('does not redirect / while logged out', (tester) async {
+      await _pumpAt(tester, '/', auth: const AccordAuthLoggedOut());
+
+      expect(find.text('login'), findsOneWidget);
+      expect(find.text('spaces'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

While signed in, opening **Settings** made the UI twitch as if it were about to open, then instantly snap back. **Switch account** appeared to do nothing, and **Server administration** was affected the same way.

## Root cause

The logged-in redirect on the `/` route guarded on `state.matchedLocation`:

```dart
final location = state.matchedLocation;
if (location != '/' && location != '/login' && location != '/register') {
  return null;
}
// logged in → redirect to /spaces
```

The redirect is attached to the parent `/` route. For a **parent-route** redirect, go_router sets `state.matchedLocation` to that route's *own* matched segment — which is always `/` — not the full incoming location (confirmed in go_router's `RouteMatch.buildState`: `matchedLocation` = the route's own segment, `uri` = the full destination).

So navigating to `/settings`, `/switcher`, or `/admin` while logged in was seen as `/`, passed the guard, and got redirected straight to `/spaces` — the twitch, and the dead Switch-account button.

Regressed in #177, when the login redirect moved from a `build()` post-frame callback into a go_router route-level redirect.

## Fix

Guard on the full destination (`state.uri.path`) instead of the per-route `matchedLocation`, so only `/`, `/login`, and `/register` bounce a logged-in user home — sub-routes open normally. Added a comment documenting the `matchedLocation` vs `uri.path` gotcha to prevent regression.

## Testing

- `flutter analyze --no-fatal-infos lib/router/controller.dart` → No issues found.
- Verified `/settings`, `/switcher`, and `/admin` all reach their screens while logged in; `/`, `/login`, `/register` still redirect home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)