### PR TITLE
fix(members/auth): stop roster spinning forever; sign out on expired token

### DIFF
--- a/lib/features/authentication/repositories/accord_auth.dart
+++ b/lib/features/authentication/repositories/accord_auth.dart
@@ -63,6 +63,11 @@ class AccordAuth extends _$AccordAuth {
   final Map<String, _Conn> _connections = {};
   String? _activeKey;
 
+  /// Connection keys currently being torn down after a 401, so the burst of
+  /// simultaneous unauthorized responses (spaces, members, emojis, …) triggers
+  /// exactly one sign-out per connection.
+  final Set<String> _signingOut = {};
+
   /// The active connection's client, or null when signed out. Repositories
   /// should obtain this via the logged-in [AccordAuthLoggedIn] state rather than
   /// reaching in here.
@@ -312,6 +317,30 @@ class AccordAuth extends _$AccordAuth {
         .set(ConnectionStatus.disconnected);
     ref.read(readyControllerProvider.notifier).setReady(false);
     state = const AccordAuthLoggedOut();
+  }
+
+  /// Reacts to a `401 Unauthorized` from connection [key]: its token is invalid
+  /// or expired and accordkit exposes no refresh path, so the session can't be
+  /// recovered silently. Sign the affected account out via [removeAccount],
+  /// which switches to another live server if one exists or otherwise
+  /// [logout]s to the login screen — matching "log me back in" rather than
+  /// leaving cached spaces/channels rendered behind a dead token.
+  ///
+  /// Guarded by [_signingOut] so the burst of simultaneous 401s (spaces,
+  /// members, emojis, …) tears the connection down exactly once; a no-op once
+  /// the connection is already gone.
+  Future<void> _handleUnauthorized(String key) async {
+    if (_signingOut.contains(key)) return;
+    final conn = _connections[key];
+    if (conn == null) return;
+    _signingOut.add(key);
+    debugPrint('Session $key is unauthorized (token invalid/expired); '
+        'signing it out.');
+    try {
+      await removeAccount(conn.session);
+    } finally {
+      _signingOut.remove(key);
+    }
   }
 
   // ── Add-a-server (multi-connection) ────────────────────────────────────────
@@ -728,6 +757,7 @@ class AccordAuth extends _$AccordAuth {
       baseUrl: session.server.baseUrl,
       gatewayUrl: session.server.gatewayUrl,
       cdnUrl: session.server.cdnUrl,
+      onUnauthorized: () => _handleUnauthorized(key),
       intents: [
         GatewayIntents.spaces,
         GatewayIntents.messages,

--- a/lib/features/member/controllers/accord_members.dart
+++ b/lib/features/member/controllers/accord_members.dart
@@ -23,8 +23,9 @@ const int _maxConcurrentUserFetches = 8;
 
 /// Whether the initial roster fetch for a space failed (a non-2xx response, a
 /// network error, or a timeout). Lets the roster show a retry affordance instead
-/// of spinning forever when `members.list` never yields a list. Reset to false
-/// whenever a load (re)starts; set true only after the retries are exhausted.
+/// of spinning forever when `members.list` never yields a list. Cleared on a
+/// successful load, and by the roster's Retry button before it re-triggers
+/// `_load`; set true only after the retries are exhausted.
 @Riverpod(keepAlive: true)
 class MembersLoadFailed extends _$MembersLoadFailed {
   @override

--- a/lib/features/member/controllers/accord_members.dart
+++ b/lib/features/member/controllers/accord_members.dart
@@ -21,6 +21,19 @@ final Set<String> activeMemberSpaces = <String>{};
 /// without tripping the limiter.
 const int _maxConcurrentUserFetches = 8;
 
+/// Whether the initial roster fetch for a space failed (a non-2xx response, a
+/// network error, or a timeout). Lets the roster show a retry affordance instead
+/// of spinning forever when `members.list` never yields a list. Reset to false
+/// whenever a load (re)starts; set true only after the retries are exhausted.
+@Riverpod(keepAlive: true)
+class MembersLoadFailed extends _$MembersLoadFailed {
+  @override
+  bool build(String spaceId) => false;
+
+  // ignore: use_setters_to_change_properties
+  void set(bool value) => state = value;
+}
+
 /// A space's members, keyed by space ID and indexed by user ID for O(1) author
 /// resolution. Self-loads via `members.list` the first time it's watched (once
 /// logged in) and is kept in sync by member join/update/leave gateway events.
@@ -40,16 +53,41 @@ class AccordMembersController extends _$AccordMembersController {
   }
 
   Future<void> _load(AccordClient client, String spaceId) async {
-    // `withUser` asks the server to embed each member's user object, so
-    // `_resolveUsers` finds them already populated and skips the per-member
-    // fetch. Older servers ignore the flag; the fallback fetch still runs then.
-    final list = (await client.members
-            .list(spaceId, query: {'limit': 100}, withUser: true))
-        .listOrLog<AccordMember>('members for $spaceId');
-    if (list == null) return;
-    final members = {for (final member in list) member.userId: member};
-    state = members;
-    await _resolveUsers(client, members);
+    // Retry a few times so a transient network blip or a still-warming server
+    // doesn't strand the roster on a permanent spinner. The `timeout` guards a
+    // hung socket, since the underlying HTTP client has no timeout of its own —
+    // without it a stalled request would leave `state` null (a forever spinner)
+    // that never recovers, even across navigation or an app restart.
+    //
+    // Every write to `membersLoadFailedProvider` happens after the first
+    // `await` below: `build` calls `_load` synchronously, and Riverpod forbids
+    // a provider mutating another during initialization.
+    for (var attempt = 0; attempt < 3; attempt++) {
+      List<AccordMember>? list;
+      try {
+        // `withUser` asks the server to embed each member's user object, so
+        // `_resolveUsers` finds them already populated and skips the per-member
+        // fetch. Older servers ignore the flag; the fallback fetch runs then.
+        list = (await client.members
+                .list(spaceId, query: {'limit': 100}, withUser: true)
+                .timeout(const Duration(seconds: 20)))
+            .listOrLog<AccordMember>('members for $spaceId');
+      } catch (e) {
+        debugPrint('Failed to load members for $spaceId: $e');
+      }
+      if (list != null) {
+        final members = {for (final member in list) member.userId: member};
+        state = members;
+        ref.read(membersLoadFailedProvider(spaceId).notifier).set(false);
+        await _resolveUsers(client, members);
+        return;
+      }
+      // Back off before retrying (1s, then 2s); no wait after the final try.
+      if (attempt < 2) {
+        await Future.delayed(Duration(seconds: attempt + 1));
+      }
+    }
+    ref.read(membersLoadFailedProvider(spaceId).notifier).set(true);
   }
 
   /// The members endpoint returns only `user_id` per member — no embedded user

--- a/lib/features/member/controllers/accord_members.g.dart
+++ b/lib/features/member/controllers/accord_members.g.dart
@@ -8,6 +8,125 @@ part of 'accord_members.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Whether the initial roster fetch for a space failed (a non-2xx response, a
+/// network error, or a timeout). Lets the roster show a retry affordance instead
+/// of spinning forever when `members.list` never yields a list. Reset to false
+/// whenever a load (re)starts; set true only after the retries are exhausted.
+
+@ProviderFor(MembersLoadFailed)
+const membersLoadFailedProvider = MembersLoadFailedFamily._();
+
+/// Whether the initial roster fetch for a space failed (a non-2xx response, a
+/// network error, or a timeout). Lets the roster show a retry affordance instead
+/// of spinning forever when `members.list` never yields a list. Reset to false
+/// whenever a load (re)starts; set true only after the retries are exhausted.
+final class MembersLoadFailedProvider
+    extends $NotifierProvider<MembersLoadFailed, bool> {
+  /// Whether the initial roster fetch for a space failed (a non-2xx response, a
+  /// network error, or a timeout). Lets the roster show a retry affordance instead
+  /// of spinning forever when `members.list` never yields a list. Reset to false
+  /// whenever a load (re)starts; set true only after the retries are exhausted.
+  const MembersLoadFailedProvider._({
+    required MembersLoadFailedFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'membersLoadFailedProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$membersLoadFailedHash();
+
+  @override
+  String toString() {
+    return r'membersLoadFailedProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  MembersLoadFailed create() => MembersLoadFailed();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MembersLoadFailedProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$membersLoadFailedHash() => r'13daffe42918003e1b2b4dcdaf0e5120feadfc47';
+
+/// Whether the initial roster fetch for a space failed (a non-2xx response, a
+/// network error, or a timeout). Lets the roster show a retry affordance instead
+/// of spinning forever when `members.list` never yields a list. Reset to false
+/// whenever a load (re)starts; set true only after the retries are exhausted.
+
+final class MembersLoadFailedFamily extends $Family
+    with $ClassFamilyOverride<MembersLoadFailed, bool, bool, bool, String> {
+  const MembersLoadFailedFamily._()
+    : super(
+        retry: null,
+        name: r'membersLoadFailedProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  /// Whether the initial roster fetch for a space failed (a non-2xx response, a
+  /// network error, or a timeout). Lets the roster show a retry affordance instead
+  /// of spinning forever when `members.list` never yields a list. Reset to false
+  /// whenever a load (re)starts; set true only after the retries are exhausted.
+
+  MembersLoadFailedProvider call(String spaceId) =>
+      MembersLoadFailedProvider._(argument: spaceId, from: this);
+
+  @override
+  String toString() => r'membersLoadFailedProvider';
+}
+
+/// Whether the initial roster fetch for a space failed (a non-2xx response, a
+/// network error, or a timeout). Lets the roster show a retry affordance instead
+/// of spinning forever when `members.list` never yields a list. Reset to false
+/// whenever a load (re)starts; set true only after the retries are exhausted.
+
+abstract class _$MembersLoadFailed extends $Notifier<bool> {
+  late final _$args = ref.$arg as String;
+  String get spaceId => _$args;
+
+  bool build(String spaceId);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}
+
 /// A space's members, keyed by space ID and indexed by user ID for O(1) author
 /// resolution. Self-loads via `members.list` the first time it's watched (once
 /// logged in) and is kept in sync by member join/update/leave gateway events.
@@ -73,7 +192,7 @@ final class AccordMembersControllerProvider
 }
 
 String _$accordMembersControllerHash() =>
-    r'd8db4fd898bfb79e1fcaf114445b2fce95ce42d5';
+    r'b31efa98ebbf57dc6e172572b36863d15d9a571e';
 
 /// A space's members, keyed by space ID and indexed by user ID for O(1) author
 /// resolution. Self-loads via `members.list` the first time it's watched (once

--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -70,6 +70,19 @@ class _Roster extends ConsumerWidget {
     final presences = ref.watch(presenceControllerProvider);
 
     if (members == null) {
+      // The roster fetch itself failed (timeout / non-2xx / network) — surface
+      // a retry instead of spinning forever. Retrying re-runs the controller's
+      // load, which clears the failed flag on the way in.
+      if (ref.watch(membersLoadFailedProvider(spaceId))) {
+        return ServerUnreachable(
+          title: "Couldn't load members",
+          message: 'Something went wrong fetching the member list.',
+          onRetry: () {
+            ref.read(membersLoadFailedProvider(spaceId).notifier).set(false);
+            ref.invalidate(accordMembersControllerProvider(spaceId));
+          },
+        );
+      }
       if (ref.watch(connectionControllerProvider).isUnreachable) {
         return ServerUnreachable(onRetry: () {
           final auth = ref.read(accordAuthProvider);

--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -71,8 +71,8 @@ class _Roster extends ConsumerWidget {
 
     if (members == null) {
       // The roster fetch itself failed (timeout / non-2xx / network) — surface
-      // a retry instead of spinning forever. Retrying re-runs the controller's
-      // load, which clears the failed flag on the way in.
+      // a retry instead of spinning forever. onRetry clears the failed flag
+      // itself, then invalidates the controller to re-run `_load`.
       if (ref.watch(membersLoadFailedProvider(spaceId))) {
         return ServerUnreachable(
           title: "Couldn't load members",

--- a/lib/shared/components/server_unreachable.dart
+++ b/lib/shared/components/server_unreachable.dart
@@ -8,9 +8,14 @@ import 'package:flutter/material.dart';
 class ServerUnreachable extends StatelessWidget {
   const ServerUnreachable({
     super.key,
+    this.title = 'Server unreachable',
     this.message = 'Trying to reconnect…',
     this.onRetry,
   });
+
+  /// The headline (e.g. 'Server unreachable', or 'Couldn't load members' for a
+  /// pane whose own fetch failed while the connection is otherwise up).
+  final String title;
 
   /// The secondary line under the headline (e.g. a hint about retrying).
   final String message;
@@ -31,7 +36,7 @@ class ServerUnreachable extends StatelessWidget {
             Icon(Icons.cloud_off_outlined, size: 40, color: colors.gray),
             const SizedBox(height: 12),
             Text(
-              'Server unreachable',
+              title,
               textAlign: TextAlign.center,
               style: textTheme.titleSmall?.copyWith(color: colors.dirtyWhite),
             ),

--- a/packages/accordkit/lib/src/core/accord_client.dart
+++ b/packages/accordkit/lib/src/core/accord_client.dart
@@ -86,6 +86,7 @@ class AccordClient {
     String? baseUrl,
     String? gatewayUrl,
     String? cdnUrl,
+    void Function()? onUnauthorized,
     http.Client? httpClient,
     GatewayConnectionFactory? connectionFactory,
     Future<void> Function(Duration)? sleep,
@@ -99,6 +100,7 @@ class AccordClient {
       config.apiUrl(),
       token: token,
       tokenType: tokenType,
+      onUnauthorized: onUnauthorized,
       client: httpClient,
       sleep: sleep,
     );

--- a/packages/accordkit/lib/src/rest/accord_rest.dart
+++ b/packages/accordkit/lib/src/rest/accord_rest.dart
@@ -20,6 +20,13 @@ class AccordRest {
   String tokenType; // "Bot" or "Bearer"
   String baseUrl;
 
+  /// Invoked whenever an authenticated request comes back `401 Unauthorized`
+  /// (an invalid, revoked, or expired token). Lets the owner react centrally —
+  /// e.g. sign the session out — instead of every call site handling it. Not
+  /// fired for the login/register routes on a throwaway unauthenticated client,
+  /// which simply leave this null.
+  void Function()? onUnauthorized;
+
   final http.Client _client;
   final Future<void> Function(Duration) _sleep;
 
@@ -27,6 +34,7 @@ class AccordRest {
     this.baseUrl, {
     this.token = '',
     this.tokenType = 'Bot',
+    this.onUnauthorized,
     http.Client? client,
     Future<void> Function(Duration)? sleep,
   })  : _client = client ?? http.Client(),
@@ -77,6 +85,7 @@ class AccordRest {
         );
       }
 
+      if (response.statusCode == 401) onUnauthorized?.call();
       return _parseResponse(
           response.statusCode, utf8.decode(response.bodyBytes));
     }
@@ -187,6 +196,7 @@ class AccordRest {
         );
       }
 
+      if (response.statusCode == 401) onUnauthorized?.call();
       return _parseResponse(
           response.statusCode, utf8.decode(response.bodyBytes));
     }

--- a/packages/accordkit/test/rest_test.dart
+++ b/packages/accordkit/test/rest_test.dart
@@ -163,6 +163,41 @@ void main() {
       expect(result.ok, isFalse);
       expect(result.error!.code, 'INTERNAL');
     });
+
+    test('fires onUnauthorized on a 401 response', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonError('UNAUTHORIZED', 'nope', status: 401),
+        onUnauthorized: () => calls++,
+      );
+      final result = await rest.makeRequest('GET', '/x');
+      expect(result.ok, isFalse);
+      expect(result.statusCode, 401);
+      expect(calls, 1);
+    });
+
+    test('does not fire onUnauthorized on non-401 failures', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonError('FORBIDDEN', 'no', status: 403),
+        onUnauthorized: () => calls++,
+      );
+      await rest.makeRequest('GET', '/x');
+      expect(calls, 0);
+    });
+
+    test('does not fire onUnauthorized on success', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonData({'ok': true}),
+        onUnauthorized: () => calls++,
+      );
+      await rest.makeRequest('GET', '/x');
+      expect(calls, 0);
+    });
   });
 
   group('AccordRest.makeRawRequest', () {
@@ -208,6 +243,20 @@ void main() {
       expect(body, contains('filename="a.txt"'));
       expect(body, contains('hello'));
       expect(body.trimRight().endsWith('--BOUND--'), isTrue);
+    });
+
+    test('fires onUnauthorized on a 401 response', () async {
+      var calls = 0;
+      final rest = mockRest(
+        log: [],
+        responder: (_) => jsonError('UNAUTHORIZED', 'nope', status: 401),
+        onUnauthorized: () => calls++,
+      );
+      final form = MultipartForm(boundary: 'BOUND')..addField('a', 'b');
+      final result =
+          await rest.makeMultipartRequest('POST', '/upload', form);
+      expect(result.ok, isFalse);
+      expect(calls, 1);
     });
   });
 

--- a/packages/accordkit/test/support/test_helpers.dart
+++ b/packages/accordkit/test/support/test_helpers.dart
@@ -38,6 +38,7 @@ AccordRest mockRest({
   String token = 'test-token',
   String tokenType = 'Bot',
   String baseUrl = 'https://example.test/api/v1',
+  void Function()? onUnauthorized,
 }) {
   final client = MockClient((request) async {
     final captured = CapturedRequest(
@@ -54,6 +55,7 @@ AccordRest mockRest({
     baseUrl,
     token: token,
     tokenType: tokenType,
+    onUnauthorized: onUnauthorized,
     client: client,
     sleep: (_) async {},
   );

--- a/test/features/member/accord_members_load_test.dart
+++ b/test/features/member/accord_members_load_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/member/controllers/accord_members.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _spaceId = 'space1';
+
+/// A member payload with the user embedded, so `_resolveUsers` has nothing
+/// left to backfill and the test doesn't need to also mock `/users/*`.
+String _membersJson(List<String> userIds) => jsonEncode([
+      for (final id in userIds)
+        {
+          'user_id': id,
+          'user': {'id': id, 'username': id},
+        },
+    ]);
+
+/// Builds a logged-in [ProviderContainer] whose [AccordClient] is backed by
+/// [responder] instead of real HTTP, so `AccordMembersController._load`'s
+/// retry/timeout/failure-flag behaviour can be driven deterministically.
+ProviderContainer makeContainer(
+  Future<http.Response> Function(http.Request request) responder,
+) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final client = AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient(responder),
+  );
+  final session = AccordSession(
+    server: server,
+    token: 'test-token',
+    userId: 'u-self',
+    username: 'self',
+  );
+  final container = ProviderContainer(
+    overrides: [
+      accordAuthProvider.overrideWithValue(
+        AccordAuthLoggedIn(client: client, session: session),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  addTearDown(client.dispose);
+  return container;
+}
+
+Map<String, AccordMember>? _state(ProviderContainer c) =>
+    c.read(accordMembersControllerProvider(_spaceId));
+
+bool _failed(ProviderContainer c) =>
+    c.read(membersLoadFailedProvider(_spaceId));
+
+/// Polls [condition] until it's true, so tests don't hard-code the retry
+/// loop's real (1s, 2s) backoff durations. Fails the test if [timeout] elapses
+/// first.
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  group('AccordMembersController._load', () {
+    test('a genuinely empty roster is not treated as a failure', () async {
+      final container = makeContainer(
+        (_) async => http.Response(_membersJson(const []), 200),
+      );
+
+      container.read(accordMembersControllerProvider(_spaceId));
+      await _waitUntil(() => _state(container) != null);
+
+      expect(_state(container), isEmpty);
+      expect(_failed(container), isFalse);
+    });
+
+    test('retries a failing attempt and succeeds once the server recovers',
+        () async {
+      var attempts = 0;
+      final container = makeContainer((_) async {
+        attempts++;
+        if (attempts == 1) return http.Response('', 500);
+        return http.Response(_membersJson(const ['u1']), 200);
+      });
+
+      container.read(accordMembersControllerProvider(_spaceId));
+      // First attempt fails immediately; the retry backs off ~1s before the
+      // second attempt, which succeeds.
+      await _waitUntil(() => _state(container) != null);
+
+      expect(attempts, 2);
+      expect(_state(container)?.keys, contains('u1'));
+      expect(_failed(container), isFalse);
+    });
+
+    test('sets the failed flag once every retry is exhausted', () async {
+      var attempts = 0;
+      final container = makeContainer((_) async {
+        attempts++;
+        return http.Response('', 500);
+      });
+
+      container.read(accordMembersControllerProvider(_spaceId));
+      // 3 attempts, backing off 1s then 2s between them (~3s total).
+      await _waitUntil(() => _failed(container));
+
+      expect(attempts, 3);
+      expect(_state(container), isNull);
+    });
+
+    test('a fresh invalidate-triggered load clears the failed flag on success',
+        () async {
+      var attempts = 0;
+      final container = makeContainer((_) async {
+        attempts++;
+        // Fail every attempt of the first load (3 tries), then succeed.
+        if (attempts <= 3) return http.Response('', 500);
+        return http.Response(_membersJson(const ['u1']), 200);
+      });
+
+      container.read(accordMembersControllerProvider(_spaceId));
+      await _waitUntil(() => _failed(container));
+
+      // Mirrors the roster's Retry button: clear the flag, then reload.
+      container.read(membersLoadFailedProvider(_spaceId).notifier).set(false);
+      container.invalidate(accordMembersControllerProvider(_spaceId));
+      container.read(accordMembersControllerProvider(_spaceId));
+      await _waitUntil(() => _state(container) != null);
+
+      expect(_state(container)?.keys, contains('u1'));
+      expect(_failed(container), isFalse);
+    });
+  });
+}

--- a/test/shared/server_unreachable_test.dart
+++ b/test/shared/server_unreachable_test.dart
@@ -1,0 +1,51 @@
+import 'package:bonfire/shared/components/server_unreachable.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  group('ServerUnreachable', () {
+    testWidgets('defaults to the "Server unreachable" title', (tester) async {
+      await tester.pumpWidget(_host(const ServerUnreachable()));
+      expect(find.text('Server unreachable'), findsOneWidget);
+      expect(find.text('Trying to reconnect…'), findsOneWidget);
+    });
+
+    testWidgets('renders a custom title for a pane-specific failure', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_host(const ServerUnreachable(
+        title: "Couldn't load members",
+        message: 'Something went wrong fetching the member list.',
+      )));
+      expect(find.text("Couldn't load members"), findsOneWidget);
+      expect(
+        find.text('Something went wrong fetching the member list.'),
+        findsOneWidget,
+      );
+      expect(find.text('Server unreachable'), findsNothing);
+    });
+
+    testWidgets('hides the Retry button when onRetry is null', (tester) async {
+      await tester.pumpWidget(_host(const ServerUnreachable()));
+      expect(find.text('Retry'), findsNothing);
+    });
+
+    testWidgets('shows and wires the Retry button when onRetry is set', (
+      tester,
+    ) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        _host(ServerUnreachable(onRetry: () => tapped = true)),
+      );
+      expect(find.text('Retry'), findsOneWidget);
+      await tester.tap(find.text('Retry'));
+      expect(tapped, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

The member roster **loaded forever and never resolved**, even after an app restart. Investigation surfaced two independent problems behind that one symptom.

### 1. Roster had no failure path (`lib/features/member`)
`AccordMembersController._load` set `state` **only on success**, and accordkit's HTTP client has **no request timeout**. So a hung, `4xx`/`5xx`, or throwing `members.list` call left `state == null` — and since the provider is `@Riverpod(keepAlive: true)`, it never retried or recovered. The only error UI was gated on the *gateway* being unreachable, which a failed REST call doesn't trip → permanent spinner.

**Fix:** `_load` now wraps the fetch in a **20s timeout** with **bounded retry** (3 attempts, backoff), and on exhausted failure flips a new `membersLoadFailedProvider`. The roster then shows a **"Couldn't load members" + Retry** card (`ServerUnreachable` gained an optional `title`) instead of spinning; Retry re-runs the load. Genuinely-empty spaces still render an empty roster (no false error).

### 2. Expired token still rendered cached data (`lib/features/authentication` + `packages/accordkit`)
The deeper cause: a dead/expired token still rendered **cached spaces and channels** while every authenticated REST call `401`'d in the background — which is what made this look like a member-list-specific hang. accordkit exposes **no token-refresh endpoint**, so silent recovery isn't possible.

**Fix:** central 401 handling.
- `AccordRest` gains an `onUnauthorized` hook, fired on any `401`, threaded through `AccordClient`.
- `AccordAuth` wires each **live** connection to `_handleUnauthorized`, which signs the account out via `removeAccount` — switching to another live account if one exists, otherwise logging out to the **login screen**. A `_signingOut` guard collapses the burst of simultaneous 401s into a single sign-out.
- Login/register use throwaway unauthenticated clients (no `onUnauthorized`), so a wrong-password `401` never triggers a global sign-out.

## Verified live
Ran on Linux desktop against `chat.daccord.gg` with an expired session:

```
Session 312534760092073984@https://chat.daccord.gg is unauthorized (token invalid/expired); signing it out.
```

Sign-out fired exactly **once** (guard held), and the app landed on the login screen instead of a broken home. Roster retry state renders in place of the infinite spinner.

## Reviewer notes
- No behavioural change for healthy sessions — `onUnauthorized` only fires on real `401`s.
- Multi-account: if a background account's token dies, only that connection is dropped; the active session is untouched.
- `dart analyze` (accordkit) and `flutter analyze --no-fatal-infos` on all touched files are clean. `accord_members.g.dart` is regenerated Riverpod codegen for the new provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)