### PR TITLE
fix(router): stop nesting the signed-in screens under the sign-in route

### DIFF
--- a/lib/features/authentication/views/accord_login.dart
+++ b/lib/features/authentication/views/accord_login.dart
@@ -266,11 +266,12 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(accordAuthProvider);
 
-    // This only covers a login that completes *while this screen is showing*.
-    // Landing on a login route while *already* logged in (e.g. tapping "back"
-    // out of /admin or /settings, whose router parent is this screen) never
-    // reaches build: the router redirects it straight home (see
-    // `_redirectLoggedInToHome` in `lib/router/controller.dart`).
+    // Covers a login that completes *while this screen is showing* — a state
+    // change doesn't re-run router redirects. Landing on a sign-in route while
+    // *already* logged in never reaches build: the router redirects it straight
+    // home (see `redirectLoggedInToHome` in `lib/router/controller.dart`), and
+    // the signed-in screens are siblings of these routes, so this screen is not
+    // mounted underneath them.
     ref.listen(accordAuthProvider, (previous, next) {
       if (next is AccordAuthLoggedIn) {
         final spaceId = _pendingJoinSpaceId;
@@ -322,7 +323,9 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
           onBrowse: () => setState(() => _view = _LoggedOutView.browse),
           onManualConnect: () =>
               setState(() => _view = _LoggedOutView.credentials),
-          onSwitchAccount: _hasAccounts ? () => context.go('/switcher') : null,
+          onSwitchAccount: _hasAccounts
+              ? () => context.push('/switcher')
+              : null,
         ),
         maxWidth: 480,
       ),
@@ -344,7 +347,7 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
           tosAccepted: _tosAccepted,
           onBack: _atFlowRoot ? null : _goBack,
           onModeChanged: _onModeChanged,
-          onSwitchAccount: () => context.go('/switcher'),
+          onSwitchAccount: () => context.push('/switcher'),
           onGeneratePassword: _generatePassword,
           onTosChanged: (v) => setState(() => _tosAccepted = v),
           onTosLinkTap: _openTos,

--- a/lib/features/authentication/views/switcher.dart
+++ b/lib/features/authentication/views/switcher.dart
@@ -116,7 +116,11 @@ class _AccountSwitcherScreenState extends ConsumerState<AccountSwitcherScreen> {
               ),
               const SizedBox(height: 8),
               TextButton(
-                onPressed: () => context.go('/spaces'),
+                // Pushed from the home screen or the sign-in screen, so pop
+                // back to whichever opened it; fall back to home for a cold
+                // deep link that has nothing beneath it.
+                onPressed: () =>
+                    context.canPop() ? context.pop() : context.go('/spaces'),
                 child: Text('Back', style: theme.textTheme.bodyMedium),
               ),
             ],

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -399,7 +399,7 @@ class _AccountSection extends StatelessWidget {
           leading: Icon(Icons.switch_account, color: colors.dirtyWhite),
           title: const Text('Switch account'),
           trailing: const Icon(Icons.chevron_right),
-          onTap: () => context.go('/switcher'),
+          onTap: () => context.push('/switcher'),
         ),
         ListTile(
           leading: Icon(Icons.devices, color: colors.dirtyWhite),
@@ -430,7 +430,7 @@ class _AccountSection extends StatelessWidget {
             ),
             title: const Text('Server administration'),
             subtitle: const Text('Spaces, users, reports, settings'),
-            onTap: () => context.go('/admin'),
+            onTap: () => context.push('/admin'),
           ),
       ],
     );

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -465,7 +465,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
       selectedSpaceId: effectiveSpaceId,
       onSelect: _selectSpace,
       onAddServer: () => showAddServerDialog(context),
-      onSwitchAccount: () => context.go('/switcher'),
+      onSwitchAccount: () => context.push('/switcher'),
       onOpenSettings: () => context.push('/settings'),
       onLogout: () async {
         if (!await confirmLogout(context)) return;
@@ -564,10 +564,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
         //
         // Wrap in [PopScope] so Android's left-edge back swipe (which shares the
         // same edge as the swipe-to-open-sidebar gesture) steps through / opens
-        // the drawers instead of popping the route. The home (`/spaces`) is a
-        // child of the login route (`/`), so an un-intercepted system back would
-        // pop down to the sign-in screen — the cause of the "swiping left
-        // re-prompts for sign in" bug.
+        // the drawers instead of popping the route (#125).
         return PopScope(
           canPop: false,
           onPopInvokedWithResult: (didPop, _) {

--- a/lib/router/controller.dart
+++ b/lib/router/controller.dart
@@ -15,24 +15,18 @@ import 'package:bonfire/features/spaces/views/accord_home.dart';
 /// Add-a-Server dialog and route over whatever screen is current.
 final rootNavigatorKey = GlobalKey<NavigatorState>();
 
-/// Sends the login-hosting locations straight home when a live session already
-/// exists — e.g. tapping "back" out of `/admin` or `/settings` (whose router
-/// parent is the login route) or deep-linking to `/login` while signed in.
-/// Only a settled [AccordAuthLoggedIn] bounces: in-progress / MFA /
+/// Sends the sign-in locations (`/`, `/login`, `/register`) straight home when
+/// a live session already exists — e.g. deep-linking to `/login` while signed
+/// in. Only a settled [AccordAuthLoggedIn] bounces: in-progress / MFA /
 /// password-reset states still render the login screen's forms, and a login
 /// that *completes* while the screen is showing navigates via the screen's own
 /// `ref.listen` (a state change doesn't re-run router redirects).
 ///
-/// Attached to the `/` route, so it also runs for every sub-route match; the
-/// location guard keeps `/switcher`, `/spaces`, `/settings`, and `/admin`
-/// reachable while logged in.
-///
-/// Guard on the full destination (`state.uri.path`), not `state.matchedLocation`:
-/// this redirect lives on the `/` route, and for a parent-route redirect
-/// go_router sets `matchedLocation` to that route's own matched segment (`/`),
-/// not the full incoming location. Using `matchedLocation` here would treat
-/// every sub-route (`/settings`, `/admin`, `/switcher`) as `/` and bounce it
-/// home while logged in.
+/// Attached to each sign-in route individually rather than to a shared parent.
+/// The location guard is belt-and-braces: should these routes ever gain
+/// children again, a parent-route redirect sees `state.matchedLocation` pinned
+/// to its own matched segment, so only `state.uri.path` reflects where the user
+/// actually navigated (#179 — every signed-in sub-route got bounced home).
 ///
 /// Public (not `_`-prefixed) and [visibleForTesting] so tests can exercise it
 /// against a real [GoRouter] instance without depending on the app's actual
@@ -47,51 +41,69 @@ String? redirectLoggedInToHome(BuildContext context, GoRouterState state) {
   return auth is AccordAuthLoggedIn ? '/spaces' : null;
 }
 
+/// Every signed-in destination is a *sibling* of the sign-in routes, never a
+/// child of them. Nesting them under `/` used to put the sign-in screen in the
+/// navigator stack underneath the whole app, which is what made `/settings`,
+/// `/admin`, and `/switcher` inherit `/`'s logged-in redirect (#179: Settings
+/// twitched open then closed) and what made Android's back swipe on the home
+/// screen pop down to sign-in (#125).
+///
+/// Screens opened *from* the home screen (Settings, Switch account, Server
+/// administration) are reached with `push`, so `/spaces` stays beneath them and
+/// their back affordance — system back, or the app bar's arrow via
+/// `context.canPop()` — returns there. `go` is for replacing the stack
+/// entirely: signing in, signing out, and returning home.
+///
+/// Keep `_buildTestRouter` in `test/router/controller_test.dart` mirroring this
+/// shape; it exercises the redirect and the push/pop stack against placeholder
+/// screens.
 final routerController = GoRouter(
   navigatorKey: rootNavigatorKey,
   routes: [
     ShellRoute(
-        builder: (context, state, child) => Scaffold(
-            body: child,
-            backgroundColor: BonfireThemeExtension.of(context).background),
-        routes: [
-          GoRoute(
-            path: '/',
-            redirect: redirectLoggedInToHome,
-            builder: (context, state) => const AccordLoginScreen(),
-            routes: [
-              GoRoute(
-                path: 'login',
-                builder: (context, state) =>
-                    const AccordLoginScreen(startOnCredentials: true),
-              ),
-              GoRoute(
-                path: 'switcher',
-                builder: (context, state) => const AccountSwitcherScreen(),
-              ),
-              GoRoute(
-                path: 'register',
-                builder: (context, state) => const AccordLoginScreen(
-                  initialMode: AuthMode.register,
-                  startOnCredentials: true,
-                ),
-              ),
-              GoRoute(
-                path: 'spaces',
-                builder: (context, state) => AccordHomeScreen(
-                  initialSpaceId: state.uri.queryParameters['space'],
-                ),
-              ),
-              GoRoute(
-                path: 'settings',
-                builder: (context, state) => const AccordSettingsScreen(),
-              ),
-              GoRoute(
-                path: 'admin',
-                builder: (context, state) => const AccordAdminPanel(),
-              ),
-            ],
+      builder: (context, state, child) => Scaffold(
+        body: child,
+        backgroundColor: BonfireThemeExtension.of(context).background,
+      ),
+      routes: [
+        GoRoute(
+          path: '/',
+          redirect: redirectLoggedInToHome,
+          builder: (context, state) => const AccordLoginScreen(),
+        ),
+        GoRoute(
+          path: '/login',
+          redirect: redirectLoggedInToHome,
+          builder: (context, state) =>
+              const AccordLoginScreen(startOnCredentials: true),
+        ),
+        GoRoute(
+          path: '/register',
+          redirect: redirectLoggedInToHome,
+          builder: (context, state) => const AccordLoginScreen(
+            initialMode: AuthMode.register,
+            startOnCredentials: true,
           ),
-        ]),
+        ),
+        GoRoute(
+          path: '/switcher',
+          builder: (context, state) => const AccountSwitcherScreen(),
+        ),
+        GoRoute(
+          path: '/spaces',
+          builder: (context, state) => AccordHomeScreen(
+            initialSpaceId: state.uri.queryParameters['space'],
+          ),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) => const AccordSettingsScreen(),
+        ),
+        GoRoute(
+          path: '/admin',
+          builder: (context, state) => const AccordAdminPanel(),
+        ),
+      ],
+    ),
   ],
 );

--- a/packages/livekit_client/lib/src/participant/local.dart
+++ b/packages/livekit_client/lib/src/participant/local.dart
@@ -375,19 +375,23 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     logger.fine('Video layers: ${layers.map((e) => e)}');
 
     Future<lk_models.TrackInfo> negotiate() async {
-      track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, publishOptions!, encodings);
+      // `publishOptions` is captured from the enclosing scope, where it's
+      // reassigned after this closure is defined (see below) — that makes it
+      // ineligible for null-promotion in here, so pin a non-null local.
+      final options = publishOptions!;
+      track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, options, encodings);
 
-      track.codec = publishOptions.videoCodec;
+      track.codec = options.videoCodec;
       if (lkBrowser() != BrowserType.firefox) {
         await room.engine.setPreferredCodec(
           track.transceiver!,
           'video',
-          publishOptions.videoCodec,
+          options.videoCodec,
         );
       }
 
       if ([TrackSource.camera, TrackSource.screenShareVideo].contains(track.source)) {
-        final degradationPreference = publishOptions.degradationPreference ??
+        final degradationPreference = options.degradationPreference ??
             getDefaultDegradationPreference(
               track,
             );
@@ -396,11 +400,11 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 
       if (kIsWeb && lkBrowser() == BrowserType.firefox && track.kind == TrackType.AUDIO) {
         //TOOD:
-      } else if (isSVCCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+      } else if (isSVCCodec(options.videoCodec) && encodings?.first.maxBitrate != null) {
         room.engine.publisher?.setTrackBitrateInfo(TrackBitrateInfo(
             cid: track.getCid(),
             transceiver: track.transceiver,
-            codec: publishOptions.videoCodec,
+            codec: options.videoCodec,
             maxbr: encodings![0].maxBitrate! ~/ 1000));
       }
 

--- a/test/router/controller_test.dart
+++ b/test/router/controller_test.dart
@@ -9,43 +9,56 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
-// Regression test for #179: a redirect attached to a parent route (here `/`)
-// sees `state.matchedLocation` pinned to that route's own segment for every
-// sub-route match, not the full incoming location — only `state.uri.path`
-// reflects where the user actually navigated. Reproduces the app's real route
-// nesting (see lib/router/controller.dart) with placeholder screens instead of
-// the real ones, so it doesn't drag in their provider dependencies.
+// Covers the two ways the "Settings does nothing" bug got in:
+//
+// * #179 — the logged-in redirect guarded on `state.matchedLocation`, which a
+//   parent-route redirect sees pinned to its own matched segment (`/`) rather
+//   than the full incoming location, so every signed-in sub-route was bounced
+//   home. Only `state.uri.path` reflects where the user actually navigated.
+// * The nesting that made that possible: `/spaces`, `/settings`, `/admin`, and
+//   `/switcher` used to be children of `/`, which both subjected them to the
+//   sign-in route's redirect and left the sign-in screen sitting in the
+//   navigator stack underneath the whole app.
+//
+// Mirrors the app's real route shape (see lib/router/controller.dart) with
+// placeholder screens instead of the real ones, so it doesn't drag in their
+// provider dependencies.
 
 GoRouter _buildTestRouter() => GoRouter(
       initialLocation: '/',
       routes: [
-        GoRoute(
-          path: '/',
-          redirect: redirectLoggedInToHome,
-          builder: (context, state) => const Text('login'),
+        ShellRoute(
+          builder: (context, state, child) => Scaffold(body: child),
           routes: [
             GoRoute(
-              path: 'login',
+              path: '/',
+              redirect: redirectLoggedInToHome,
               builder: (context, state) => const Text('login'),
             ),
             GoRoute(
-              path: 'switcher',
-              builder: (context, state) => const Text('switcher'),
+              path: '/login',
+              redirect: redirectLoggedInToHome,
+              builder: (context, state) => const Text('login'),
             ),
             GoRoute(
-              path: 'register',
+              path: '/register',
+              redirect: redirectLoggedInToHome,
               builder: (context, state) => const Text('register'),
             ),
             GoRoute(
-              path: 'spaces',
+              path: '/switcher',
+              builder: (context, state) => const Text('switcher'),
+            ),
+            GoRoute(
+              path: '/spaces',
               builder: (context, state) => const Text('spaces'),
             ),
             GoRoute(
-              path: 'settings',
+              path: '/settings',
               builder: (context, state) => const Text('settings'),
             ),
             GoRoute(
-              path: 'admin',
+              path: '/admin',
               builder: (context, state) => const Text('admin'),
             ),
           ],
@@ -107,5 +120,55 @@ void main() {
       expect(find.text('login'), findsOneWidget);
       expect(find.text('spaces'), findsNothing);
     });
+  });
+
+  group('signed-in destinations', () {
+    testWidgets('home does not stack on the sign-in screen', (tester) async {
+      final router = await _pumpAt(tester, '/spaces', auth: _loggedIn());
+
+      expect(find.text('spaces'), findsOneWidget);
+      // The sign-in screen used to sit underneath as `/spaces`' parent route,
+      // which is what let a system back swipe pop the user down to it (#125).
+      expect(find.text('login'), findsNothing);
+      expect(router.canPop(), isFalse);
+    });
+
+    // The rail's gear button is the only `push` in the app: this is the exact
+    // sequence the bug report describes ("clicking settings does nothing other
+    // than seemingly refresh the app").
+    testWidgets('pushing /settings from home opens it and pops back', (
+      tester,
+    ) async {
+      final router = await _pumpAt(tester, '/spaces', auth: _loggedIn());
+
+      router.push('/settings');
+      await tester.pumpAndSettle();
+
+      expect(find.text('settings'), findsOneWidget);
+      expect(find.text('login'), findsNothing);
+      expect(router.canPop(), isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('spaces'), findsOneWidget);
+      expect(find.text('settings'), findsNothing);
+    });
+
+    for (final path in ['/switcher', '/admin']) {
+      testWidgets('pushing $path from home pops back to it', (tester) async {
+        final router = await _pumpAt(tester, '/spaces', auth: _loggedIn());
+
+        router.push(path);
+        await tester.pumpAndSettle();
+
+        expect(find.text(path.substring(1)), findsOneWidget);
+
+        router.pop();
+        await tester.pumpAndSettle();
+
+        expect(find.text('spaces'), findsOneWidget);
+      });
+    }
   });
 }


### PR DESCRIPTION
## The report

> When I click the "settings" button in the bottom left of the app it does nothing other than seemingly refresh the app. It is doing this to me on two different computers.
> — `#bug-reports`, 2026-07-28

## What's going on

That symptom is #179: the logged-in redirect lived on `/`, and `/spaces`, `/settings`, `/admin`, `/switcher` were all **children** of `/`, so a parent-route redirect saw `state.matchedLocation` pinned to `/` and bounced every one of them home. Settings twitched open and closed — which reads exactly like "refreshed the app".

The guard fix landed in #179 on **2026-07-09 22:12 UTC**. `v0.2.6` was cut **2026-07-09 11:21 UTC** — about eleven hours earlier. So the reporter is on the newest release and it does not contain the fix. **Cutting a release ships the user-visible fix on its own**; this PR removes the thing that made the bug possible so it can't come back a third time (it was introduced by #177 and had already survived one round of review).

## What this changes

- **`/spaces`, `/settings`, `/admin`, `/switcher` are now siblings of `/`, `/login`, `/register`**, not children. Each sign-in route carries `redirectLoggedInToHome` itself, so a signed-in destination can never inherit it. The guard on `state.uri.path` stays as belt-and-braces if the routes are ever nested again.
- **The sign-in screen is no longer mounted in the navigator stack underneath the whole app.** That nesting is also what made Android's back swipe on home pop down to sign-in (#125) and what let `AccordLoginScreen`'s auth listener call `go('/spaces')` from under a screen the user was actually looking at.
- **Screens opened from home use `push` consistently** — Settings already did; Switch account and Server administration now match. `/spaces` stays beneath them, so system back and the app bar's arrow (`canPop() ? pop() : go('/spaces')`) return to home instead of unwinding to the sign-in route. `go` is left for the cases that genuinely replace the stack: signing in, signing out, returning home.
- **The switcher's Back button pops when it can**, falling back to `/spaces` for a cold deep link — same shape as Settings and Admin. Previously it always jumped to `/spaces`, which was wrong when it was opened from the signed-out sign-in screen.

## Tests

`test/router/controller_test.dart` mirrors the new route shape and keeps all of #179's redirect cases. Added coverage for the path the bug report actually walks, which #179's test never touched — it only exercised `go`, and the gear button is the one `push` in the app:

- `push('/settings')` from `/spaces` opens Settings, then pops back to home.
- Same for `/switcher` and `/admin`.
- At `/spaces`, the sign-in screen is not in the tree and `canPop()` is `false` — this fails on the old nesting and is the direct regression test for #125.

## Verification

`flutter analyze` / `flutter test` were not run locally — no Flutter SDK in this environment — so CI is the gate on this one.

## Not fixed here

"Add account" in the switcher does `go('/login')`, which the logged-in redirect bounces to `/spaces`, so it does nothing while signed in. Pre-existing, same family of bug, but it needs an intentional "let me reach sign-in while signed in" signal rather than a routing tweak. Worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mHj4GybdoXLJNizb2g7vu)_