### PR TITLE
fix(messaging): surface attachment failures instead of failing silently

### DIFF
--- a/docs/messaging/file-sharing.md
+++ b/docs/messaging/file-sharing.md
@@ -11,9 +11,11 @@ You can share files and images directly in any text channel or DM.
 
 ## Uploading Files
 
-Attach a file to your message using the attachment button in the composer. You can also **drag and drop** files into the message area.
+Attach a file to your message using the attachment button in the composer. Drag and drop is not supported yet.
 
-The maximum file size is **25 MB**. Files larger than this will show an error and will not be uploaded.
+The maximum file size is **25 MB** per file. Larger files are rejected as soon as you pick them, with the file's size shown next to the limit -- nothing is uploaded. Music and video files are the ones that most often run into this; a 320 kbps MP3 passes 25 MB at around ten minutes.
+
+If the server refuses an upload for another reason -- you don't have the **Attach Files** permission in that channel, for example -- the reason it gives is shown above the composer.
 
 ## Pasting Images
 

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -2,6 +2,7 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:bonfire/features/error_reporting/controllers/error_reporting.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -242,14 +243,23 @@ class AccordMessagesController extends _$AccordMessagesController {
   /// Sends [content] plus file [files] to this channel via
   /// `messages.createWithAttachments`. Each file is a map with `filename`,
   /// `content` (bytes) and optional `content_type`. Falls back to a plain
-  /// [send] when there are no files. Returns true on success.
-  Future<bool> sendWithAttachments(
+  /// [send] when there are no files.
+  ///
+  /// Returns null on success, or the failure message to show the user. The
+  /// server's own reason is passed through — a rejected upload (too large, no
+  /// `attach_files` permission, unsupported type) is otherwise indistinguishable
+  /// from a dead Send button.
+  Future<String?> sendWithAttachments(
     AccordClient client,
     String content,
     List<Map<String, dynamic>> files, {
     String? replyTo,
   }) async {
-    if (files.isEmpty) return send(client, content, replyTo: replyTo);
+    if (files.isEmpty) {
+      return await send(client, content, replyTo: replyTo)
+          ? null
+          : 'Failed to send message.';
+    }
     final data = <String, dynamic>{'content': content.trim()};
     if (replyTo != null) data['reply_to'] = replyTo;
 
@@ -260,14 +270,14 @@ class AccordMessagesController extends _$AccordMessagesController {
     );
     if (!result.ok) {
       debugPrint('Failed to send attachments to $channelId: ${result.error}');
-      return false;
+      return result.errorMessageOr('Failed to send attachments.');
     }
     final message = result.data;
     if (message is AccordMessage) addMessage(message);
     // Action breadcrumb for opt-in error reporting — the fact a message was
     // sent, never its content.
     ref.read(errorReportingControllerProvider.notifier).messageSent();
-    return true;
+    return null;
   }
 
   /// Appends a newly-received message, ignoring duplicates (e.g. the gateway

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -134,22 +134,32 @@ class AccordMessagesController extends _$AccordMessagesController {
     AccordClient client,
     String content, {
     String? replyTo,
+  }) async => await _createMessage(client, content, replyTo: replyTo) == null;
+
+  /// Sends [content] via `messages.create`. Returns null on success, or the
+  /// server's own failure message — shared by [send] and the no-attachments
+  /// path of [sendWithAttachments] so both surface the same reason instead of
+  /// [send]'s bool swallowing it.
+  Future<String?> _createMessage(
+    AccordClient client,
+    String content, {
+    String? replyTo,
   }) async {
     final trimmed = content.trim();
-    if (trimmed.isEmpty) return false;
+    if (trimmed.isEmpty) return 'Message is empty.';
     final data = <String, dynamic>{'content': trimmed};
     if (replyTo != null) data['reply_to'] = replyTo;
     final result = await client.messages.create(channelId, data);
     if (!result.ok) {
       debugPrint('Failed to send message to $channelId: ${result.error}');
-      return false;
+      return result.errorMessageOr('Failed to send message.');
     }
     final message = result.data;
     if (message is AccordMessage) addMessage(message);
     // Action breadcrumb for opt-in error reporting — the fact a message was
     // sent, never its content.
     ref.read(errorReportingControllerProvider.notifier).messageSent();
-    return true;
+    return null;
   }
 
   /// Pins [messageId] in this channel, optimistically flipping its `pinned`
@@ -242,8 +252,8 @@ class AccordMessagesController extends _$AccordMessagesController {
 
   /// Sends [content] plus file [files] to this channel via
   /// `messages.createWithAttachments`. Each file is a map with `filename`,
-  /// `content` (bytes) and optional `content_type`. Falls back to a plain
-  /// [send] when there are no files.
+  /// `content` (bytes) and optional `content_type`. Falls back to
+  /// `messages.create` (the same call [send] makes) when there are no files.
   ///
   /// Returns null on success, or the failure message to show the user. The
   /// server's own reason is passed through — a rejected upload (too large, no
@@ -256,9 +266,7 @@ class AccordMessagesController extends _$AccordMessagesController {
     String? replyTo,
   }) async {
     if (files.isEmpty) {
-      return await send(client, content, replyTo: replyTo)
-          ? null
-          : 'Failed to send message.';
+      return _createMessage(client, content, replyTo: replyTo);
     }
     final data = <String, dynamic>{'content': content.trim()};
     if (replyTo != null) data['reply_to'] = replyTo;

--- a/lib/features/messaging/utils/attachment_limits.dart
+++ b/lib/features/messaging/utils/attachment_limits.dart
@@ -1,0 +1,71 @@
+import 'package:file_picker/file_picker.dart';
+
+/// Maximum size of a single attachment, mirroring the limit documented in
+/// `docs/messaging/file-sharing.md`.
+///
+/// Enforced client-side so an oversize file is rejected at pick time with a
+/// clear message, rather than being read into memory, assembled into a
+/// multipart body and uploaded in full only to come back as an opaque server
+/// error.
+const int kMaxAttachmentBytes = 25 * 1024 * 1024;
+
+/// Renders a byte count for user-facing messages ("41.2 MB", "812 KB").
+String formatFileSize(int bytes) {
+  const kb = 1024;
+  const mb = kb * 1024;
+  if (bytes >= mb) {
+    final value = bytes / mb;
+    return '${value.toStringAsFixed(value >= 10 ? 0 : 1)} MB';
+  }
+  if (bytes >= kb) return '${(bytes / kb).round()} KB';
+  return '$bytes bytes';
+}
+
+/// The outcome of screening picked files: the ones that can be attached, plus a
+/// line per file that can't be, naming it and why.
+class AttachmentScreening {
+  const AttachmentScreening({required this.accepted, required this.rejections});
+
+  final List<PlatformFile> accepted;
+
+  /// One human-readable line per rejected file.
+  final List<String> rejections;
+
+  /// The rejections as a single message, or null when nothing was rejected.
+  String? get error => rejections.isEmpty ? null : rejections.join('\n');
+}
+
+/// Screens [files] for attachability.
+///
+/// Two things disqualify a file, and both used to be dropped silently — the
+/// composer kept any file with bytes and said nothing about the rest:
+///
+/// - the picker returned no bytes (a cloud- or provider-backed file the
+///   platform couldn't read into memory);
+/// - the file exceeds [maxBytes], which music and video routinely do where the
+///   images this flow was built around never did.
+AttachmentScreening screenAttachments(
+  Iterable<PlatformFile> files, {
+  int maxBytes = kMaxAttachmentBytes,
+}) {
+  final accepted = <PlatformFile>[];
+  final rejections = <String>[];
+  for (final file in files) {
+    final bytes = file.bytes;
+    if (bytes == null) {
+      rejections.add(
+        "${file.name} couldn't be read. Copy it to local storage and try again.",
+      );
+      continue;
+    }
+    if (bytes.length > maxBytes) {
+      rejections.add(
+        '${file.name} is ${formatFileSize(bytes.length)} — the limit is '
+        '${formatFileSize(maxBytes)}.',
+      );
+      continue;
+    }
+    accepted.add(file);
+  }
+  return AttachmentScreening(accepted: accepted, rejections: rejections);
+}

--- a/lib/features/messaging/views/message_pane/composer.dart
+++ b/lib/features/messaging/views/message_pane/composer.dart
@@ -338,27 +338,20 @@ class _ComposerState extends ConsumerState<_Composer> {
       accordMessagesControllerProvider(widget.channelId).notifier,
     );
     final replyTo = widget.replyingTo?.id;
-    final String? error;
-    if (_attachments.isEmpty) {
-      error = await controller.send(client, text, replyTo: replyTo)
-          ? null
-          : 'Failed to send message.';
-    } else {
-      final files = [
-        for (final file in _attachments)
-          {
-            'filename': file.name,
-            'content': file.bytes!,
-            'content_type': _mimeType(file.extension),
-          },
-      ];
-      error = await controller.sendWithAttachments(
-        client,
-        text,
-        files,
-        replyTo: replyTo,
-      );
-    }
+    final files = [
+      for (final file in _attachments)
+        {
+          'filename': file.name,
+          'content': file.bytes!,
+          'content_type': _mimeType(file.extension),
+        },
+    ];
+    final error = await controller.sendWithAttachments(
+      client,
+      text,
+      files,
+      replyTo: replyTo,
+    );
     if (!mounted) return;
     final ok = error == null;
     setState(() {

--- a/lib/features/messaging/views/message_pane/composer.dart
+++ b/lib/features/messaging/views/message_pane/composer.dart
@@ -29,6 +29,10 @@ class _ComposerState extends ConsumerState<_Composer> {
   /// Files the user has attached but not yet sent.
   final List<PlatformFile> _attachments = [];
 
+  /// Why the last attach or send didn't work, shown above the composer.
+  /// Cleared when the user attaches again or retries the send.
+  String? _error;
+
   /// The server's typing indicator lasts ~10s, so we re-trigger at most once
   /// every 8s while the user keeps typing rather than on every keystroke.
   DateTime? _lastTypingSent;
@@ -87,15 +91,13 @@ class _ComposerState extends ConsumerState<_Composer> {
     if (!mounted) return;
     if (image != null && image.isNotEmpty) {
       final bytes = image;
-      setState(
-        () => _attachments.add(
-          PlatformFile(
-            name: 'pasted-${DateTime.now().millisecondsSinceEpoch}.png',
-            size: bytes.length,
-            bytes: bytes,
-          ),
+      _addFiles([
+        PlatformFile(
+          name: 'pasted-${DateTime.now().millisecondsSinceEpoch}.png',
+          size: bytes.length,
+          bytes: bytes,
         ),
-      );
+      ]);
       return;
     }
 
@@ -112,11 +114,9 @@ class _ComposerState extends ConsumerState<_Composer> {
       if (!mounted || asFile == null) return;
       if (asFile) {
         final bytes = Uint8List.fromList(utf8.encode(text));
-        setState(
-          () => _attachments.add(
-            PlatformFile(name: 'message.txt', size: bytes.length, bytes: bytes),
-          ),
-        );
+        _addFiles([
+          PlatformFile(name: 'message.txt', size: bytes.length, bytes: bytes),
+        ]);
         return;
       }
     }
@@ -279,10 +279,17 @@ class _ComposerState extends ConsumerState<_Composer> {
       withData: true,
     );
     if (result == null || !mounted) return;
+    _addFiles(result.files);
+  }
+
+  /// Attaches every file in [files] that passes screening, and reports the ones
+  /// that don't. Unreadable and oversize files used to be dropped in silence,
+  /// which is indistinguishable from the attach button doing nothing.
+  void _addFiles(Iterable<PlatformFile> files) {
+    final screened = screenAttachments(files);
     setState(() {
-      for (final file in result.files) {
-        if (file.bytes != null) _attachments.add(file);
-      }
+      _attachments.addAll(screened.accepted);
+      _error = screened.error;
     });
   }
 
@@ -323,14 +330,19 @@ class _ComposerState extends ConsumerState<_Composer> {
     );
     if (client == null) return;
 
-    setState(() => _sending = true);
+    setState(() {
+      _sending = true;
+      _error = null;
+    });
     final controller = ref.read(
       accordMessagesControllerProvider(widget.channelId).notifier,
     );
     final replyTo = widget.replyingTo?.id;
-    final bool ok;
+    final String? error;
     if (_attachments.isEmpty) {
-      ok = await controller.send(client, text, replyTo: replyTo);
+      error = await controller.send(client, text, replyTo: replyTo)
+          ? null
+          : 'Failed to send message.';
     } else {
       final files = [
         for (final file in _attachments)
@@ -340,7 +352,7 @@ class _ComposerState extends ConsumerState<_Composer> {
             'content_type': _mimeType(file.extension),
           },
       ];
-      ok = await controller.sendWithAttachments(
+      error = await controller.sendWithAttachments(
         client,
         text,
         files,
@@ -348,8 +360,10 @@ class _ComposerState extends ConsumerState<_Composer> {
       );
     }
     if (!mounted) return;
+    final ok = error == null;
     setState(() {
       _sending = false;
+      _error = error;
       if (ok) _attachments.clear();
     });
     if (ok) {
@@ -400,6 +414,22 @@ class _ComposerState extends ConsumerState<_Composer> {
                       tooltip: 'Cancel reply',
                       visualDensity: VisualDensity.compact,
                       onPressed: widget.onCancelReply,
+                      icon: Icon(Icons.close, size: 14, color: colors.gray),
+                    ),
+                  ],
+                ),
+              ),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 8, 4, 0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(child: InlineError(_error!, centered: false)),
+                    IconButton(
+                      tooltip: 'Dismiss',
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () => setState(() => _error = null),
                       icon: Icon(Icons.close, size: 14, color: colors.gray),
                     ),
                   ],

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -19,6 +19,7 @@ import 'package:bonfire/features/member/views/accord_member_popout.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
 import 'package:bonfire/features/messaging/controllers/typing.dart';
+import 'package:bonfire/features/messaging/utils/attachment_limits.dart';
 import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:bonfire/features/messaging/views/box/accord_embed_box.dart';
 import 'package:bonfire/features/messaging/views/box/accord_message_content.dart';

--- a/lib/shared/utils/rest_result_ext.dart
+++ b/lib/shared/utils/rest_result_ext.dart
@@ -9,6 +9,15 @@ import 'package:flutter/material.dart';
 extension RestResultErrorText on RestResult {
   /// The error rendered as text, or [fallback] when there is none.
   String errorOr(String fallback) => error?.toString() ?? fallback;
+
+  /// The server's own explanation, for surfaces shown to end users rather than
+  /// to operators. [errorOr] renders `AccordError.toString()`, which carries the
+  /// `AccordError(code: …)` wrapper — fine in an admin screen, noise in the
+  /// message composer. Falls back to [fallback] when the error has no message.
+  String errorMessageOr(String fallback) {
+    final message = error?.message ?? '';
+    return message.isEmpty ? fallback : message;
+  }
 }
 
 /// Payload-parsing helpers for the self-loading cache controllers.

--- a/test/features/messaging/accord_messages_send_test.dart
+++ b/test/features/messaging/accord_messages_send_test.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A logged-out container so `build()` skips its auto `_load` REST call —
+/// these tests drive `send`/`sendWithAttachments` directly with a client of
+/// their own, the same way the composer and other callers do.
+///
+/// On success, `send`/`sendWithAttachments` post a breadcrumb through
+/// `errorReportingControllerProvider`, which watches `settingsControllerProvider`,
+/// which reads the `accord-settings` Hive box — so the suite's `setUp` opens a
+/// real (temp-dir-backed) one, same as `error_reporting_test.dart`. Reporting
+/// itself stays off (no consent given), so the breadcrumb call is a no-op.
+ProviderContainer _makeContainer() {
+  final container = ProviderContainer(
+    overrides: [
+      accordAuthProvider.overrideWithValue(const AccordAuthLoggedOut()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+AccordClient _clientWith(
+  Future<http.Response> Function(http.Request request) responder,
+) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final client = AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient(responder),
+  );
+  addTearDown(client.dispose);
+  return client;
+}
+
+http.Response _errorResponse(int status, String code, String message) =>
+    http.Response(
+      jsonEncode({
+        'error': {'code': code, 'message': message},
+      }),
+      status,
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync('accord-messages-send-test');
+    Hive.init(tempDir.path);
+    await Hive.openBox('accord-settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('accord-settings');
+    await Hive.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('send', () {
+    test('returns true on success', () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => http.Response(
+          jsonEncode({'id': 'm1', 'channel_id': 'ch1', 'content': 'hi'}),
+          200,
+        ),
+      );
+
+      expect(await n.send(client, 'hi'), isTrue);
+    });
+
+    test('returns false on a server failure', () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => _errorResponse(403, 'FORBIDDEN', 'Missing permission'),
+      );
+
+      expect(await n.send(client, 'hi'), isFalse);
+    });
+  });
+
+  group('sendWithAttachments — no files', () {
+    // sendWithAttachments falls back to the same messages.create call `send`
+    // makes, but needs the server's own failure reason rather than `send`'s
+    // bare bool — that's what the composer shows above the message box.
+    test('surfaces the server error message on failure, not a generic one',
+        () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => _errorResponse(
+          403,
+          'FORBIDDEN',
+          'Missing Attach Files permission',
+        ),
+      );
+
+      final error = await n.sendWithAttachments(client, 'hi', const []);
+
+      expect(error, 'Missing Attach Files permission');
+    });
+
+    test('returns null on success', () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => http.Response(
+          jsonEncode({'id': 'm1', 'channel_id': 'ch1', 'content': 'hi'}),
+          200,
+        ),
+      );
+
+      expect(await n.sendWithAttachments(client, 'hi', const []), isNull);
+    });
+  });
+
+  group('sendWithAttachments — with files', () {
+    test('surfaces the server error message on failure', () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => _errorResponse(413, 'FILE_TOO_LARGE', 'File too large'),
+      );
+
+      final error = await n.sendWithAttachments(client, 'hi', [
+        {'filename': 'song.mp3', 'content': <int>[1, 2, 3]},
+      ]);
+
+      expect(error, 'File too large');
+    });
+
+    test('falls back to a generic message when the server sends none',
+        () async {
+      final n = _makeContainer().read(
+        accordMessagesControllerProvider('ch1').notifier,
+      );
+      final client = _clientWith(
+        (_) async => http.Response(
+          jsonEncode({
+            'error': {'code': 'INTERNAL'},
+          }),
+          500,
+        ),
+      );
+
+      final error = await n.sendWithAttachments(client, 'hi', [
+        {'filename': 'song.mp3', 'content': <int>[1, 2, 3]},
+      ]);
+
+      expect(error, 'Failed to send attachments.');
+    });
+  });
+}

--- a/test/features/messaging/attachment_limits_test.dart
+++ b/test/features/messaging/attachment_limits_test.dart
@@ -1,0 +1,66 @@
+import 'dart:typed_data';
+
+import 'package:bonfire/features/messaging/utils/attachment_limits.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+PlatformFile _file(String name, {int? bytes}) => PlatformFile(
+  name: name,
+  size: bytes ?? 0,
+  bytes: bytes == null ? null : Uint8List(bytes),
+);
+
+void main() {
+  group('formatFileSize', () {
+    test('scales to KB and MB', () {
+      expect(formatFileSize(512), '512 bytes');
+      expect(formatFileSize(2048), '2 KB');
+      expect(formatFileSize(3 * 1024 * 1024), '3.0 MB');
+    });
+
+    test('drops the decimal at 10 MB and above', () {
+      expect(formatFileSize(41 * 1024 * 1024), '41 MB');
+    });
+  });
+
+  group('screenAttachments', () {
+    test('accepts a file within the limit', () {
+      final result = screenAttachments([_file('song.mp3', bytes: 4 * 1024)]);
+      expect(result.accepted.single.name, 'song.mp3');
+      expect(result.error, isNull);
+    });
+
+    test('rejects a file over the limit, naming it and both sizes', () {
+      final result = screenAttachments(
+        [_file('album.mp3', bytes: 2048)],
+        maxBytes: 1024,
+      );
+      expect(result.accepted, isEmpty);
+      expect(result.error, contains('album.mp3'));
+      expect(result.error, contains('2 KB'));
+      expect(result.error, contains('1 KB'));
+    });
+
+    test('rejects a file the picker could not read', () {
+      final result = screenAttachments([_file('remote.mp3')]);
+      expect(result.accepted, isEmpty);
+      expect(result.error, contains('remote.mp3'));
+      expect(result.error, contains("couldn't be read"));
+    });
+
+    test('keeps the good files and reports only the bad ones', () {
+      final result = screenAttachments([
+        _file('ok.mp3', bytes: 512),
+        _file('huge.mp3', bytes: 4096),
+        _file('unreadable.mp3'),
+      ], maxBytes: 1024);
+      expect(result.accepted.map((f) => f.name), ['ok.mp3']);
+      expect(result.rejections, hasLength(2));
+    });
+
+    test('the documented limit is 25 MB', () {
+      expect(kMaxAttachmentBytes, 25 * 1024 * 1024);
+      expect(formatFileSize(kMaxAttachmentBytes), '25 MB');
+    });
+  });
+}

--- a/test/shared/rest_result_ext_test.dart
+++ b/test/shared/rest_result_ext_test.dart
@@ -35,6 +35,34 @@ void main() {
     });
   });
 
+  group('RestResult.errorMessageOr', () {
+    test('returns the bare message, without the AccordError wrapper', () {
+      final result = RestResult(
+        ok: false,
+        statusCode: 413,
+        error: AccordError(
+          code: 'FILE_TOO_LARGE',
+          message: 'File exceeds 25 MB',
+        ),
+      );
+      expect(result.errorMessageOr('default'), 'File exceeds 25 MB');
+      expect(result.errorMessageOr('default'), isNot(contains('AccordError')));
+    });
+
+    test('returns fallback when the error carries no message', () {
+      final result = RestResult(
+        ok: false,
+        statusCode: 500,
+        error: AccordError(code: 'INTERNAL'),
+      );
+      expect(result.errorMessageOr('default'), 'default');
+    });
+
+    test('returns fallback when error is null', () {
+      expect(_ok().errorMessageOr('default'), 'default');
+    });
+  });
+
   group('showErrorSnack', () {
     testWidgets('shows snack bar with prefix and error', (tester) async {
       final err = AccordError(message: 'server error');


### PR DESCRIPTION
## Summary

Attaching a file that gets rejected (too large, unreadable, no `attach_files` permission, server error) used to fail with no visible feedback — the Send button just looked dead. Every silent path is now visible:

- Files are screened at pick time against the documented 25 MB limit (`lib/features/messaging/utils/attachment_limits.dart`), naming the file and both sizes on rejection instead of silently dropping it.
- `sendWithAttachments` now returns the server's own failure reason (`String?`) instead of a bare `bool`, via a new `RestResult.errorMessageOr` extension that renders the bare server message rather than the `AccordError(code: …)` wrapper.
- The composer shows send/attach failures in a dismissible inline error above the message box.
- Docs (`docs/messaging/file-sharing.md`) updated to drop the drag-and-drop claim (unimplemented) and document the new behavior.

### Follow-up from self-review

Reviewing the initial change surfaced the same silent-failure gap one level up: the no-attachments path of `sendWithAttachments` wrapped `send()`'s bare `bool` in a hardcoded `'Failed to send message.'`, discarding the real server reason — the exact problem this PR exists to fix, just for plain-text sends. Extracted a shared `_createMessage` helper so `send()` and `sendWithAttachments`'s no-files branch both surface the same server-provided reason, removed the duplicated ternary in `composer.dart`, and added controller-level test coverage (`test/features/messaging/accord_messages_send_test.dart`) that didn't exist before for `send`/`sendWithAttachments`.

## Test plan

- [x] `test/features/messaging/attachment_limits_test.dart` — file screening (size limit, unreadable files, size formatting)
- [x] `test/shared/rest_result_ext_test.dart` — `errorMessageOr`
- [x] `test/features/messaging/accord_messages_send_test.dart` (new) — `send`/`sendWithAttachments` success/failure, and specifically that the no-files path surfaces the server's message rather than a generic fallback
- [ ] `flutter analyze` / `flutter test` — **could not be run**: no Dart/Flutter SDK is installed in this sandbox. Changes were reviewed manually line-by-line against the surrounding code and existing test patterns (`accord_members_load_test.dart`, `error_reporting_test.dart`) instead.
- [ ] Manual UI verification (attach an oversize file, attach an unreadable file, trigger a server-side rejection) — not performed, no running app/device in this environment.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KejDtFqkZEdSUJz5H3diNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01G69JTFuHoebbfVpR7GVFTx)_