### PR TITLE
fix(updates): ship the Linux bundle as .tgz to unstrand <=0.2.6 .deb installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,9 +278,17 @@ jobs:
 
       - name: Package (Linux)
         if: matrix.platform == 'linux'
+        # `.tgz`, NOT `.tar.gz` — this suffix is load-bearing. Clients at v0.2.6
+        # and earlier pick a `.tar.gz` asset unconditionally on Linux and try to
+        # swap it into a `.deb` install's root-owned /opt, which silently fails
+        # and relaunches the old build; those clients are frozen, so withholding
+        # the suffix is the only way to break them out of the loop. With no
+        # `.tar.gz` present they fall back to offering the `.deb` as a manual
+        # download. See update_controller._installableExts and the guard in the
+        # release job below.
         run: |
           cd build/linux/x64/release/bundle
-          tar czf "$GITHUB_WORKSPACE/${{ matrix.artifact }}.tar.gz" .
+          tar czf "$GITHUB_WORKSPACE/${{ matrix.artifact }}.tgz" .
 
       - name: Build .deb (Linux)
         if: matrix.platform == 'linux'
@@ -359,7 +367,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: |
             ${{ matrix.artifact }}.zip
-            ${{ matrix.artifact }}.tar.gz
+            ${{ matrix.artifact }}.tgz
             ${{ matrix.artifact }}.apk
             ${{ matrix.artifact }}.deb
             daccord-windows-x86_64-setup.exe
@@ -378,6 +386,21 @@ jobs:
           pattern: daccord-*
           merge-multiple: true
 
+      - name: Guard against a .tar.gz asset
+        # Publishing any asset whose name ends in `.tar.gz` re-arms the broken
+        # self-updater in clients ≤ v0.2.6: on Linux they select it regardless of
+        # whether the install root is writable, so a `.deb` install downloads it,
+        # runs a swap against root-owned /opt that can't succeed, and relaunches
+        # the old build with no error shown. The Linux bundle ships as `.tgz` so
+        # those clients find nothing installable and offer the `.deb` instead.
+        run: |
+          cd artifacts
+          if ls | grep -q '\.tar\.gz$'; then
+            echo "::error::Refusing to publish a .tar.gz asset — it silently breaks self-update on clients <= v0.2.6. Ship the Linux bundle as .tgz."
+            ls
+            exit 1
+          fi
+
       - name: Generate checksums
         # SHA256SUMS.txt lets the in-app self-updater verify a downloaded bundle
         # before swapping it in (see update_controller._expectedSha), and gives
@@ -391,6 +414,16 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
+          # Prepended to the auto-generated notes. The in-app Updates page renders
+          # this body (AppRelease.notes), so it's the one channel that reaches
+          # users stranded on a build whose self-updater can't apply anything.
+          # Drop this notice once ≤ v0.2.6 installs have aged out.
+          body: |
+            > **Linux `.deb` users on v0.2.6 or earlier:** update once by hand —
+            > download `daccord-linux-x86_64.deb` below and install it
+            > (`sudo dpkg -i daccord-linux-x86_64.deb`). Self-update could not
+            > replace a system install in those builds and failed silently; from
+            > v0.2.7 onward it updates the package for you (with an admin prompt).
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -40,10 +40,18 @@ updater in a "bridge" Godot release. We skip all of that and announce manually.
 |----------|-------|------------------|
 | Windows  | `daccord-windows-x86_64.zip`, `daccord-windows-x86_64-setup.exe` | in-place binary swap (#87) |
 | macOS    | `daccord-macos-universal.dmg` | replace `.app`, strip quarantine (#87) |
-| Linux    | `daccord-linux-x86_64.tar.gz`, `daccord-linux-x86_64.deb` | replace bundle tree (#87) |
+| Linux    | `daccord-linux-x86_64.tgz`, `daccord-linux-x86_64.deb` | replace bundle tree (#87), or `pkexec dpkg -i` for a system install (#178) |
 | Android  | `daccord-android.apk` | system installer (#88) |
 | Web      | `daccord-web.zip` | service-worker reload (#91) |
 | All      | `SHA256SUMS.txt` | integrity check before swap (#87) |
+
+The Linux portable bundle ships as `.tgz` and releases must **never** publish an
+asset ending in `.tar.gz` (the release workflow fails if one appears). Clients at
+v0.2.6 and earlier select a `.tar.gz` on Linux without checking that the install
+root is writable, so a `.deb` install downloads it, attempts a swap into
+root-owned `/opt` that cannot succeed, and relaunches the old build with nothing
+shown to the user. Those clients can't be fixed in code — withholding the suffix
+they key on is what routes them to the `.deb` download instead.
 
 Code signing / notarization (#90) and an iOS distribution path (#89) are tracked
 separately and are **not** part of this cutover.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,19 +17,28 @@ Choose the right file for your platform:
 
 | Platform | File |
 |----------|------|
-| Linux (x86_64) | `daccord-linux-x86_64.zip` |
-| Linux (ARM64) | `daccord-linux-arm64.zip` |
+| Linux (x86_64, recommended) | `daccord-linux-x86_64.deb` |
+| Linux (x86_64, portable) | `daccord-linux-x86_64.tgz` |
 | Windows (installer) | `daccord-windows-x86_64-setup.exe` |
 | Windows (portable) | `daccord-windows-x86_64.zip` |
-| macOS | `daccord-macos.dmg` |
+| macOS | `daccord-macos-universal.dmg` |
 | Android | `daccord-android.apk` |
 | Web | `daccord-web.zip` |
 
 ## Linux
 
-1. Extract the downloaded archive.
+**Package (recommended):** download `daccord-linux-x86_64.deb` and install it with `sudo dpkg -i daccord-linux-x86_64.deb` (or open it in your software centre). This is the build that keeps working with the in-app updater.
+
+**Portable:**
+
+1. Extract `daccord-linux-x86_64.tgz`.
 2. Run the `daccord` executable.
 3. On some distributions you may need to mark it as executable first: right-click the file, open Properties, and enable "Allow executing file as program".
+
+> **Already on v0.2.6 or earlier?** Those builds could not replace a system
+> (`.deb`) install and failed silently, so the app never updated itself. Install
+> the `.deb` above by hand once; from v0.2.7 onward the in-app updater handles it
+> for you.
 
 ## Windows
 

--- a/lib/features/updates/controllers/update_controller.dart
+++ b/lib/features/updates/controllers/update_controller.dart
@@ -270,6 +270,18 @@ class UpdateController extends _$UpdateController {
   /// Windows uses the more-specific `windows-x86_64.zip` suffix before the
   /// generic `.zip` so the web build bundle (`daccord-web.zip`) is never
   /// mistakenly selected ahead of the actual Windows installer.
+  ///
+  /// The Linux portable bundle is matched as `.tgz`, and releases must **never**
+  /// publish an asset ending in `.tar.gz` again (the release workflow enforces
+  /// this). Clients at v0.2.6 and earlier picked `.tar.gz` unconditionally on
+  /// Linux, with no writable-root check — so a `.deb` install under root-owned
+  /// `/opt` silently downloaded the portable tarball and ran a swap that could
+  /// never succeed, then relaunched the old build. Those clients are frozen and
+  /// can't be fixed in code; withholding the suffix they key on is what breaks
+  /// them out of it. With no `.tar.gz` asset they find nothing installable, fall
+  /// back to their "Update available — tap to view" banner, and offer the `.deb`
+  /// as a manual download — a working recovery path instead of a silent no-op.
+  /// `.tar.gz` stays *accepted* here so an older release is still applicable.
   List<String> get _installableExts {
     if (UniversalPlatform.isAndroid) return const ['.apk'];
     if (UniversalPlatform.isWindows) {
@@ -281,7 +293,9 @@ class UpdateController extends _$UpdateController {
       return UpdateInstaller.isInstallRootWritable ? const ['.dmg'] : const [];
     }
     if (UniversalPlatform.isLinux) {
-      if (UpdateInstaller.isInstallRootWritable) return const ['.tar.gz'];
+      if (UpdateInstaller.isInstallRootWritable) {
+        return const ['.tgz', '.tar.gz'];
+      }
       // System install: update the package itself when we can elevate.
       return UpdateInstaller.hasPrivilegedInstaller ? const ['.deb'] : const [];
     }
@@ -304,8 +318,8 @@ class UpdateController extends _$UpdateController {
       // portable tarball they'd have to extract themselves. A writable install
       // prefers the tarball — it's also the in-place asset.
       return UpdateInstaller.isInstallRootWritable
-          ? const ['.tar.gz', '.deb', '.rpm', '.appimage']
-          : const ['.deb', '.rpm', '.appimage', '.tar.gz'];
+          ? const ['.tgz', '.tar.gz', '.deb', '.rpm', '.appimage']
+          : const ['.deb', '.rpm', '.appimage', '.tgz', '.tar.gz'];
     }
     return const [];
   }

--- a/test/features/updates/update_controller_test.dart
+++ b/test/features/updates/update_controller_test.dart
@@ -46,17 +46,21 @@ void setLatest(ProviderContainer c, List<AppReleaseAsset> assets) {
 AppReleaseAsset _asset(String name) =>
     AppReleaseAsset(name: name, url: 'https://example/download/$name');
 
-/// The full asset set the release workflow publishes (mirrors the real v0.2.4
-/// release). Crucially this lists BOTH a `.deb` and a `.tar.gz` for Linux, and
-/// because GitHub returns assets in upload/alphabetical order the unextractable
-/// `.deb` sorts *before* the `.tar.gz` — the exact trap behind the recurring
-/// "Unsupported archive: daccord-linux-x86_64.deb" failure (#99).
+/// The full asset set the release workflow publishes. Crucially this lists BOTH
+/// a `.deb` and a portable bundle for Linux, and because GitHub returns assets
+/// in upload/alphabetical order the unextractable `.deb` sorts *before* the
+/// bundle — the exact trap behind the recurring "Unsupported archive:
+/// daccord-linux-x86_64.deb" failure (#99).
+///
+/// The Linux bundle is `.tgz`: releases must never publish a `.tar.gz` again,
+/// because clients ≤ v0.2.6 select that suffix even on a `.deb` install they
+/// can't swap, and fail silently. See `_installableExts`.
 final _fullReleaseAssets = [
   _asset('SHA256SUMS.txt'),
   _asset('app-release.aab'),
   _asset('daccord-android.apk'),
   _asset('daccord-linux-x86_64.deb'),
-  _asset('daccord-linux-x86_64.tar.gz'),
+  _asset('daccord-linux-x86_64.tgz'),
   _asset('daccord-macos-universal.dmg'),
   _asset('daccord-web.zip'),
   _asset('daccord-windows-x86_64-setup.exe'),
@@ -71,7 +75,7 @@ String? get _hostInstallableExt {
   if (UniversalPlatform.isAndroid) return '.apk';
   if (UniversalPlatform.isWindows) return '.zip';
   if (UniversalPlatform.isMacOS) return '.dmg';
-  if (UniversalPlatform.isLinux) return '.tar.gz';
+  if (UniversalPlatform.isLinux) return '.tgz';
   return null;
 }
 
@@ -149,7 +153,7 @@ void main() {
       UpdateInstaller.debugHasPrivilegedInstaller = false;
       setLatest(c, [
         _asset('daccord-linux-x86_64.deb'),
-        _asset('daccord-linux-x86_64.tar.gz'),
+        _asset('daccord-linux-x86_64.tgz'),
       ]);
       expect(controllerOf(c).platformAssetUrl(), endsWith('.deb'));
     });
@@ -163,13 +167,40 @@ void main() {
       UpdateInstaller.debugHasPrivilegedInstaller = true;
       setLatest(c, [
         _asset('daccord-linux-x86_64.deb'),
-        _asset('daccord-linux-x86_64.tar.gz'),
+        _asset('daccord-linux-x86_64.tgz'),
       ]);
       expect(controllerOf(c).canInstallInPlace, isTrue);
       // The in-place asset is the package, not the tarball…
       expect(controllerOf(c).platformAsset()!.name, endsWith('.deb'));
       // …and the UI is told to warn about the admin prompt.
       expect(controllerOf(c).requiresPrivilegedInstall, isTrue);
+    });
+
+    test('writable Linux install applies the .tgz portable bundle', () {
+      // The release workflow ships the portable bundle as `.tgz` (never
+      // `.tar.gz`, which silently breaks clients <= v0.2.6 — see
+      // `_installableExts`), so a writable install root must still self-update.
+      if (!UniversalPlatform.isLinux) return;
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+      expect(controllerOf(c).canInstallInPlace, isTrue);
+      expect(controllerOf(c).platformAsset()!.name, endsWith('.tgz'));
+      // No polkit prompt for a user-writable swap.
+      expect(controllerOf(c).requiresPrivilegedInstall, isFalse);
+    });
+
+    test('legacy .tar.gz bundles stay applicable on a writable install', () {
+      // Withholding `.tar.gz` from *new* releases is a publishing rule, not a
+      // capability we dropped: an older release that still carries one must
+      // remain installable rather than silently offering nothing.
+      if (!UniversalPlatform.isLinux) return;
+      final c = makeContainer();
+      setLatest(c, [
+        _asset('daccord-linux-x86_64.deb'),
+        _asset('daccord-linux-x86_64.tar.gz'),
+      ]);
+      expect(controllerOf(c).canInstallInPlace, isTrue);
+      expect(controllerOf(c).platformAsset()!.name, endsWith('.tar.gz'));
     });
   });
 


### PR DESCRIPTION
## The problem

#178 fixed self-update for Linux system (`.deb`) installs — but it shipped **in v0.2.7**, the release that affected clients can't apply. Their selector is frozen at:

```dart
if (UniversalPlatform.isLinux) return const ['.tar.gz'];   // v0.2.6, no writable-root check
```

So a `.deb` install under root-owned `/opt` downloads the portable tarball, extracts it, and runs the swap helper — whose `mv "$dst" "$dst.old"` fails with EACCES, is swallowed by `2>/dev/null`, and then relaunches the *old* binary. The app restarts, the version never changes, and nothing is shown to the user.

Found on a real machine still on 0.2.6 hours after 0.2.7 shipped. The forensic trail: `daccord-linux-x86_64.tar.gz` downloaded 20:10:57, extracted to `staged/` 20:11:28, `apply.sh` self-deleted (so the helper ran to completion), no `.old` directory anywhere, `/opt/daccord` untouched since Jul 9, and no `pkexec`/`dpkg` activity in the polkit or dpkg logs. The helper logic itself is fine — replayed against a writable sandbox root it swaps correctly.

## Why this can't be fixed in the client

Those installs run frozen code. Any fix we merge reaches them only through a release they are structurally unable to install. The one input we still control is **what the release contains**.

## The fix

Ship the Linux bundle as `.tgz`. With no `.tar.gz` asset present, a v0.2.6 client:

| | before | after |
|---|---|---|
| `platformAsset()` | the `.tar.gz` | `null` |
| `canInstallInPlace` | `true` | `false` |
| `prepareUpdate()` | silently downloads a doomed swap | no-ops |
| banner | nothing (stays hidden until "ready") | **"Update available — tap to view"** |
| Updates page | — | **"Download"** → falls through `_downloadExts` to the **`.deb`** |

A silent no-op becomes a working manual-install prompt.

Supporting changes:
- **Release guard** — the release job fails if any asset ends in `.tar.gz`, since publishing one re-arms the bug. Verified it fires on a regressed asset set and stays silent on the new one.
- **Release body** — carries a manual-install notice for affected users. The in-app Updates page renders this (`AppRelease.notes`), so it reaches them inside the app, not just on GitHub.
- `.tar.gz` stays **accepted** by the selector so older releases remain applicable; only the *published* suffix changes.

## Scope

Windows and macOS need no equivalent: `installer.iss` is `PrivilegesRequired=lowest` so `{autopf}` resolves per-user and writable, and `/Applications` is admin-writable. Only root-owned `/opt` was affected. Disarming Windows wouldn't even work — with the windows zip removed, a v0.2.6 client's `.zip` fallback would select `daccord-web.zip`.

## Trade-off

v0.2.7 **portable** (writable-root) installs match `.tar.gz`, so they fall back to a manual download for one cycle; one-click returns for them at v0.2.8. The `.deb` population — the recommended install, and the broken one — keeps one-click via `pkexec` throughout. Reversible if you'd rather weight it the other way.

## Testing

- `flutter test` — 516 passed, including two new cases: `.tgz` is applied on a writable root, and legacy `.tar.gz` bundles stay installable.
- `flutter analyze --no-fatal-infos` — clean on the touched directories.
- Release guard exercised both ways.
- `pkexec dpkg -i` (the exact command the v0.2.7 path runs) verified end-to-end on a real 0.2.6 → 0.2.7 upgrade.

## Follow-ups (not in this PR)

1. **An apt repo** — `.deb` users would update through `apt` and never depend on the in-app updater, making this class of bug unreachable.
2. **Post-apply verification** — #178 gates on a *probe* predicting the swap will work, not a check that it did. Stamping the attempted version before quitting and comparing on next launch would make any future silent no-op report itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)