### PR TITLE
fix(channels): clear voice channels' unread badge and ack it to the server

### DIFF
--- a/lib/features/channels/utils/mark_channel_read.dart
+++ b/lib/features/channels/utils/mark_channel_read.dart
@@ -1,0 +1,41 @@
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Clears [channelId]'s unread badge locally *and* POSTs `channels.ack` so the
+/// server's read position catches up too.
+///
+/// Both halves matter: the local clear hides the dot now, the ack is what stops
+/// the READY payload's `unread` array from re-lighting it on the next connect.
+/// The acked position is the newest cached message, falling back to
+/// [fallbackMessageId] (the channel's `last_message_id`) when the message cache
+/// is empty — which is the common case for a channel whose messages were never
+/// opened (any voice channel joined without its chat panel) and for a *phantom*
+/// unread whose message has since been deleted.
+///
+/// [serverKey] pins the ack to a specific connection; it defaults to the active
+/// one. Pass it explicitly when the channel may live on a background server
+/// (e.g. a voice call pinned to a server the user has since navigated away
+/// from).
+void markChannelRead(
+  WidgetRef ref,
+  String channelId, {
+  String? serverKey,
+  String? fallbackMessageId,
+}) {
+  final key = serverKey ?? ref.read(connectionsControllerProvider).activeKey;
+  if (key == null) return;
+  ref.read(readStateControllerProvider(key).notifier).markRead(channelId);
+
+  final messages = ref.read(accordMessagesControllerProvider(channelId));
+  final lastId =
+      messages?.isNotEmpty == true ? messages!.last.id : fallbackMessageId;
+  if (lastId == null) return;
+  ref
+      .read(accordAuthProvider.notifier)
+      .clientForKey(key)
+      ?.channels
+      .ack(channelId, lastId);
+}

--- a/lib/features/channels/views/channel_context_menu.dart
+++ b/lib/features/channels/views/channel_context_menu.dart
@@ -3,7 +3,7 @@ import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/views/channel_management.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
-import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/shared/components/context_menu.dart';
 import 'package:flutter/material.dart';
@@ -66,16 +66,15 @@ Future<void> showChannelContextMenu(
           .read(readStateControllerProvider(activeKey))
           .isUnread(channel.id);
 
-  void markRead() {
-    if (activeKey != null) {
-      ref
-          .read(readStateControllerProvider(activeKey).notifier)
-          .markRead(channel.id);
-    }
-    final messages = ref.read(accordMessagesControllerProvider(channel.id));
-    final lastId = messages?.isNotEmpty == true ? messages!.last.id : null;
-    if (lastId != null) client?.channels.ack(channel.id, lastId);
-  }
+  // Falls back to the channel's `last_message_id` so acking a channel whose
+  // history was never opened (any voice channel, or one only ever seen as a
+  // badge) still moves the server's read position — otherwise the badge returns
+  // on the next connect.
+  void markRead() => markChannelRead(
+        ref,
+        channel.id,
+        fallbackMessageId: channel.lastMessageId,
+      );
 
   final entries = <AccordMenuEntry>[
     if (unread)

--- a/lib/features/messaging/views/box/accord_message_content.dart
+++ b/lib/features/messaging/views/box/accord_message_content.dart
@@ -2,7 +2,7 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/channels/controllers/open_tabs.dart';
-import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/channels/models/open_tab.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/views/accord_member_popout.dart';
@@ -138,7 +138,8 @@ class AccordMessageContent extends ConsumerWidget {
             name: channel?.name ?? channelId,
           ),
         );
-    ref.read(readStateControllerProvider(activeKey).notifier).markRead(channelId);
+    markChannelRead(ref, channelId,
+        fallbackMessageId: channel?.lastMessageId);
     ref.read(settingsControllerProvider.notifier).setLastSelection(
           spaceId,
           channelId,

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -12,6 +12,7 @@ import 'package:bonfire/features/channels/controllers/open_tabs.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/channels/models/open_tab.dart';
 import 'package:bonfire/features/channels/utils/channel_reorder.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/channels/utils/channel_sort.dart';
 import 'package:bonfire/features/developer/services/mcp_home_bridge.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
@@ -274,9 +275,11 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
             name: channel?.name ?? channelId,
           ),
         );
-    if (channel?.type != 'voice') {
-      _markChannelRead(channelId, fallbackMessageId: channel?.lastMessageId);
-    }
+    // Voice channels carry a text chat and so carry unread state like any other
+    // channel; opening one clears it exactly the same way (the ack matters most
+    // here — a voice channel's messages are rarely cached, so without the
+    // `last_message_id` fallback the badge would come back on every connect).
+    _markChannelRead(channelId, fallbackMessageId: channel?.lastMessageId);
     setState(() => _pendingOpenSpaceId = null);
     ref
         .read(settingsControllerProvider.notifier)
@@ -312,27 +315,11 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
     });
   }
 
-  /// Marks [channelId] read locally and POSTs `channels.ack` with the latest
-  /// known message ID so the server's read position catches up too. Prefers the
-  /// newest cached message; when the cache is empty it falls back to
-  /// [fallbackMessageId] (the channel's `last_message_id`). That fallback is
-  /// what clears a *phantom* unread: if the message that lit the channel was
-  /// since deleted, the cache loads empty but the server still lists the channel
-  /// in its READY `unread` array — without acking the channel's last_message_id
-  /// the badge would re-light on every cold start.
-  void _markChannelRead(String channelId, {String? fallbackMessageId}) {
-    final activeKey = ref.read(connectionsControllerProvider).activeKey;
-    if (activeKey != null) {
-      ref
-          .read(readStateControllerProvider(activeKey).notifier)
-          .markRead(channelId);
-    }
-    final messages = ref.read(accordMessagesControllerProvider(channelId));
-    final lastId =
-        messages?.isNotEmpty == true ? messages!.last.id : fallbackMessageId;
-    if (lastId == null) return;
-    ref.accordClient?.channels.ack(channelId, lastId);
-  }
+  /// Marks [channelId] read locally and POSTs `channels.ack` on the active
+  /// connection. See [markChannelRead] for why the ack (and its
+  /// [fallbackMessageId]) is what makes the badge stay gone.
+  void _markChannelRead(String channelId, {String? fallbackMessageId}) =>
+      markChannelRead(ref, channelId, fallbackMessageId: fallbackMessageId);
 
   /// Shows the rules interstitial once when a space with a rules channel is
   /// first opened this session.

--- a/lib/features/voice/views/voice_text_panel.dart
+++ b/lib/features/voice/views/voice_text_panel.dart
@@ -1,5 +1,6 @@
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/controllers/accord_channels.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/messaging/views/box/accord_message_content.dart';
@@ -11,6 +12,7 @@ import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/utils/participant_display.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/theme/theme.dart';
+import 'package:collection/collection.dart';
 import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -51,20 +53,32 @@ class _VoiceTextPanelState extends ConsumerState<VoiceTextPanel> {
   void initState() {
     super.initState();
     // Opening the panel clears the voice channel's unread state, mirroring the
-    // reference's `Client.clear_channel_unread`.
+    // reference's `Client.clear_channel_unread`. This acks to the server too —
+    // a local-only clear comes back on the next connect via READY's `unread`.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        // The panel's channel lives on whichever server the call is pinned to,
-        // which may not be the active one.
-        final serverKey = ref.read(voiceControllerProvider).serverKey ??
-            ref.read(connectionsControllerProvider).activeKey;
-        if (serverKey != null) {
-          ref
-              .read(readStateControllerProvider(serverKey).notifier)
-              .markRead(widget.channelId);
-        }
-      }
+      if (!mounted) return;
+      // The panel's channel lives on whichever server the call is pinned to,
+      // which may not be the active one.
+      final serverKey = ref.read(voiceControllerProvider).serverKey ??
+          ref.read(connectionsControllerProvider).activeKey;
+      markChannelRead(
+        ref,
+        widget.channelId,
+        serverKey: serverKey,
+        fallbackMessageId: _lastMessageId(),
+      );
     });
+  }
+
+  /// The channel's `last_message_id` from the space's channel cache — the ack
+  /// position to use before this panel's own history has loaded.
+  String? _lastMessageId() {
+    final spaceId = widget.spaceId;
+    if (spaceId == null) return null;
+    return ref
+        .read(accordChannelsControllerProvider(spaceId))
+        ?.firstWhereOrNull((c) => c.id == widget.channelId)
+        ?.lastMessageId;
   }
 
   @override

--- a/test/features/channels/mark_channel_read_test.dart
+++ b/test/features/channels/mark_channel_read_test.dart
@@ -1,0 +1,107 @@
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Pumps a bare [ProviderScope] and captures its [WidgetRef] via [Consumer],
+/// mirroring how [markChannelRead] is actually called (from callbacks, with a
+/// live [WidgetRef]) rather than a bare [ProviderContainer].
+Future<WidgetRef> _pumpRef(WidgetTester tester) async {
+  late WidgetRef ref;
+  await tester.pumpWidget(
+    ProviderScope(
+      child: Consumer(
+        builder: (context, r, _) {
+          ref = r;
+          return const SizedBox();
+        },
+      ),
+    ),
+  );
+  return ref;
+}
+
+bool _isUnread(WidgetRef ref, String serverKey, String channelId) =>
+    ref.read(readStateControllerProvider(serverKey)).isUnread(channelId);
+
+void _seedUnread(WidgetRef ref, String serverKey, String channelId) =>
+    ref
+        .read(readStateControllerProvider(serverKey).notifier)
+        .markUnread(channelId, spaceId: 's1');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('markChannelRead', () {
+    testWidgets(
+      'clears local unread state via an explicit serverKey with no cached '
+      'messages and no live client (the voice-channel case)',
+      (tester) async {
+        final ref = await _pumpRef(tester);
+        const key = 'u1@server.test';
+        _seedUnread(ref, key, 'c1');
+        expect(_isUnread(ref, key, 'c1'), isTrue);
+
+        // No client is connected in this container, so the `channels.ack`
+        // REST call resolves to a no-op — the local clear must not depend on
+        // it succeeding (or even being attempted).
+        markChannelRead(ref, 'c1', serverKey: key, fallbackMessageId: 'm-fallback');
+
+        expect(_isUnread(ref, key, 'c1'), isFalse);
+      },
+    );
+
+    testWidgets(
+      'falls back to the active connection when no serverKey is given',
+      (tester) async {
+        final ref = await _pumpRef(tester);
+        const key = 'active-key';
+        ref.read(connectionsControllerProvider.notifier).setActive(key);
+        _seedUnread(ref, key, 'c1');
+
+        markChannelRead(ref, 'c1');
+
+        expect(_isUnread(ref, key, 'c1'), isFalse);
+      },
+    );
+
+    testWidgets(
+      'is a no-op when there is no explicit serverKey and no active '
+      'connection',
+      (tester) async {
+        final ref = await _pumpRef(tester);
+        const key = 'u1@server.test';
+        _seedUnread(ref, key, 'c1');
+
+        markChannelRead(ref, 'c1');
+
+        expect(_isUnread(ref, key, 'c1'), isTrue);
+      },
+    );
+
+    testWidgets(
+      'an explicit serverKey wins over an unrelated active connection',
+      (tester) async {
+        final ref = await _pumpRef(tester);
+        const activeKey = 'active-key';
+        const pinnedKey = 'pinned-key';
+        ref.read(connectionsControllerProvider.notifier).setActive(activeKey);
+        _seedUnread(ref, activeKey, 'c1');
+        _seedUnread(ref, pinnedKey, 'c1');
+
+        markChannelRead(ref, 'c1', serverKey: pinnedKey);
+
+        expect(_isUnread(ref, pinnedKey, 'c1'), isFalse);
+        expect(_isUnread(ref, activeKey, 'c1'), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
A voice channel's unread dot never went away — e.g. **Dev Talk** stayed lit no matter what.

## Root cause

`_openChannel` in `accord_home.dart` gated the read-clear on `channel?.type != 'voice'`, so tapping a voice channel joined the call and opened the tab but never marked it read or POSTed `channels.ack`. The only voice-side clear lived in `VoiceTextPanel.initState`, with two gaps:

1. it runs only when the user explicitly opens the call's chat panel (off by default), and
2. it cleared **local** state only — with no ack, the next gateway READY re-hydrated the badge from the server's `unread` array, so the dot came straight back.

The context menu's *Mark as read* had a related hole: it acked only the newest **cached** message. A voice channel's history is almost never cached, so the ack was skipped and the clear didn't survive a reconnect.

## Changes

- **New `lib/features/channels/utils/mark_channel_read.dart`** — one helper that does the local `markRead` *and* the `channels.ack`, acking the newest cached message or falling back to the channel's `last_message_id`. Takes an optional `serverKey` so a call pinned to a background server acks on the right connection.
- **`accord_home.dart`** — dropped the `!= 'voice'` guard; `_markChannelRead` delegates to the helper.
- **`voice_text_panel.dart`** — acks (with the `last_message_id` fallback) instead of clearing locally.
- **`channel_context_menu.dart`** — *Mark as read* gained the `last_message_id` fallback, so it sticks for never-opened channels.
- **`accord_message_content.dart`** — mention-tap channel open acks too, same phantom-unread fix.

Net effect: voice channels now clear exactly like text channels, and every clear moves the server's read position so it survives a reconnect.

## Testing

- `flutter analyze --no-fatal-infos` — 0 errors (only the pre-existing infos).
- `flutter test` — 483 passing.
- Not verified live: reproducing needs a signed-in session with an unread voice channel. The ack goes through the same `client.channels.ack` path text channels already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)