### PR TITLE
feat(messaging): attach files by dragging them onto the composer

### DIFF
--- a/docs/messaging/file-sharing.md
+++ b/docs/messaging/file-sharing.md
@@ -11,7 +11,7 @@ You can share files and images directly in any text channel or DM.
 
 ## Uploading Files
 
-Attach a file to your message using the attachment button in the composer. Drag and drop is not supported yet.
+Attach a file to your message using the attachment button in the composer, or drag files from your file manager and drop them onto the composer.
 
 The maximum file size is **25 MB** per file. Larger files are rejected as soon as you pick them, with the file's size shown next to the limit -- nothing is uploaded. Music and video files are the ones that most often run into this; a 320 kbps MP3 passes 25 MB at around ten minutes.
 

--- a/lib/features/messaging/utils/attachment_limits.dart
+++ b/lib/features/messaging/utils/attachment_limits.dart
@@ -21,6 +21,23 @@ String formatFileSize(int bytes) {
   return '$bytes bytes';
 }
 
+/// Message for a file that couldn't be read into memory (a cloud- or
+/// provider-backed file the platform declined to hand over bytes for).
+/// Shared by the picker and drag-and-drop paths so the wording never drifts
+/// between the two.
+String unreadableAttachmentMessage(String name) =>
+    "$name couldn't be read. Copy it to local storage and try again.";
+
+/// Message for a file that exceeds [maxBytes]. Shared by the picker and
+/// drag-and-drop paths so the wording never drifts between the two.
+String oversizeAttachmentMessage(
+  String name,
+  int size, {
+  int maxBytes = kMaxAttachmentBytes,
+}) =>
+    '$name is ${formatFileSize(size)} — the limit is '
+    '${formatFileSize(maxBytes)}.';
+
 /// The outcome of screening picked files: the ones that can be attached, plus a
 /// line per file that can't be, naming it and why.
 class AttachmentScreening {
@@ -53,15 +70,12 @@ AttachmentScreening screenAttachments(
   for (final file in files) {
     final bytes = file.bytes;
     if (bytes == null) {
-      rejections.add(
-        "${file.name} couldn't be read. Copy it to local storage and try again.",
-      );
+      rejections.add(unreadableAttachmentMessage(file.name));
       continue;
     }
     if (bytes.length > maxBytes) {
       rejections.add(
-        '${file.name} is ${formatFileSize(bytes.length)} — the limit is '
-        '${formatFileSize(maxBytes)}.',
+        oversizeAttachmentMessage(file.name, bytes.length, maxBytes: maxBytes),
       );
       continue;
     }

--- a/lib/features/messaging/utils/dropped_entity.dart
+++ b/lib/features/messaging/utils/dropped_entity.dart
@@ -1,0 +1,12 @@
+/// Directory detection for files dropped onto the composer.
+///
+/// `desktop_drop` only types directories as `DropItemDirectory` on macOS and
+/// web — its shared `performOperation` handler, which Linux and Windows both
+/// use, wraps every dropped path in a `DropItemFile` with no directory check.
+/// Without this, a folder dropped on Linux or Windows falls through to
+/// `XFile.length()`, which throws `FileSystemException: Is a directory`, and
+/// the composer reports it as an unreadable file — telling the user to "copy it
+/// to local storage and try again", which cannot help.
+library;
+
+export 'dropped_entity_stub.dart' if (dart.library.io) 'dropped_entity_io.dart';

--- a/lib/features/messaging/utils/dropped_entity_io.dart
+++ b/lib/features/messaging/utils/dropped_entity_io.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+/// Whether [path] points at a directory on this filesystem.
+///
+/// Returns false for an empty path and for anything that no longer exists —
+/// a vanished path is a read failure, not a folder, and should be reported as
+/// one.
+bool isDroppedDirectory(String path) {
+  if (path.isEmpty) return false;
+  try {
+    return FileSystemEntity.isDirectorySync(path);
+  } on FileSystemException {
+    return false;
+  }
+}

--- a/lib/features/messaging/utils/dropped_entity_stub.dart
+++ b/lib/features/messaging/utils/dropped_entity_stub.dart
@@ -1,0 +1,4 @@
+/// Web has no filesystem to inspect, and its `desktop_drop` implementation
+/// already reports a dropped folder as a `DropItemDirectory`, so the caller's
+/// type check catches it before this is consulted.
+bool isDroppedDirectory(String path) => false;

--- a/lib/features/messaging/views/message_pane/composer.dart
+++ b/lib/features/messaging/views/message_pane/composer.dart
@@ -295,7 +295,10 @@ class _ComposerState extends ConsumerState<_Composer> {
     final picked = <PlatformFile>[];
     final rejections = <String>[];
     for (final item in details.files) {
-      if (item is DropItemDirectory) {
+      // `DropItemDirectory` only comes back on macOS and web; Linux and Windows
+      // share a handler that types every dropped path as a file, so the path
+      // itself has to be checked or a folder reads as an unreadable file.
+      if (item is DropItemDirectory || isDroppedDirectory(item.path)) {
         rejections.add(
           '${item.name} is a folder — drop the files inside it instead.',
         );

--- a/lib/features/messaging/views/message_pane/composer.dart
+++ b/lib/features/messaging/views/message_pane/composer.dart
@@ -308,10 +308,7 @@ class _ComposerState extends ConsumerState<_Composer> {
       try {
         final size = await item.length();
         if (size > kMaxAttachmentBytes) {
-          rejections.add(
-            '${item.name} is ${formatFileSize(size)} — the limit is '
-            '${formatFileSize(kMaxAttachmentBytes)}.',
-          );
+          rejections.add(oversizeAttachmentMessage(item.name, size));
           continue;
         }
         final bytes = await item.readAsBytes();
@@ -324,10 +321,7 @@ class _ComposerState extends ConsumerState<_Composer> {
           ),
         );
       } catch (_) {
-        rejections.add(
-          "${item.name} couldn't be read. Copy it to local storage and try "
-          'again.',
-        );
+        rejections.add(unreadableAttachmentMessage(item.name));
       } finally {
         if (scoped) await _stopScopedAccess(bookmark!);
       }

--- a/lib/features/messaging/views/message_pane/composer.dart
+++ b/lib/features/messaging/views/message_pane/composer.dart
@@ -29,6 +29,10 @@ class _ComposerState extends ConsumerState<_Composer> {
   /// Files the user has attached but not yet sent.
   final List<PlatformFile> _attachments = [];
 
+  /// True while a file drag is hovering the composer, which swaps the hint for
+  /// a drop prompt and outlines the box.
+  bool _dragging = false;
+
   /// Why the last attach or send didn't work, shown above the composer.
   /// Cleared when the user attaches again or retries the send.
   String? _error;
@@ -282,14 +286,90 @@ class _ComposerState extends ConsumerState<_Composer> {
     _addFiles(result.files);
   }
 
+  /// Attaches the files dragged onto the composer. Directories aren't
+  /// attachable, and files are size-checked before being read so a dropped
+  /// 4 GB video is rejected rather than pulled into memory first.
+  Future<void> _onDrop(DropDoneDetails details) async {
+    setState(() => _dragging = false);
+    if (_sending) return;
+    final picked = <PlatformFile>[];
+    final rejections = <String>[];
+    for (final item in details.files) {
+      if (item is DropItemDirectory) {
+        rejections.add(
+          '${item.name} is a folder — drop the files inside it instead.',
+        );
+        continue;
+      }
+      // macOS sandbox: a file dragged in from outside the container is only
+      // readable while its security-scoped bookmark is held open.
+      final bookmark = item.extraAppleBookmark;
+      final scoped = await _startScopedAccess(bookmark);
+      try {
+        final size = await item.length();
+        if (size > kMaxAttachmentBytes) {
+          rejections.add(
+            '${item.name} is ${formatFileSize(size)} — the limit is '
+            '${formatFileSize(kMaxAttachmentBytes)}.',
+          );
+          continue;
+        }
+        final bytes = await item.readAsBytes();
+        picked.add(
+          PlatformFile(
+            name: item.name,
+            size: bytes.length,
+            bytes: bytes,
+            path: item.path.isEmpty ? null : item.path,
+          ),
+        );
+      } catch (_) {
+        rejections.add(
+          "${item.name} couldn't be read. Copy it to local storage and try "
+          'again.',
+        );
+      } finally {
+        if (scoped) await _stopScopedAccess(bookmark!);
+      }
+    }
+    if (!mounted) return;
+    _addFiles(picked, alsoRejected: rejections);
+  }
+
+  Future<bool> _startScopedAccess(Uint8List? bookmark) async {
+    if (bookmark == null || bookmark.isEmpty) return false;
+    try {
+      return await DesktopDrop.instance.startAccessingSecurityScopedResource(
+        bookmark: bookmark,
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> _stopScopedAccess(Uint8List bookmark) async {
+    try {
+      await DesktopDrop.instance.stopAccessingSecurityScopedResource(
+        bookmark: bookmark,
+      );
+    } catch (_) {
+      // Access lapses with the drop anyway; nothing useful to tell the user.
+    }
+  }
+
   /// Attaches every file in [files] that passes screening, and reports the ones
-  /// that don't. Unreadable and oversize files used to be dropped in silence,
+  /// that don't, along with any [alsoRejected] lines the caller screened out
+  /// itself. Unreadable and oversize files used to be dropped in silence,
   /// which is indistinguishable from the attach button doing nothing.
-  void _addFiles(Iterable<PlatformFile> files) {
+  void _addFiles(
+    Iterable<PlatformFile> files, {
+    List<String> alsoRejected = const [],
+  }) {
     final screened = screenAttachments(files);
+    final rejections = [...alsoRejected, ...screened.rejections];
     setState(() {
       _attachments.addAll(screened.accepted);
-      _error = screened.error;
+      _error = rejections.isEmpty ? null : rejections.join('\n');
     });
   }
 
@@ -374,134 +454,148 @@ class _ComposerState extends ConsumerState<_Composer> {
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
-    final hint = widget.channelName != null
+    final hint = _dragging
+        ? 'Drop files to attach'
+        : widget.channelName != null
         ? 'Message #${widget.channelName}'
         : 'Message';
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        decoration: BoxDecoration(
-          color: colors.darkGray,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (widget.replyingTo != null)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 6, 4, 0),
-                child: Row(
-                  children: [
-                    Icon(Icons.reply, size: 14, color: colors.gray),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        'Replying to ${widget.replyName ?? 'message'}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(
-                          context,
-                        ).textTheme.labelMedium!.copyWith(color: colors.gray),
-                      ),
-                    ),
-                    IconButton(
-                      tooltip: 'Cancel reply',
-                      visualDensity: VisualDensity.compact,
-                      onPressed: widget.onCancelReply,
-                      icon: Icon(Icons.close, size: 14, color: colors.gray),
-                    ),
-                  ],
-                ),
-              ),
-            if (_error != null)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 8, 4, 0),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(child: InlineError(_error!, centered: false)),
-                    IconButton(
-                      tooltip: 'Dismiss',
-                      visualDensity: VisualDensity.compact,
-                      onPressed: () => setState(() => _error = null),
-                      icon: Icon(Icons.close, size: 14, color: colors.gray),
-                    ),
-                  ],
-                ),
-              ),
-            if (_attachments.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    for (final file in _attachments)
-                      _AttachmentChip(
-                        file: file,
-                        onRemove: _sending
-                            ? null
-                            : () => _removeAttachment(file),
-                      ),
-                  ],
-                ),
-              ),
-            if (_mentionQuery != null && widget.spaceId != null)
-              _MentionPopup(
-                spaceId: widget.spaceId!,
-                query: _mentionQuery!,
-                onPick: _pickMention,
-              ),
-            Row(
-              children: [
-                IconButton(
-                  tooltip: 'Attach files',
-                  onPressed: _sending ? null : _pickFiles,
-                  icon: Icon(
-                    Icons.add_circle_outline,
-                    size: 20,
-                    color: colors.dirtyWhite,
-                  ),
-                ),
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    enabled: !_sending,
-                    minLines: 1,
-                    maxLines: 6,
-                    textInputAction: TextInputAction.send,
-                    onChanged: _onChanged,
-                    onSubmitted: (_) => _send(),
-                    style: Theme.of(context).textTheme.bodyLarge,
-                    decoration: InputDecoration(
-                      isDense: true,
-                      border: InputBorder.none,
-                      hintText: hint,
-                      hintStyle: Theme.of(
-                        context,
-                      ).textTheme.bodyLarge!.copyWith(color: colors.gray),
-                    ),
-                  ),
-                ),
-                IconButton(
-                  tooltip: 'Emoji',
-                  onPressed: _sending ? null : _pickEmoji,
-                  icon: Icon(
-                    Icons.emoji_emotions_outlined,
-                    size: 20,
-                    color: colors.dirtyWhite,
-                  ),
-                ),
-                IconButton(
-                  tooltip: 'Send',
-                  onPressed: _sending ? null : _send,
-                  icon: Icon(Icons.send, size: 20, color: colors.dirtyWhite),
-                ),
-              ],
+    // A DropTarget keeps receiving drags even when covered, so it's disabled
+    // while a dialog/sheet (emoji picker, lightbox, …) is on top of the pane.
+    final onTop = ModalRoute.of(context)?.isCurrent ?? true;
+    return DropTarget(
+      enable: !_sending && onTop,
+      onDragEntered: (_) => setState(() => _dragging = true),
+      onDragExited: (_) => setState(() => _dragging = false),
+      onDragDone: _onDrop,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: BoxDecoration(
+            color: colors.darkGray,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: _dragging ? colors.primary : Colors.transparent,
             ),
-          ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.replyingTo != null)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 6, 4, 0),
+                  child: Row(
+                    children: [
+                      Icon(Icons.reply, size: 14, color: colors.gray),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          'Replying to ${widget.replyName ?? 'message'}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.labelMedium!.copyWith(color: colors.gray),
+                        ),
+                      ),
+                      IconButton(
+                        tooltip: 'Cancel reply',
+                        visualDensity: VisualDensity.compact,
+                        onPressed: widget.onCancelReply,
+                        icon: Icon(Icons.close, size: 14, color: colors.gray),
+                      ),
+                    ],
+                  ),
+                ),
+              if (_error != null)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 8, 4, 0),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(child: InlineError(_error!, centered: false)),
+                      IconButton(
+                        tooltip: 'Dismiss',
+                        visualDensity: VisualDensity.compact,
+                        onPressed: () => setState(() => _error = null),
+                        icon: Icon(Icons.close, size: 14, color: colors.gray),
+                      ),
+                    ],
+                  ),
+                ),
+              if (_attachments.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                  child: Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final file in _attachments)
+                        _AttachmentChip(
+                          file: file,
+                          onRemove: _sending
+                              ? null
+                              : () => _removeAttachment(file),
+                        ),
+                    ],
+                  ),
+                ),
+              if (_mentionQuery != null && widget.spaceId != null)
+                _MentionPopup(
+                  spaceId: widget.spaceId!,
+                  query: _mentionQuery!,
+                  onPick: _pickMention,
+                ),
+              Row(
+                children: [
+                  IconButton(
+                    tooltip: 'Attach files',
+                    onPressed: _sending ? null : _pickFiles,
+                    icon: Icon(
+                      Icons.add_circle_outline,
+                      size: 20,
+                      color: colors.dirtyWhite,
+                    ),
+                  ),
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      enabled: !_sending,
+                      minLines: 1,
+                      maxLines: 6,
+                      textInputAction: TextInputAction.send,
+                      onChanged: _onChanged,
+                      onSubmitted: (_) => _send(),
+                      style: Theme.of(context).textTheme.bodyLarge,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        border: InputBorder.none,
+                        hintText: hint,
+                        hintStyle: Theme.of(
+                          context,
+                        ).textTheme.bodyLarge!.copyWith(color: colors.gray),
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Emoji',
+                    onPressed: _sending ? null : _pickEmoji,
+                    icon: Icon(
+                      Icons.emoji_emotions_outlined,
+                      size: 20,
+                      color: colors.dirtyWhite,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Send',
+                    onPressed: _sending ? null : _send,
+                    icon: Icon(Icons.send, size: 20, color: colors.dirtyWhite),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -49,6 +49,7 @@ import 'package:bonfire/shared/utils/refocus.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
+import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -20,6 +20,7 @@ import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
 import 'package:bonfire/features/messaging/controllers/typing.dart';
 import 'package:bonfire/features/messaging/utils/attachment_limits.dart';
+import 'package:bonfire/features/messaging/utils/dropped_entity.dart';
 import 'package:bonfire/features/messaging/utils/emoji_catalog.dart';
 import 'package:bonfire/features/messaging/views/box/accord_embed_box.dart';
 import 'package:bonfire/features/messaging/views/box/accord_message_content.dart';

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <audioplayers_linux/audioplayers_linux_plugin.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <flutter_webrtc/flutter_web_r_t_c_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <livekit_client/live_kit_plugin.h>
@@ -21,6 +22,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AudioplayersLinuxPlugin");
   audioplayers_linux_plugin_register_with_registrar(audioplayers_linux_registrar);
+  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
+  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
   g_autoptr(FlPluginRegistrar) flutter_webrtc_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterWebRTCPlugin");
   flutter_web_r_t_c_plugin_register_with_registrar(flutter_webrtc_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_linux
+  desktop_drop
   flutter_webrtc
   gtk
   livekit_client

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import app_links
 import audioplayers_darwin
 import connectivity_plus
+import desktop_drop
 import device_info_plus
 import file_picker
 import flutter_local_notifications
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -432,6 +432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  desktop_drop:
+    dependency: "direct main"
+    description:
+      name: desktop_drop
+      sha256: aa1e797255bfbc76f9eb5aa4f61e5b68dbf69962ab1be6495816d2f251bc0d1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   device_info_plus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,6 +86,7 @@ dependencies:
   # already-resolved transitive version to avoid a version-solve conflict.
   archive: ^3.6.1
   crop_your_image: ^2.0.0
+  desktop_drop: ^0.7.1
 
 dependency_overrides:
   http: ^1.2.1

--- a/test/features/messaging/attachment_limits_test.dart
+++ b/test/features/messaging/attachment_limits_test.dart
@@ -63,4 +63,35 @@ void main() {
       expect(formatFileSize(kMaxAttachmentBytes), '25 MB');
     });
   });
+
+  group('unreadableAttachmentMessage', () {
+    test('names the file', () {
+      expect(
+        unreadableAttachmentMessage('video.mov'),
+        "video.mov couldn't be read. Copy it to local storage and try again.",
+      );
+    });
+  });
+
+  group('oversizeAttachmentMessage', () {
+    test('names the file and both sizes, using the default limit', () {
+      final message = oversizeAttachmentMessage('movie.mp4', 30 * 1024 * 1024);
+      expect(message, contains('movie.mp4'));
+      expect(message, contains('30 MB'));
+      expect(message, contains('25 MB'));
+    });
+
+    test('honors an explicit maxBytes, matching screenAttachments wording', () {
+      final direct = oversizeAttachmentMessage(
+        'album.mp3',
+        2048,
+        maxBytes: 1024,
+      );
+      final viaScreening = screenAttachments(
+        [_file('album.mp3', bytes: 2048)],
+        maxBytes: 1024,
+      ).error;
+      expect(direct, viaScreening);
+    });
+  });
 }

--- a/test/features/messaging/dropped_entity_test.dart
+++ b/test/features/messaging/dropped_entity_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:bonfire/features/messaging/utils/dropped_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() => tmp = Directory.systemTemp.createTempSync('dropped_entity'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  group('isDroppedDirectory', () {
+    test('is true for a directory', () {
+      expect(isDroppedDirectory(tmp.path), isTrue);
+    });
+
+    test('is false for a regular file', () {
+      final file = File('${tmp.path}/note.txt')..writeAsStringSync('hi');
+      expect(isDroppedDirectory(file.path), isFalse);
+    });
+
+    test('is false for a path that does not exist', () {
+      // A vanished path is a read failure, not a folder — the caller should
+      // report it as unreadable rather than tell the user to open it.
+      expect(isDroppedDirectory('${tmp.path}/gone'), isFalse);
+    });
+
+    test('is false for an empty path', () {
+      // Web drops and macOS file promises can carry no path at all.
+      expect(isDroppedDirectory(''), isFalse);
+    });
+  });
+
+  test('a dropped directory would otherwise read as an unreadable file', () {
+    // Why the check exists. desktop_drop types directories as
+    // DropItemDirectory only on macOS and web; Linux and Windows share a
+    // handler that wraps every dropped path in a DropItemFile. The composer
+    // then calls XFile.length() on it, which throws — and a caught throw is
+    // reported as "couldn't be read. Copy it to local storage and try again",
+    // advice that cannot help someone who dropped a folder. XFile.length()
+    // delegates straight to File.length(), asserted on here to keep the test
+    // off a transitive dependency.
+    expect(
+      () => File(tmp.path).length(),
+      throwsA(isA<FileSystemException>()),
+    );
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <flutter_webrtc/flutter_web_r_t_c_plugin.h>
 #include <livekit_client/live_kit_plugin.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
@@ -25,6 +26,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  DesktopDropPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   FlutterWebRTCPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterWebRTCPlugin"));
   LiveKitPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   audioplayers_windows
   connectivity_plus
+  desktop_drop
   flutter_webrtc
   livekit_client
   media_kit_libs_windows_video


### PR DESCRIPTION
Files could only become attachments via the picker or a clipboard paste — dragging one from a file manager onto the message box did nothing.

This wraps the composer in a `desktop_drop` `DropTarget` and funnels dropped items through the same screening and pending-attachment path the picker uses, so they render as the usual chips and go out with the same send call. While a drag hovers, the box outlines and the hint reads "Drop files to attach".

### Details

- **Size is checked before reading.** `length()` runs ahead of `readAsBytes()`, so a dropped 4 GB video is rejected rather than pulled into memory first.
- **Failures are visible.** Folders, oversize files and unreadable files surface in the composer's existing inline error instead of vanishing. `_addFiles` gained an `alsoRejected` parameter so caller-side rejections merge with the ones `screenAttachments` produces, and the oversize wording reuses `attachment_limits`.
- **macOS sandbox.** The item's security-scoped bookmark is opened around the read, so files dragged in from outside the container work in the App Store build (`files.user-selected.read-write` is already entitled).
- **Covered targets.** The drop target is disabled while sending and while a dialog or sheet is on top (`ModalRoute.isCurrent`) — `desktop_drop` otherwise keeps delivering events to targets that aren't visible.

Adds `desktop_drop: ^0.7.1` (Linux / Windows / macOS / Web / Android; a no-op on iOS, where it only installs an inbound method-call handler and never invokes the channel).

Scope note: this covers the main channel composer. The thread-reply composer in `thread_view.dart` has no attachment support at all — no attach button, no upload path — so there was nothing to hook a drop into there.

### Testing

- `flutter analyze --no-fatal-infos lib/` — clean (9 pre-existing infos, none in messaging)
- `flutter test` — 506 passing
- `flutter build linux --debug` — succeeds, native plugin registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)