### PR TITLE
Broadcast mid-call mute/deafen in DM calls

### DIFF
--- a/lib/features/voice/controllers/voice.dart
+++ b/lib/features/voice/controllers/voice.dart
@@ -657,10 +657,13 @@ class VoiceController extends _$VoiceController {
 
   void _sendVoiceStateUpdate() {
     final channelId = state.channelId;
-    final spaceId = state.spaceId;
-    if (channelId == null || spaceId == null) return;
+    if (channelId == null) return;
+    // `spaceId` is null during a DM call. That used to mean bailing out — the
+    // gateway op was space-scoped, so peers saw the mute/deafen state we opened
+    // the call with and nothing after it (#135). The server now resolves the
+    // scope from the channel and routes DM updates to the call's participants.
     _client?.updateVoiceState(
-      spaceId,
+      state.spaceId,
       channelId,
       selfMute: state.selfMute,
       selfDeaf: state.selfDeaf,

--- a/packages/accordkit/lib/src/core/accord_client.dart
+++ b/packages/accordkit/lib/src/core/accord_client.dart
@@ -152,9 +152,10 @@ class AccordClient {
           {Map<String, dynamic> activity = const {}}) =>
       gateway.updatePresence(status, activity: activity);
 
-  /// Sends a voice state update through the gateway.
+  /// Sends a voice state update through the gateway. [spaceId] is null for DM
+  /// and group DM calls, which have no parent space.
   void updateVoiceState(
-    String spaceId,
+    String? spaceId,
     String? channelId, {
     bool selfMute = false,
     bool selfDeaf = false,

--- a/packages/accordkit/lib/src/gateway/gateway_socket.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_socket.dart
@@ -389,8 +389,13 @@ class GatewaySocket {
   }
 
   /// Sends a voice state update. [channelId] may be null to disconnect.
+  ///
+  /// [spaceId] is null for DM and group DM calls, which have no parent space —
+  /// the server resolves the scope from the channel and routes the update to
+  /// the call's participants. When non-null it must be the channel's own space;
+  /// the server ignores an update that claims a different one.
   void updateVoiceState(
-    String spaceId,
+    String? spaceId,
     String? channelId, {
     bool selfMute = false,
     bool selfDeaf = false,

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -244,6 +244,16 @@ void main() {
       socket.updateVoiceState('7', null);
       expect(lastSent(conn)['data']['channel_id'], isNull);
 
+      // DM/group DM calls have no parent space. The server resolves the scope
+      // from the channel, so a null space_id is the payload for a DM call —
+      // not a reason to withhold the update.
+      socket.updateVoiceState(null, '5', selfMute: true, selfDeaf: true);
+      expect(lastSent(conn)['op'], GatewayOpcodes.voiceStateUpdate);
+      expect(lastSent(conn)['data']['space_id'], isNull);
+      expect(lastSent(conn)['data']['channel_id'], '5');
+      expect(lastSent(conn)['data']['self_mute'], true);
+      expect(lastSent(conn)['data']['self_deaf'], true);
+
       socket.requestMembers('7', query: 'al', limit: 5);
       expect(lastSent(conn)['op'], GatewayOpcodes.requestMembers);
       expect(lastSent(conn)['data']['limit'], 5);

--- a/test/features/voice/voice_dm_state_update_test.dart
+++ b/test/features/voice/voice_dm_state_update_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A [GatewayConnection] that records every frame the socket sends, so a test
+/// can assert on the outbound wire payload without real networking.
+class _FakeGatewayConnection implements GatewayConnection {
+  final _messages = StreamController<String>();
+  final List<String> sent = [];
+
+  @override
+  Future<void> get ready => Future.value();
+
+  @override
+  Stream<String> get messages => _messages.stream;
+
+  @override
+  void sendText(String text) => sent.add(text);
+
+  @override
+  Future<void> close([int? code, String? reason]) async {
+    if (!_messages.isClosed) await _messages.close();
+  }
+
+  @override
+  int? closeCode;
+
+  @override
+  String? closeReason;
+}
+
+/// Hands out a single [_FakeGatewayConnection] regardless of the requested URL.
+class _FakeConnectionFactory {
+  final connection = _FakeGatewayConnection();
+  GatewayConnection call(String url) => connection;
+}
+
+/// Routes [VoiceController._client] to a client wired to a fake gateway
+/// connection instead of a real login.
+class _FakeAccordAuth extends AccordAuth {
+  _FakeAccordAuth(this._client);
+  final AccordClient _client;
+
+  @override
+  AccordAuthState build() => const AccordAuthLoggedOut();
+
+  @override
+  AccordClient? clientForKey(String key) => _client;
+}
+
+/// A [VoiceController] that starts out connected to a DM call (no space) on
+/// the fake connection's key, without ever touching LiveKit.
+class _DmConnectedVoiceController extends VoiceController {
+  @override
+  VoiceConnection build() => const VoiceConnection(
+        channelId: 'dm-channel',
+        spaceId: null,
+        serverKey: 'server-key',
+      );
+}
+
+/// A [VoiceController] connected to a space (non-DM) voice channel, for
+/// contrast against the DM case.
+class _SpaceConnectedVoiceController extends VoiceController {
+  @override
+  VoiceConnection build() => const VoiceConnection(
+        channelId: 'space-channel',
+        spaceId: 'space-1',
+        serverKey: 'server-key',
+      );
+}
+
+Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+Map<String, dynamic> _lastSent(_FakeGatewayConnection c) =>
+    jsonDecode(c.sent.last) as Map<String, dynamic>;
+
+void main() {
+  group('mid-call self-state broadcast (#135)', () {
+    test('setMute broadcasts over a DM call, where spaceId is null',
+        () async {
+      final factory = _FakeConnectionFactory();
+      final client = AccordClient(
+        baseUrl: 'https://test.example',
+        gatewayUrl: 'wss://test.example/ws',
+        connectionFactory: factory.call,
+      );
+      addTearDown(client.dispose);
+      client.login();
+      await pump();
+
+      final container = ProviderContainer(
+        overrides: [
+          accordAuthProvider.overrideWith(() => _FakeAccordAuth(client)),
+          voiceControllerProvider.overrideWith(
+            _DmConnectedVoiceController.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(voiceControllerProvider.notifier).setMute(true);
+      await pump();
+
+      // The old guard bailed out here because `spaceId` was null — nothing
+      // was ever sent and peers never saw the mute. It must now go out with
+      // an explicit null `space_id`, not be withheld.
+      final sent = _lastSent(factory.connection);
+      expect(sent['op'], GatewayOpcodes.voiceStateUpdate);
+      expect(sent['data']['space_id'], isNull);
+      expect(sent['data']['channel_id'], 'dm-channel');
+      expect(sent['data']['self_mute'], isTrue);
+    });
+
+    test('setMute still carries the space id for a space voice channel',
+        () async {
+      final factory = _FakeConnectionFactory();
+      final client = AccordClient(
+        baseUrl: 'https://test.example',
+        gatewayUrl: 'wss://test.example/ws',
+        connectionFactory: factory.call,
+      );
+      addTearDown(client.dispose);
+      client.login();
+      await pump();
+
+      final container = ProviderContainer(
+        overrides: [
+          accordAuthProvider.overrideWith(() => _FakeAccordAuth(client)),
+          voiceControllerProvider.overrideWith(
+            _SpaceConnectedVoiceController.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(voiceControllerProvider.notifier).setMute(true);
+      await pump();
+
+      final sent = _lastSent(factory.connection);
+      expect(sent['data']['space_id'], 'space-1');
+      expect(sent['data']['channel_id'], 'space-channel');
+    });
+  });
+}

--- a/test/features/voice/voice_dm_state_update_test.dart
+++ b/test/features/voice/voice_dm_state_update_test.dart
@@ -82,6 +82,10 @@ Map<String, dynamic> _lastSent(_FakeGatewayConnection c) =>
     jsonDecode(c.sent.last) as Map<String, dynamic>;
 
 void main() {
+  // setMute()/setDeafen() touch the global `soundManager` singleton, which
+  // constructs an AudioPlayer that needs ServicesBinding.instance.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('mid-call self-state broadcast (#135)', () {
     test('setMute broadcasts over a DM call, where spaceId is null',
         () async {


### PR DESCRIPTION
Closes #135, and the remaining half of #141 (PiP landed in #136).

## The bug

Toggling mute, deafen, video or screen share during a DM call changed nothing for the other side. Peers saw the state the call *opened* with — carried by `voice/join` — and never an update after that.

## Why it wasn't just a missing call

`_sendVoiceStateUpdate` early-returned on `spaceId == null`, which is always true in a DM. That wasn't an oversight: `updateVoiceState` took `spaceId` as a non-nullable positional and put it in the payload, and the server's `VOICE_STATE_UPDATE` was space-scoped by construction, so there was nothing to call. No REST fallback either — the voice surface is `getInfo`/`join`/`leave`/`ring`/`declineCall`/`cancelCall`/`listRegions`/`getStatus`, and only `join` carries self-mute/self-deaf.

## What changed

[accordserver#46](https://github.com/DaccordProject/accordserver/pull/46) makes `space_id` optional and resolves the scope from the channel row, routing DM voice state to the call's participants. This is the client half:

- `updateVoiceState` takes a nullable `spaceId` on both `GatewaySocket` and the `AccordClient` façade. Existing callers pass positionally, so they're unaffected.
- `_sendVoiceStateUpdate` guards only on `channelId` and passes `state.spaceId` straight through.

That's the whole change — 25 lines, most of them comments explaining why the guard was there.

## Dependency

**Needs accordserver#46 deployed to have any effect.** Against an older server the extra op is simply ignored, so this is safe to merge first; it just won't do anything until the server side lands.

## Testing

`dart analyze` clean and all 147 accordkit tests pass, including a new case asserting the DM payload — null `space_id`, real `channel_id`, flags carried. `flutter analyze --no-fatal-infos` shows only pre-existing infos, and all 942 Flutter tests pass.

The server side is covered by 9 new tests in accordserver#46, including a peer actually receiving a mid-call mute over a DM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)