### PR TITLE
ci(windows): support Certum cloud code signing via SimplySign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ name: Release
 #           → `fastlane mac dmg` signs the .app (Developer ID + hardened
 #             runtime), signs the .dmg, notarizes it with notarytool and staples
 #             the ticket. Absent → plain unsigned .dmg (Gatekeeper warns).
-#   Windows WINDOWS_CERT_PFX_BASE64 (+ WINDOWS_CERT_PASSWORD)
+#   Windows SIMPLYSIGN_USER + SIMPLYSIGN_TOTP_SECRET  (Certum cloud key), or
+#           WINDOWS_CERT_PFX_BASE64 (+ WINDOWS_CERT_PASSWORD)  (exportable .pfx)
 #           → Authenticode-signs daccord.exe, the bundled DLLs and the Inno
 #             Setup installer via dist/sign-windows.ps1. Absent → unsigned
 #             binaries (SmartScreen warns).
@@ -128,8 +129,12 @@ jobs:
       # otherwise the lane starts, fails on a missing ENV.fetch, and we take the
       # slow path to the same unsigned DMG.
       DEVID_AVAILABLE: ${{ secrets.DEVELOPER_ID_CERT_P12 != '' && secrets.ASC_KEY_P8_BASE64 != '' }}
-      # Authenticode signing of the Windows .exe / DLLs / installer.
-      WINDOWS_SIGN_AVAILABLE: ${{ secrets.WINDOWS_CERT_PFX_BASE64 != '' }}
+      # Authenticode signing of the Windows .exe / DLLs / installer. Either
+      # credential will do: an exportable .pfx, or a Certum cloud key mounted by
+      # dist/simplysign-login.ps1 (which exports WINDOWS_CERT_SHA1 for the
+      # signing steps to pick up).
+      WINDOWS_SIGN_AVAILABLE: ${{ secrets.WINDOWS_CERT_PFX_BASE64 != '' || (secrets.SIMPLYSIGN_USER != '' && secrets.SIMPLYSIGN_TOTP_SECRET != '') }}
+      SIMPLYSIGN_AVAILABLE: ${{ secrets.SIMPLYSIGN_USER != '' && secrets.SIMPLYSIGN_TOTP_SECRET != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -421,11 +426,30 @@ jobs:
           spctl -a -t open --context context:primary-signature -v "$DMG" \
             || echo "::warning::Gatekeeper would reject $DMG"
 
+      - name: Open SimplySign session (Windows)
+        # Certum's cloud key can't be exported, so it has to be mounted as a
+        # virtual smart card before signtool can see it. This runs once and
+        # exports WINDOWS_CERT_SHA1 through $GITHUB_ENV; both signing steps
+        # below then pick it up automatically. The session stays open for the
+        # rest of the job.
+        #
+        # It drives a GUI with SendKeys because Certum ship no login CLI, so it
+        # is the least reliable step in this workflow by some margin. It exits 0
+        # on every failure path, which leaves WINDOWS_CERT_SHA1 unset and lands
+        # us on the usual unsigned-artifacts fallback.
+        if: matrix.platform == 'windows' && env.SIMPLYSIGN_AVAILABLE == 'true'
+        continue-on-error: true
+        shell: pwsh
+        env:
+          SIMPLYSIGN_USER: ${{ secrets.SIMPLYSIGN_USER }}
+          SIMPLYSIGN_TOTP_SECRET: ${{ secrets.SIMPLYSIGN_TOTP_SECRET }}
+        run: ./dist/simplysign-login.ps1
+
       - name: Sign binaries (Windows)
         # Authenticode-sign the app and the DLLs we build BEFORE they are zipped
         # or swept into the installer, so every shipped copy carries the
-        # signature. Skipped entirely when WINDOWS_CERT_PFX_BASE64 is unset, and
-        # `continue-on-error` keeps even a hard signing failure (expired cert,
+        # signature. Skipped entirely when no signing credential is configured,
+        # and `continue-on-error` keeps even a hard signing failure (expired cert,
         # timestamp server down) from sinking a tagged release — it degrades to
         # today's unsigned artifacts with a warning on the step.
         if: matrix.platform == 'windows' && env.WINDOWS_SIGN_AVAILABLE == 'true'

--- a/dist/sign-windows.ps1
+++ b/dist/sign-windows.ps1
@@ -1,21 +1,36 @@
 <#
 .SYNOPSIS
   Authenticode-signs Windows release binaries (the app .exe, its DLLs and the
-  Inno Setup installer) with a PFX/PKCS#12 certificate supplied through the
-  environment.
+  Inno Setup installer), using either a PFX/PKCS#12 file or a certificate
+  already present in the Windows store (hardware token / cloud virtual card).
 
 .DESCRIPTION
   Called by .github/workflows/release.yml. Everything is driven by env vars so
-  no secret ever appears on a command line (and therefore never in a log):
+  no secret ever appears on a command line (and therefore never in a log).
 
-    WINDOWS_CERT_PFX_BASE64   base64 of the code-signing .pfx      (required)
-    WINDOWS_CERT_PASSWORD     password protecting that .pfx        (optional)
+  Two credential modes, checked in this order:
+
+    WINDOWS_CERT_SHA1         thumbprint of a certificate in
+                              Cert:\CurrentUser\My — signs via the store, so
+                              the private key never has to be exportable. This
+                              is the mode used with Certum's cloud key after
+                              dist/simplysign-login.ps1 has mounted it (that
+                              script sets this variable), and it equally covers
+                              a USB token on a self-hosted runner.
+
+    WINDOWS_CERT_PFX_BASE64   base64 of a code-signing .pfx, with
+    WINDOWS_CERT_PASSWORD     its password (optional). Public CAs stopped
+                              issuing exportable keys in June 2023, so in
+                              practice this is for self-signed rehearsal certs
+                              and pre-2023 certificates.
+
     WINDOWS_TIMESTAMP_URL     RFC-3161 timestamp server            (optional,
-                              defaults to http://timestamp.digicert.com)
+                              defaults to http://timestamp.digicert.com;
+                              Certum certificates want http://time.certum.pl)
 
-  **Never fails the release.** If WINDOWS_CERT_PFX_BASE64 is unset the script
-  prints a warning and exits 0, leaving the artifacts unsigned exactly as they
-  were before signing existed. The workflow additionally marks the signing steps
+  **Never fails the release.** With neither credential set the script prints a
+  warning and exits 0, leaving the artifacts unsigned exactly as they were
+  before signing existed. The workflow additionally marks the signing steps
   `continue-on-error: true`, so even a hard signing failure (expired cert,
   timestamp server down) degrades to an unsigned-but-published release rather
   than a broken tag.
@@ -45,8 +60,15 @@ $ErrorActionPreference = 'Stop'
 # opt out. Harmless on Windows PowerShell 5.1, where the variable is unused.
 $PSNativeCommandUseErrorActionPreference = $false
 
-if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERT_PFX_BASE64)) {
-    Write-Host "::warning::WINDOWS_CERT_PFX_BASE64 is not set - shipping UNSIGNED Windows binaries."
+# Thumbprints are copied out of certmgr, which pads them with spaces and an
+# invisible left-to-right mark; normalise before comparing or passing to
+# signtool, which wants bare hex.
+$certSha1 = ($env:WINDOWS_CERT_SHA1 -replace '[^0-9a-fA-F]', '')
+$useStore = -not [string]::IsNullOrWhiteSpace($certSha1)
+$usePfx = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERT_PFX_BASE64)
+
+if (-not $useStore -and -not $usePfx) {
+    Write-Host "::warning::Neither WINDOWS_CERT_SHA1 nor WINDOWS_CERT_PFX_BASE64 is set - shipping UNSIGNED Windows binaries."
     exit 0
 }
 
@@ -111,18 +133,34 @@ if ($targets.Count -eq 0) {
 $signtool = Find-SignTool
 Write-Host "Using signtool: $signtool"
 
-$pfxPath = Join-Path ([System.IO.Path]::GetTempPath()) ("daccord-codesign-{0}.pfx" -f ([guid]::NewGuid()))
+$pfxPath = $null
 try {
-    [System.IO.File]::WriteAllBytes(
-        $pfxPath,
-        [System.Convert]::FromBase64String($env:WINDOWS_CERT_PFX_BASE64.Trim())
-    )
+    if ($useStore) {
+        # Store mode. The key stays where it is — in a cloud HSM behind
+        # SimplySign's virtual card, or on a USB token — and signtool reaches it
+        # through the CSP/minidriver, so there is no key material on disk and no
+        # password to pass. Fail loudly here rather than letting signtool emit
+        # its much vaguer "no certificates were found" later.
+        $cert = Get-ChildItem Cert:\CurrentUser\My -ErrorAction SilentlyContinue |
+            Where-Object { $_.Thumbprint -eq $certSha1 } | Select-Object -First 1
+        if (-not $cert) {
+            throw "No certificate with thumbprint $certSha1 in Cert:\CurrentUser\My (is the SimplySign session still open?)"
+        }
+        Write-Host "Signing with store certificate: $($cert.Subject)"
+        $signArgs = @('sign', '/fd', 'sha256', '/sha1', $certSha1)
+    } else {
+        $pfxPath = Join-Path ([System.IO.Path]::GetTempPath()) ("daccord-codesign-{0}.pfx" -f ([guid]::NewGuid()))
+        [System.IO.File]::WriteAllBytes(
+            $pfxPath,
+            [System.Convert]::FromBase64String($env:WINDOWS_CERT_PFX_BASE64.Trim())
+        )
 
-    $signArgs = @('sign', '/fd', 'sha256', '/f', $pfxPath)
-    if (-not [string]::IsNullOrEmpty($env:WINDOWS_CERT_PASSWORD)) {
-        # Passed as an argument to signtool only; the value comes from the
-        # environment so it is never written into the workflow file or the log.
-        $signArgs += @('/p', $env:WINDOWS_CERT_PASSWORD)
+        $signArgs = @('sign', '/fd', 'sha256', '/f', $pfxPath)
+        if (-not [string]::IsNullOrEmpty($env:WINDOWS_CERT_PASSWORD)) {
+            # Passed as an argument to signtool only; the value comes from the
+            # environment so it is never written into the workflow file or the log.
+            $signArgs += @('/p', $env:WINDOWS_CERT_PASSWORD)
+        }
     }
     $signArgs += @('/tr', $timestampUrl, '/td', 'sha256', '/v')
     $signArgs += $targets
@@ -150,5 +188,5 @@ try {
     Write-Host "Signed $($targets.Count) file(s)."
 }
 finally {
-    if (Test-Path $pfxPath) { Remove-Item $pfxPath -Force -ErrorAction SilentlyContinue }
+    if ($pfxPath -and (Test-Path $pfxPath)) { Remove-Item $pfxPath -Force -ErrorAction SilentlyContinue }
 }

--- a/dist/simplysign-login.ps1
+++ b/dist/simplysign-login.ps1
@@ -1,0 +1,240 @@
+<#
+.SYNOPSIS
+  Opens a Certum SimplySign cloud-signing session on a Windows CI runner and
+  publishes the resulting certificate thumbprint for dist/sign-windows.ps1.
+
+.DESCRIPTION
+  Certum's cloud code-signing key (the "Open Source Code Signing in the Cloud"
+  product) is never exportable, so the PFX path in dist/sign-windows.ps1 cannot
+  be used with it. The key lives in Certum's HSM and is reachable only through
+  **SimplySign Desktop**, which mounts it as a *virtual smart card*: once a
+  session is open the certificate appears in Cert:\CurrentUser\My and signtool
+  signs with it exactly as it would with a physical token.
+
+  Certum publishes no API and no command-line login for SimplySign Desktop, so
+  opening that session without a human means driving the GUI. This script:
+
+    1. installs SimplySign Desktop if it isn't already present,
+    2. derives the current TOTP from the enrolment secret,
+    3. launches the app and types the credentials into it via SendKeys,
+    4. polls Cert:\CurrentUser\My until the cloud certificate shows up,
+    5. writes its thumbprint to $GITHUB_ENV as WINDOWS_CERT_SHA1.
+
+  Step 3 is the fragile part and there is no supported alternative — see
+  docs/release-signing.md. Treat this as best-effort.
+
+  **Never fails the release.** Every failure path warns and exits 0 without
+  setting WINDOWS_CERT_SHA1; sign-windows.ps1 then finds no credential and
+  ships unsigned binaries, which is the same outcome as having no certificate
+  at all.
+
+  Environment:
+
+    SIMPLYSIGN_USER          SimplySign account ID / e-mail            (required)
+    SIMPLYSIGN_TOTP_SECRET   base32 TOTP secret, or the whole          (required)
+                             otpauth:// URI from the enrolment QR code
+    SIMPLYSIGN_TIMEOUT_SEC   seconds to wait for the card to mount     (optional,
+                             default 180)
+
+  SIMPLYSIGN_TOTP_SECRET is the *second factor* for the signing account. Putting
+  it in CI necessarily collapses 2FA to 1FA for anyone holding repo secrets.
+  That is inherent to unattended signing, not something this script introduces,
+  but it is worth knowing before you configure it.
+
+.EXAMPLE
+  ./dist/simplysign-login.ps1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+# Nothing here may sink a tagged release, so the whole body runs inside a
+# try/catch that downgrades any error to a warning + exit 0.
+function Write-Warn([string]$Message) { Write-Host "::warning::$Message" }
+
+if ([string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_USER) -or
+    [string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_TOTP_SECRET)) {
+    Write-Warn "SIMPLYSIGN_USER / SIMPLYSIGN_TOTP_SECRET are not both set - skipping SimplySign login."
+    exit 0
+}
+
+$timeoutSec = 180
+if (-not [string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_TIMEOUT_SEC)) {
+    [int]::TryParse($env:SIMPLYSIGN_TIMEOUT_SEC, [ref]$timeoutSec) | Out-Null
+}
+
+# --- TOTP ------------------------------------------------------------------
+# The enrolment QR code is a standard otpauth:// URI, so accept either the URI
+# (what you get by revealing the QR in a password manager) or the bare base32
+# secret. Pasting the whole URI is the easier thing to do correctly.
+function Get-Base32Secret([string]$Value) {
+    $v = $Value.Trim()
+    if ($v -match '^otpauth://') {
+        # secret=... is required by the spec; other params (issuer, digits) are
+        # ignored here because Certum uses the SHA1/6-digit/30s defaults.
+        if ($v -match '[?&]secret=([^&]+)') { return $Matches[1] }
+        throw "otpauth:// URI has no secret= parameter"
+    }
+    return $v
+}
+
+function ConvertFrom-Base32([string]$Value) {
+    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+    $clean = ($Value -replace '[=\s-]', '').ToUpperInvariant()
+    if ($clean.Length -eq 0) { throw "TOTP secret is empty" }
+
+    $bits = New-Object System.Text.StringBuilder
+    foreach ($ch in $clean.ToCharArray()) {
+        $idx = $alphabet.IndexOf($ch)
+        if ($idx -lt 0) { throw "TOTP secret is not valid base32 (bad character '$ch')" }
+        [void]$bits.Append([Convert]::ToString($idx, 2).PadLeft(5, '0'))
+    }
+
+    # Base32 packs 5 bits per character, so the tail is padding unless the total
+    # lands on a byte boundary; drop whatever doesn't fill a full byte.
+    $s = $bits.ToString()
+    $bytes = New-Object System.Collections.Generic.List[byte]
+    for ($i = 0; $i + 8 -le $s.Length; $i += 8) {
+        $bytes.Add([Convert]::ToByte($s.Substring($i, 8), 2))
+    }
+    return $bytes.ToArray()
+}
+
+function Get-Totp([byte[]]$Secret, [int]$Digits = 6, [int]$Period = 30) {
+    # RFC 6238 with the defaults Certum uses (HMAC-SHA1, 6 digits, 30s window).
+    $counter = [BitConverter]::GetBytes([long][Math]::Floor([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() / $Period))
+    if ([BitConverter]::IsLittleEndian) { [Array]::Reverse($counter) }
+
+    $hmac = [System.Security.Cryptography.HMACSHA1]::new($Secret)
+    try { $hash = $hmac.ComputeHash($counter) } finally { $hmac.Dispose() }
+
+    $offset = $hash[$hash.Length - 1] -band 0x0F
+    $binary = ((($hash[$offset] -band 0x7F) -shl 24) -bor
+               (($hash[$offset + 1] -band 0xFF) -shl 16) -bor
+               (($hash[$offset + 2] -band 0xFF) -shl 8) -bor
+                ($hash[$offset + 3] -band 0xFF))
+    return ($binary % [int][Math]::Pow(10, $Digits)).ToString().PadLeft($Digits, '0')
+}
+
+# --- SimplySign Desktop ----------------------------------------------------
+function Find-SimplySign {
+    $roots = @(
+        "${env:ProgramFiles(x86)}\Certum",
+        "$env:ProgramFiles\Certum",
+        "${env:ProgramFiles(x86)}\proCertum SmartSign",
+        "$env:ProgramFiles\proCertum SmartSign"
+    ) | Where-Object { $_ -and (Test-Path $_) }
+
+    foreach ($root in $roots) {
+        $exe = Get-ChildItem -Path $root -Recurse -Filter 'SimplySign*.exe' -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($exe) { return $exe.FullName }
+    }
+    return $null
+}
+
+function Install-SimplySign {
+    # winget is present on the GitHub windows-latest image and Certum publish a
+    # package there, which is far less brittle than scraping their download page
+    # for a version-stamped MSI URL.
+    Write-Host "Installing SimplySign Desktop via winget..."
+    winget install --id Certum.SmartSignSimplySignDesktop --exact --silent `
+        --accept-package-agreements --accept-source-agreements --disable-interactivity
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "winget install returned $LASTEXITCODE; continuing in case the app is already present."
+    }
+}
+
+# Certificates the cloud card is about to add. Diffing against this is more
+# reliable than matching on subject: the OSS certificate's subject is issued to
+# an individual ("Open Source Developer, <name>") and we'd rather not hardcode
+# a person's name in the repo.
+function Get-CodeSigningCerts {
+    Get-ChildItem Cert:\CurrentUser\My -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.HasPrivateKey -and
+            $_.EnhancedKeyUsageList.ObjectId -contains '1.3.6.1.5.5.7.3.3'
+        }
+}
+
+try {
+    $before = @(Get-CodeSigningCerts | Select-Object -ExpandProperty Thumbprint)
+    Write-Host "Code-signing certificates present before login: $($before.Count)"
+
+    $exe = Find-SimplySign
+    if (-not $exe) {
+        Install-SimplySign
+        $exe = Find-SimplySign
+    }
+    if (-not $exe) {
+        Write-Warn "SimplySign Desktop could not be found or installed - shipping UNSIGNED Windows binaries."
+        exit 0
+    }
+    Write-Host "Using SimplySign Desktop: $exe"
+
+    $otp = Get-Totp (ConvertFrom-Base32 (Get-Base32Secret $env:SIMPLYSIGN_TOTP_SECRET))
+    Write-Host "Generated a $($otp.Length)-digit TOTP."   # never log the value
+
+    Start-Process -FilePath $exe | Out-Null
+    Start-Sleep -Seconds 20   # the tray app takes a while to paint its window
+
+    # There is no supported way to script this. AppActivate + SendKeys against
+    # the login dialog is what the community does; it depends on the runner
+    # having an interactive desktop and on Certum not reshuffling the tab order.
+    # If it breaks, the certificate simply never appears and we ship unsigned.
+    $shell = New-Object -ComObject WScript.Shell
+
+    $proc = Get-Process -Name 'SimplySign*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+    if ($proc) {
+        $shell.AppActivate($proc.Id) | Out-Null
+    } else {
+        Write-Warn "No SimplySign window found to activate; typing into the foreground window instead."
+    }
+    Start-Sleep -Seconds 2
+
+    # SendKeys treats these as control characters, so anything appearing in an
+    # account ID has to be escaped by wrapping it in braces.
+    $user = $env:SIMPLYSIGN_USER -replace '([+^%~(){}])', '{$1}'
+    $shell.SendKeys($user)
+    Start-Sleep -Milliseconds 500
+    $shell.SendKeys('{TAB}')
+    Start-Sleep -Milliseconds 500
+    $shell.SendKeys($otp)
+    Start-Sleep -Milliseconds 500
+    $shell.SendKeys('{ENTER}')
+
+    Write-Host "Credentials submitted; waiting up to ${timeoutSec}s for the virtual card to mount..."
+
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    $found = $null
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 5
+        $found = Get-CodeSigningCerts | Where-Object { $before -notcontains $_.Thumbprint } | Select-Object -First 1
+        if ($found) { break }
+    }
+
+    if (-not $found) {
+        Write-Warn "SimplySign session did not produce a code-signing certificate within ${timeoutSec}s - shipping UNSIGNED Windows binaries."
+        exit 0
+    }
+
+    Write-Host "Cloud certificate mounted: $($found.Subject)"
+    Write-Host "  expires: $($found.NotAfter.ToString('yyyy-MM-dd'))"
+
+    # Hand the thumbprint to the signing steps. It is not a secret (it's derived
+    # from the public certificate) and keeping it out of the repo secrets means
+    # renewals don't need a secret rotation.
+    if ($env:GITHUB_ENV) {
+        "WINDOWS_CERT_SHA1=$($found.Thumbprint)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        Write-Host "Exported WINDOWS_CERT_SHA1 for subsequent steps."
+    } else {
+        Write-Host "GITHUB_ENV is unset (running locally); export WINDOWS_CERT_SHA1=$($found.Thumbprint) yourself."
+    }
+}
+catch {
+    Write-Warn "SimplySign login failed: $($_.Exception.Message) - shipping UNSIGNED Windows binaries."
+    exit 0
+}

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -14,7 +14,7 @@ always did — unsigned, but published. A missing secret can never fail a releas
 | Artifact | Signing | Secrets needed | Without them |
 |----------|---------|----------------|--------------|
 | `daccord-macos-universal.dmg` | Developer ID + hardened runtime, notarized (`notarytool`) + stapled | `DEVELOPER_ID_CERT_P12`, `CERT_P12_PASSWORD`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_P8_BASE64`, `APPLE_TEAM_ID` | Unsigned `.dmg`; Gatekeeper says *"can't be opened because Apple cannot check it"* |
-| `daccord-windows-x86_64-setup.exe`, `daccord-windows-x86_64.zip` | Authenticode (SHA-256, RFC-3161 timestamped) on `daccord.exe`, the bundled DLLs and the installer | `WINDOWS_CERT_PFX_BASE64`, `WINDOWS_CERT_PASSWORD` | Unsigned binaries; SmartScreen shows *"Windows protected your PC — unrecognized app"* |
+| `daccord-windows-x86_64-setup.exe`, `daccord-windows-x86_64.zip` | Authenticode (SHA-256, RFC-3161 timestamped) on `daccord.exe`, the bundled DLLs and the installer | `SIMPLYSIGN_USER` + `SIMPLYSIGN_TOTP_SECRET` (Certum cloud), **or** `WINDOWS_CERT_PFX_BASE64` + `WINDOWS_CERT_PASSWORD` (exportable `.pfx`) | Unsigned binaries; SmartScreen shows *"Windows protected your PC — unrecognized app"* |
 | `daccord-linux-x86_64.tgz` / `.deb` | none needed | — | — |
 | `SHA256SUMS.txt` | always generated | none | always present |
 | `checksums.asc` (detached GPG signature of `SHA256SUMS.txt`) | OpenPGP | `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE` | Checksums ship unsigned |
@@ -34,7 +34,7 @@ plain `'true'`/`'false'` string, and the steps gate on that:
 jobs:
   build:
     env:
-      WINDOWS_SIGN_AVAILABLE: ${{ secrets.WINDOWS_CERT_PFX_BASE64 != '' }}
+      WINDOWS_SIGN_AVAILABLE: ${{ secrets.WINDOWS_CERT_PFX_BASE64 != '' || (secrets.SIMPLYSIGN_USER != '' && secrets.SIMPLYSIGN_TOTP_SECRET != '') }}
     steps:
       - name: Sign binaries (Windows)
         if: matrix.platform == 'windows' && env.WINDOWS_SIGN_AVAILABLE == 'true'
@@ -56,7 +56,8 @@ The flags live at the top of each job:
 | Flag | Job | True when |
 |------|-----|-----------|
 | `DEVID_AVAILABLE` | `build` | `DEVELOPER_ID_CERT_P12` **and** `ASC_KEY_P8_BASE64` are set |
-| `WINDOWS_SIGN_AVAILABLE` | `build` | `WINDOWS_CERT_PFX_BASE64` is set |
+| `WINDOWS_SIGN_AVAILABLE` | `build` | `WINDOWS_CERT_PFX_BASE64` is set, **or** both `SIMPLYSIGN_*` secrets are |
+| `SIMPLYSIGN_AVAILABLE` | `build` | `SIMPLYSIGN_USER` **and** `SIMPLYSIGN_TOTP_SECRET` are set |
 | `GPG_AVAILABLE` | `release` | `GPG_PRIVATE_KEY` is set |
 
 ## macOS — Developer ID + notarization
@@ -122,11 +123,26 @@ retries a few times because timestamp servers are the flakiest part of signing.
 Without a timestamp every signature would stop validating the day the
 certificate expires.
 
+`sign-windows.ps1` takes its credential from **either** of two modes, checked in
+this order:
+
+| Mode | Variable | When to use |
+|------|----------|-------------|
+| **store** | `WINDOWS_CERT_SHA1` — thumbprint of a cert in `Cert:\CurrentUser\My` | The private key is non-exportable: a cloud key mounted by `dist/simplysign-login.ps1`, or a USB token on a self-hosted runner. Signs with `/sha1`; no key material touches the disk. |
+| **pfx** | `WINDOWS_CERT_PFX_BASE64` + `WINDOWS_CERT_PASSWORD` | An exportable PKCS#12. In practice this means a self-signed rehearsal cert or a pre-2023 certificate — see below. Signs with `/f`. |
+
 | Secret / variable | What it is |
 |-------------------|------------|
+| `SIMPLYSIGN_USER` (secret) | Certum SimplySign account ID / e-mail |
+| `SIMPLYSIGN_TOTP_SECRET` (secret) | the enrolment `otpauth://` URI, or just its base32 `secret=` value |
 | `WINDOWS_CERT_PFX_BASE64` (secret) | base64 of the code-signing `.pfx`/PKCS#12 |
 | `WINDOWS_CERT_PASSWORD` (secret) | password protecting that `.pfx` (omit if none) |
-| `WINDOWS_TIMESTAMP_URL` (repo **variable**, optional) | RFC-3161 timestamp server; defaults to `http://timestamp.digicert.com`. Some CAs require their own. |
+| `WINDOWS_TIMESTAMP_URL` (repo **variable**, optional) | RFC-3161 timestamp server; defaults to `http://timestamp.digicert.com`. **Set this to `http://time.certum.pl` when signing with a Certum certificate.** |
+
+`WINDOWS_CERT_SHA1` is not a secret and is not configured by hand — it is derived
+from the public certificate by `simplysign-login.ps1` and passed to the signing
+steps through `$GITHUB_ENV`, so renewing the certificate needs no secret
+rotation.
 
 ```bash
 base64 -w0 daccord-codesign.pfx | gh secret set WINDOWS_CERT_PFX_BASE64
@@ -166,9 +182,60 @@ Options, cheapest first:
 
 | Option | Cost | Notes |
 |--------|------|-------|
-| **SignPath Foundation** | free for OSS | Purpose-built for open-source projects (GPLv3 qualifies). Application + review required; signing runs through their service/GitHub Action. Best first thing to try for this project. |
-| **Azure Trusted Signing** | ~$10/month (Basic) | Microsoft-operated, keys in Microsoft's HSM — see below. |
-| **DigiCert KeyLocker / SSL.com eSigner / Certum** | ~$200–600/year | Traditional CA + their cloud HSM. Most portable, most expensive. |
+| **SignPath Foundation** | free for OSS | Purpose-built for open-source projects (GPLv3 qualifies). ~~Best first thing to try for this project.~~ **Applied — declined.** Their bar is a project with an established public track record, so it is worth re-applying once Daccord has one. |
+| **Certum Open Source Code Signing in the Cloud** | **€49/year** | **What we use.** OSS-specific product, far cheaper than Certum's commercial OV cert. Issued to an individual (`Open Source Developer, <name>`), needs identity-document verification. Automation is awkward — see below. |
+| **Azure Trusted Signing** | ~$10/month (Basic) | Microsoft-operated, keys in Microsoft's HSM — see below. Eligibility is the blocker, not price. |
+| **DigiCert KeyLocker / SSL.com eSigner / Certum (commercial OV)** | ~$200–600/year | Traditional CA + their cloud HSM. Proper CI APIs, no GUI automation, but ~10× the cost. |
+
+### Certum SimplySign — how the cloud key is actually reached
+
+Certum publish **no signing API and no login CLI**. The cloud key is reachable
+only through **SimplySign Desktop**, which mounts it as a *virtual smart card*;
+once a session is open the certificate appears in `Cert:\CurrentUser\My` and
+`signtool` signs with it by thumbprint exactly as it would with a physical
+token. So unlike DigiCert/SSL.com there is no `/dlib` to point at — the store
+mode described above is the integration.
+
+Opening that session unattended is the hard part, and `dist/simplysign-login.ps1`
+does it the only way anyone has documented:
+
+1. installs SimplySign Desktop (`winget install Certum.SmartSignSimplySignDesktop`),
+2. derives the current TOTP from `SIMPLYSIGN_TOTP_SECRET` (RFC 6238, the
+   SHA1/6-digit/30s defaults Certum use),
+3. launches the app and **types the credentials into its GUI via `SendKeys`**,
+4. polls `Cert:\CurrentUser\My` until a new code-signing cert appears,
+5. exports its thumbprint as `WINDOWS_CERT_SHA1`.
+
+Step 3 is exactly as fragile as it sounds. It depends on the runner having an
+interactive desktop and on Certum not rearranging the login dialog's tab order,
+and it will break without warning at some point. Two things make that
+acceptable rather than reckless:
+
+- the script exits 0 on **every** failure path, so a broken login leaves
+  `WINDOWS_CERT_SHA1` unset and the release ships unsigned — the same outcome as
+  owning no certificate;
+- the signing steps are already `continue-on-error: true`, so a tagged release
+  can never be lost to it.
+
+Two caveats worth stating plainly:
+
+- **It collapses 2FA to 1FA.** `SIMPLYSIGN_TOTP_SECRET` is the second factor;
+  storing it next to the account ID means anyone with repo-secret access can
+  sign as you. That is inherent to unattended signing with this product, not
+  something the script introduces.
+- **Session lifetime is unverified.** Certum do not document how long a
+  SimplySign session stays open. The login runs once per job and both signing
+  steps reuse it, which is fine if sessions outlive a build; if they turn out to
+  be shorter, the installer-signing step is the one that will start failing
+  first, and the fix is to re-run the login before it.
+
+The Linux alternative ([hpvb/certum-container](https://github.com/hpvb/certum-container)
+— SimplySign under Xvnc, `p11-kit` socket, `osslsigncode`) is more robust but
+needs a human to enter the OTP over VNC per session, so it only suits a
+persistent self-hosted runner, not GitHub-hosted ones.
+
+Certum certificates should be timestamped against Certum's own server: set the
+`WINDOWS_TIMESTAMP_URL` repo variable to `http://time.certum.pl`.
 
 ### Azure Trusted Signing — evaluation
 


### PR DESCRIPTION
## Why

SignPath Foundation declined our application, so the Windows Authenticode path needs a certificate we can actually buy. [Certum Open Source Code Signing in the Cloud](https://certum.store/open-source-code-signing-on-simplysign.html) is **€49/year** — the previous "~$200–600/year" figure in our docs was for Certum's commercial OV cert, not the OSS product.

The catch: its key is non-exportable, so the existing `WINDOWS_CERT_PFX_BASE64` flow can't use it.

## How the cloud key is reached

Certum publish **no signing API and no login CLI**. The key is reachable only through SimplySign Desktop, which mounts it as a *virtual smart card* — once a session is open the certificate appears in `Cert:\CurrentUser\My` and `signtool` signs with it by thumbprint. Unlike DigiCert/SSL.com there's no `/dlib` to point at, so this is a second credential mode rather than a new vendor library.

## Changes

- **`dist/sign-windows.ps1`** — new *store* mode: `WINDOWS_CERT_SHA1` signs via `/sha1`, keeping the private key where it is. The `.pfx` path is untouched and still covers self-signed rehearsal certs and pre-2023 certificates. Also covers a USB token on a self-hosted runner.
- **`dist/simplysign-login.ps1`** *(new)* — installs SimplySign Desktop via winget, derives the TOTP from the enrolment secret, drives the login GUI, polls for the mounted certificate, exports `WINDOWS_CERT_SHA1` through `$GITHUB_ENV`.
- **`.github/workflows/release.yml`** — runs the login once per job before the two signing steps; `WINDOWS_SIGN_AVAILABLE` now accepts either credential, plus a new `SIMPLYSIGN_AVAILABLE` flag following the existing `env:`-resolves-secrets pattern.
- **`docs/release-signing.md`** — corrected pricing, recorded the SignPath denial, documented the SimplySign mechanics and their costs.

## The honest caveat

Step 3 of the login **drives a GUI with `SendKeys`**. It depends on the runner having an interactive desktop and on Certum not rearranging the login dialog's tab order, and it will break without warning at some point. Two things make that acceptable rather than reckless:

- the script exits 0 on **every** failure path, so a broken login leaves `WINDOWS_CERT_SHA1` unset and the release ships unsigned — the same outcome as owning no certificate;
- the signing steps remain `continue-on-error: true`, so a tagged release can never be lost to it.

Also worth stating plainly:

- **This collapses 2FA to 1FA.** `SIMPLYSIGN_TOTP_SECRET` is the second factor; storing it beside the account ID means anyone with repo-secret access can sign as us. Inherent to unattended signing with this product, not introduced by this PR.
- **Session lifetime is unverified** — Certum don't document it. The login runs once and both signing steps reuse the session. If sessions turn out to be shorter than a build, the installer-signing step fails first and the fix is to re-run the login before it.

## Testing

- Workflow YAML parses; step gating and ordering verified.
- TOTP + base32 ported line-for-line to Python and checked against **all five RFC 6238 SHA-1 test vectors** — all pass, base32 decoder round-trips.
- The GUI automation is necessarily **untested** until a certificate exists. First real validation is a tagged release after purchase.

## Follow-up (not in this PR)

1. Buy the cert — issued to an individual (`Open Source Developer, <name>`), needs identity-document verification, so budget a few days.
2. Set secrets `SIMPLYSIGN_USER` + `SIMPLYSIGN_TOTP_SECRET`, and repo variable `WINDOWS_TIMESTAMP_URL=http://time.certum.pl`.
3. Re-apply to SignPath Foundation once Daccord has a longer public track record — free and far more robust than this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)