### PR TITLE
fix(ci): guard SIMPLYSIGN_TIMEOUT_SEC parsing, add TOTP unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
   powershell-tests:
     name: PowerShell unit tests
     runs-on: ubuntu-latest
-    # Only the pure TOTP/base32 math (dist/lib/totp.ps1) is covered here — the
-    # GUI automation in dist/simplysign-login.ps1 needs a real SimplySign
+    # Only the pure, dependency-free helpers under dist/lib are covered here —
+    # the GUI automation in dist/simplysign-login.ps1 needs a real SimplySign
     # install and an interactive desktop, so it isn't exercised in CI.
     steps:
       - name: Checkout
@@ -128,7 +128,9 @@ jobs:
         run: |
           Import-Module Pester -MinimumVersion 5.0.0
           $config = New-PesterConfiguration
-          $config.Run.Path = 'dist/lib/totp.Tests.ps1'
+          # Discovers every *.Tests.ps1 under dist/lib, so new lib modules get
+          # CI coverage automatically instead of needing this path updated.
+          $config.Run.Path = 'dist/lib'
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'
           Invoke-Pester -Configuration $config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,30 @@ jobs:
       - name: Test
         run: flutter test
 
+  powershell-tests:
+    name: PowerShell unit tests
+    runs-on: ubuntu-latest
+    # Only the pure TOTP/base32 math (dist/lib/totp.ps1) is covered here — the
+    # GUI automation in dist/simplysign-login.ps1 needs a real SimplySign
+    # install and an interactive desktop, so it isn't exercised in CI.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion 5.0.0
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'dist/lib/totp.Tests.ps1'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+
   build:
     name: Build ${{ matrix.name }}
     needs: analyze

--- a/dist/lib/timeout.Tests.ps1
+++ b/dist/lib/timeout.Tests.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+  Pester tests for dist/lib/timeout.ps1, the SIMPLYSIGN_TIMEOUT_SEC parsing
+  dist/simplysign-login.ps1 depends on.
+
+.DESCRIPTION
+  Regression coverage for the bug fixed in this PR (TryParse silently
+  resetting the timeout to 0 on a malformed value) and for the same failure
+  mode via a value that parses fine but is still unusable (0 or negative).
+
+  Run with: Invoke-Pester dist/lib/timeout.Tests.ps1
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/timeout.ps1"
+}
+
+Describe 'Resolve-TimeoutSeconds' {
+    It 'uses the default when the value is unset or blank' {
+        (Resolve-TimeoutSeconds -Value $null -Default 180).Seconds | Should -Be 180
+        (Resolve-TimeoutSeconds -Value '' -Default 180).Seconds | Should -Be 180
+        (Resolve-TimeoutSeconds -Value '   ' -Default 180).Seconds | Should -Be 180
+        (Resolve-TimeoutSeconds -Value '' -Default 180).UsedDefault | Should -BeFalse
+    }
+
+    It 'parses a valid positive integer' {
+        $result = Resolve-TimeoutSeconds -Value '300' -Default 180
+        $result.Seconds | Should -Be 300
+        $result.UsedDefault | Should -BeFalse
+    }
+
+    It 'falls back to the default on a non-numeric value' {
+        $result = Resolve-TimeoutSeconds -Value 'not-a-number' -Default 180
+        $result.Seconds | Should -Be 180
+        $result.UsedDefault | Should -BeTrue
+    }
+
+    It 'falls back to the default on zero, matching the malformed-value case rather than reintroducing it' {
+        $result = Resolve-TimeoutSeconds -Value '0' -Default 180
+        $result.Seconds | Should -Be 180
+        $result.UsedDefault | Should -BeTrue
+    }
+
+    It 'falls back to the default on a negative value' {
+        $result = Resolve-TimeoutSeconds -Value '-30' -Default 180
+        $result.Seconds | Should -Be 180
+        $result.UsedDefault | Should -BeTrue
+    }
+}

--- a/dist/lib/timeout.ps1
+++ b/dist/lib/timeout.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+  Resolves a "seconds" environment override to a positive integer, falling
+  back to a default on anything unusable.
+
+.DESCRIPTION
+  Pulled out of dist/simplysign-login.ps1 so this logic can be unit-tested
+  independently of the GUI automation, which needs a real SimplySign install
+  and an interactive desktop to run at all.
+
+  [int]::TryParse's `ref` parameter is reset to 0 on failure rather than left
+  unchanged, so a naive `if (TryParse(...)) { use it }` accepts 0 as if it
+  were a deliberately-parsed value. Worse, an explicit "0" (or a negative
+  number) parses successfully but is exactly as broken as the unparsable
+  case: a deadline loop keyed off it runs zero iterations. Both must fall
+  back to the default.
+
+  Covered by dist/lib/timeout.Tests.ps1.
+#>
+
+function Resolve-TimeoutSeconds {
+    param(
+        [string]$Value,
+        [Parameter(Mandatory = $true)] [int]$Default
+    )
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return [PSCustomObject]@{ Seconds = $Default; UsedDefault = $false }
+    }
+    $parsed = 0
+    if ([int]::TryParse($Value, [ref]$parsed) -and $parsed -gt 0) {
+        return [PSCustomObject]@{ Seconds = $parsed; UsedDefault = $false }
+    }
+    return [PSCustomObject]@{ Seconds = $Default; UsedDefault = $true }
+}

--- a/dist/lib/totp.Tests.ps1
+++ b/dist/lib/totp.Tests.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Pester tests for dist/lib/totp.ps1, the TOTP math dist/simplysign-login.ps1
+  depends on to authenticate against Certum SimplySign.
+
+.DESCRIPTION
+  The GUI-automation half of simplysign-login.ps1 can't be exercised in CI (no
+  SimplySign install, no interactive desktop), but the TOTP/base32 code it
+  depends on is pure and deterministic, so it gets real coverage here instead
+  of only the one-off manual check described in the PR that introduced it.
+
+  Run with: Invoke-Pester dist/lib/totp.Tests.ps1
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/totp.ps1"
+}
+
+Describe 'ConvertFrom-Base32' {
+    It 'round-trips RFC 4648 test vectors' {
+        # RFC 4648 §10.
+        [System.Text.Encoding]::ASCII.GetBytes('f') | Should -Be (ConvertFrom-Base32 'MY======')
+        [System.Text.Encoding]::ASCII.GetBytes('foobar') | Should -Be (ConvertFrom-Base32 'MZXW6YTBOI======')
+    }
+
+    It 'is case-insensitive and tolerates padding/whitespace/hyphens' {
+        $expected = ConvertFrom-Base32 'MZXW6YTBOI======'
+        (ConvertFrom-Base32 'mzxw6ytboi======') | Should -Be $expected
+        (ConvertFrom-Base32 " mz-xw6y-tboi `n") | Should -Be $expected
+    }
+
+    It 'throws on an invalid character' {
+        { ConvertFrom-Base32 '01239' } | Should -Throw
+    }
+
+    It 'throws on an empty secret' {
+        { ConvertFrom-Base32 '' } | Should -Throw
+    }
+}
+
+Describe 'Get-Base32Secret' {
+    It 'passes a bare base32 secret through unchanged' {
+        Get-Base32Secret 'JBSWY3DPEHPK3PXP' | Should -Be 'JBSWY3DPEHPK3PXP'
+    }
+
+    It 'extracts secret= from an otpauth:// URI' {
+        $uri = 'otpauth://totp/Certum:me@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Certum&digits=6'
+        Get-Base32Secret $uri | Should -Be 'JBSWY3DPEHPK3PXP'
+    }
+
+    It 'throws when an otpauth:// URI has no secret parameter' {
+        { Get-Base32Secret 'otpauth://totp/Certum:me@example.com?issuer=Certum' } | Should -Throw
+    }
+}
+
+Describe 'Get-Totp' {
+    # RFC 6238 Appendix B, SHA-1 mode: 20-byte ASCII secret "12345678901234567890",
+    # 8-digit codes, 30s period. These are the canonical vectors used to
+    # validate any TOTP implementation.
+    BeforeAll {
+        $script:secret = [System.Text.Encoding]::ASCII.GetBytes('12345678901234567890')
+    }
+
+    $cases = @(
+        @{ UnixSeconds = 59;          Expected = '94287082' }
+        @{ UnixSeconds = 1111111109;  Expected = '07081804' }
+        @{ UnixSeconds = 1111111111;  Expected = '14050471' }
+        @{ UnixSeconds = 1234567890;  Expected = '89005924' }
+        @{ UnixSeconds = 2000000000;  Expected = '69279037' }
+    )
+
+    It 'matches the RFC 6238 SHA-1 vector at T=<UnixSeconds>' -TestCases $cases {
+        param($UnixSeconds, $Expected)
+        $now = [DateTimeOffset]::FromUnixTimeSeconds($UnixSeconds)
+        Get-Totp -Secret $script:secret -Digits 8 -Period 30 -Now $now | Should -Be $Expected
+    }
+
+    It 'defaults to 6 digits, 30s period' {
+        $now = [DateTimeOffset]::FromUnixTimeSeconds(59)
+        (Get-Totp -Secret $script:secret -Now $now).Length | Should -Be 6
+        # A 6-digit code is the low-order 6 digits of the 8-digit vector.
+        Get-Totp -Secret $script:secret -Now $now | Should -Be '287082'
+    }
+}

--- a/dist/lib/totp.ps1
+++ b/dist/lib/totp.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+  RFC 6238 TOTP generation from a base32 (or otpauth:// URI) secret.
+
+.DESCRIPTION
+  Pulled out of dist/simplysign-login.ps1 so the pure, deterministic parts of
+  that script (parsing, base32 decoding, HOTP/TOTP math) can be dot-sourced
+  and unit-tested without touching the GUI-automation half, which needs a
+  real SimplySign install and an interactive desktop to run at all.
+
+  Covered by dist/lib/totp.Tests.ps1 against the RFC 6238 Appendix B SHA-1
+  test vectors.
+#>
+
+# The enrolment QR code is a standard otpauth:// URI, so accept either the URI
+# (what you get by revealing the QR in a password manager) or the bare base32
+# secret. Pasting the whole URI is the easier thing to do correctly.
+function Get-Base32Secret([string]$Value) {
+    $v = $Value.Trim()
+    if ($v -match '^otpauth://') {
+        # secret=... is required by the spec; other params (issuer, digits) are
+        # ignored here because Certum uses the SHA1/6-digit/30s defaults.
+        if ($v -match '[?&]secret=([^&]+)') { return $Matches[1] }
+        throw "otpauth:// URI has no secret= parameter"
+    }
+    return $v
+}
+
+function ConvertFrom-Base32([string]$Value) {
+    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+    $clean = ($Value -replace '[=\s-]', '').ToUpperInvariant()
+    if ($clean.Length -eq 0) { throw "TOTP secret is empty" }
+
+    $bits = New-Object System.Text.StringBuilder
+    foreach ($ch in $clean.ToCharArray()) {
+        $idx = $alphabet.IndexOf($ch)
+        if ($idx -lt 0) { throw "TOTP secret is not valid base32 (bad character '$ch')" }
+        [void]$bits.Append([Convert]::ToString($idx, 2).PadLeft(5, '0'))
+    }
+
+    # Base32 packs 5 bits per character, so the tail is padding unless the total
+    # lands on a byte boundary; drop whatever doesn't fill a full byte.
+    $s = $bits.ToString()
+    $bytes = New-Object System.Collections.Generic.List[byte]
+    for ($i = 0; $i + 8 -le $s.Length; $i += 8) {
+        $bytes.Add([Convert]::ToByte($s.Substring($i, 8), 2))
+    }
+    return $bytes.ToArray()
+}
+
+function Get-Totp {
+    param(
+        [Parameter(Mandatory = $true)] [byte[]]$Secret,
+        [int]$Digits = 6,
+        [int]$Period = 30,
+        # Injectable for tests; production callers rely on the default.
+        [DateTimeOffset]$Now = [DateTimeOffset]::UtcNow
+    )
+    # RFC 6238 with the defaults Certum uses (HMAC-SHA1, 6 digits, 30s window).
+    $counter = [BitConverter]::GetBytes([long][Math]::Floor($Now.ToUnixTimeSeconds() / $Period))
+    if ([BitConverter]::IsLittleEndian) { [Array]::Reverse($counter) }
+
+    $hmac = [System.Security.Cryptography.HMACSHA1]::new($Secret)
+    try { $hash = $hmac.ComputeHash($counter) } finally { $hmac.Dispose() }
+
+    $offset = $hash[$hash.Length - 1] -band 0x0F
+    $binary = ((($hash[$offset] -band 0x7F) -shl 24) -bor
+               (($hash[$offset + 1] -band 0xFF) -shl 16) -bor
+               (($hash[$offset + 2] -band 0xFF) -shl 8) -bor
+                ($hash[$offset + 3] -band 0xFF))
+    return ($binary % [int][Math]::Pow(10, $Digits)).ToString().PadLeft($Digits, '0')
+}

--- a/dist/simplysign-login.ps1
+++ b/dist/simplysign-login.ps1
@@ -62,61 +62,22 @@ if ([string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_USER) -or
 
 $timeoutSec = 180
 if (-not [string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_TIMEOUT_SEC)) {
-    [int]::TryParse($env:SIMPLYSIGN_TIMEOUT_SEC, [ref]$timeoutSec) | Out-Null
-}
-
-# --- TOTP ------------------------------------------------------------------
-# The enrolment QR code is a standard otpauth:// URI, so accept either the URI
-# (what you get by revealing the QR in a password manager) or the bare base32
-# secret. Pasting the whole URI is the easier thing to do correctly.
-function Get-Base32Secret([string]$Value) {
-    $v = $Value.Trim()
-    if ($v -match '^otpauth://') {
-        # secret=... is required by the spec; other params (issuer, digits) are
-        # ignored here because Certum uses the SHA1/6-digit/30s defaults.
-        if ($v -match '[?&]secret=([^&]+)') { return $Matches[1] }
-        throw "otpauth:// URI has no secret= parameter"
+    # TryParse's out parameter is reset to 0 on failure (not left at the
+    # default), so an unparsable value must be checked and discarded rather
+    # than trusted — otherwise a typo silently collapses the wait to 0s and
+    # the login is reported as failed before the card can ever mount.
+    $parsedTimeoutSec = 0
+    if ([int]::TryParse($env:SIMPLYSIGN_TIMEOUT_SEC, [ref]$parsedTimeoutSec)) {
+        $timeoutSec = $parsedTimeoutSec
+    } else {
+        Write-Warn "SIMPLYSIGN_TIMEOUT_SEC ('$env:SIMPLYSIGN_TIMEOUT_SEC') is not a valid integer - using the default ${timeoutSec}s."
     }
-    return $v
 }
 
-function ConvertFrom-Base32([string]$Value) {
-    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
-    $clean = ($Value -replace '[=\s-]', '').ToUpperInvariant()
-    if ($clean.Length -eq 0) { throw "TOTP secret is empty" }
-
-    $bits = New-Object System.Text.StringBuilder
-    foreach ($ch in $clean.ToCharArray()) {
-        $idx = $alphabet.IndexOf($ch)
-        if ($idx -lt 0) { throw "TOTP secret is not valid base32 (bad character '$ch')" }
-        [void]$bits.Append([Convert]::ToString($idx, 2).PadLeft(5, '0'))
-    }
-
-    # Base32 packs 5 bits per character, so the tail is padding unless the total
-    # lands on a byte boundary; drop whatever doesn't fill a full byte.
-    $s = $bits.ToString()
-    $bytes = New-Object System.Collections.Generic.List[byte]
-    for ($i = 0; $i + 8 -le $s.Length; $i += 8) {
-        $bytes.Add([Convert]::ToByte($s.Substring($i, 8), 2))
-    }
-    return $bytes.ToArray()
-}
-
-function Get-Totp([byte[]]$Secret, [int]$Digits = 6, [int]$Period = 30) {
-    # RFC 6238 with the defaults Certum uses (HMAC-SHA1, 6 digits, 30s window).
-    $counter = [BitConverter]::GetBytes([long][Math]::Floor([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() / $Period))
-    if ([BitConverter]::IsLittleEndian) { [Array]::Reverse($counter) }
-
-    $hmac = [System.Security.Cryptography.HMACSHA1]::new($Secret)
-    try { $hash = $hmac.ComputeHash($counter) } finally { $hmac.Dispose() }
-
-    $offset = $hash[$hash.Length - 1] -band 0x0F
-    $binary = ((($hash[$offset] -band 0x7F) -shl 24) -bor
-               (($hash[$offset + 1] -band 0xFF) -shl 16) -bor
-               (($hash[$offset + 2] -band 0xFF) -shl 8) -bor
-                ($hash[$offset + 3] -band 0xFF))
-    return ($binary % [int][Math]::Pow(10, $Digits)).ToString().PadLeft($Digits, '0')
-}
+# TOTP/base32 helpers live in totp.ps1 so they can be unit-tested (see
+# totp.Tests.ps1) independently of the GUI automation below, which needs a
+# real SimplySign install and an interactive desktop to run at all.
+. "$PSScriptRoot/lib/totp.ps1"
 
 # --- SimplySign Desktop ----------------------------------------------------
 function Find-SimplySign {

--- a/dist/simplysign-login.ps1
+++ b/dist/simplysign-login.ps1
@@ -60,24 +60,18 @@ if ([string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_USER) -or
     exit 0
 }
 
-$timeoutSec = 180
-if (-not [string]::IsNullOrWhiteSpace($env:SIMPLYSIGN_TIMEOUT_SEC)) {
-    # TryParse's out parameter is reset to 0 on failure (not left at the
-    # default), so an unparsable value must be checked and discarded rather
-    # than trusted — otherwise a typo silently collapses the wait to 0s and
-    # the login is reported as failed before the card can ever mount.
-    $parsedTimeoutSec = 0
-    if ([int]::TryParse($env:SIMPLYSIGN_TIMEOUT_SEC, [ref]$parsedTimeoutSec)) {
-        $timeoutSec = $parsedTimeoutSec
-    } else {
-        Write-Warn "SIMPLYSIGN_TIMEOUT_SEC ('$env:SIMPLYSIGN_TIMEOUT_SEC') is not a valid integer - using the default ${timeoutSec}s."
-    }
-}
-
-# TOTP/base32 helpers live in totp.ps1 so they can be unit-tested (see
-# totp.Tests.ps1) independently of the GUI automation below, which needs a
-# real SimplySign install and an interactive desktop to run at all.
+# Timeout parsing and TOTP/base32 helpers live in dist/lib so they can be
+# unit-tested (see dist/lib/*.Tests.ps1) independently of the GUI automation
+# below, which needs a real SimplySign install and an interactive desktop to
+# run at all.
+. "$PSScriptRoot/lib/timeout.ps1"
 . "$PSScriptRoot/lib/totp.ps1"
+
+$timeoutResult = Resolve-TimeoutSeconds -Value $env:SIMPLYSIGN_TIMEOUT_SEC -Default 180
+$timeoutSec = $timeoutResult.Seconds
+if ($timeoutResult.UsedDefault) {
+    Write-Warn "SIMPLYSIGN_TIMEOUT_SEC ('$env:SIMPLYSIGN_TIMEOUT_SEC') is not a valid positive integer - using the default ${timeoutSec}s."
+}
 
 # --- SimplySign Desktop ----------------------------------------------------
 function Find-SimplySign {


### PR DESCRIPTION
## Why

Follow-up to #205 (Certum SimplySign cloud code signing), which merged at `d2e4731` before this fix could land. Reviewing that PR (code quality / structure / test coverage) turned up one real bug and a test-coverage gap in `dist/simplysign-login.ps1`.

## Changes

- **`dist/simplysign-login.ps1`** — fixed `SIMPLYSIGN_TIMEOUT_SEC` parsing. `[int]::TryParse`'s `ref` parameter is reset to `0` on failure, not left unchanged, so a malformed timeout value silently collapsed the wait for the SimplySign virtual smart card to mount from the documented 180s default down to 0s — the deadline loop would run zero iterations and the login would be reported failed before Certum's session ever had a chance to open. Now falls back to the 180s default and warns on an unparsable value, matching the pattern `sign-windows.ps1`'s `Find-SignTool` already uses elsewhere in the same feature.
- **`dist/lib/totp.ps1`** *(new)* — extracted the pure `Get-Base32Secret` / `ConvertFrom-Base32` / `Get-Totp` functions out of `simplysign-login.ps1` so they're testable independently of the GUI automation (which needs a real SimplySign install + interactive desktop and can't run in CI). `Get-Totp` gained an injectable `-Now` parameter for determinism; production callers still default to `UtcNow`, so behavior is unchanged.
- **`dist/lib/totp.Tests.ps1`** *(new)* — Pester suite covering all five RFC 6238 Appendix B SHA-1 test vectors, RFC 4648 base32 round-trip vectors (case-insensitivity, padding/whitespace/hyphen tolerance), and `otpauth://` URI secret extraction including the missing-`secret=` error path. #205's description claimed this was checked manually against a one-off Python port; nothing was previously committed to catch a regression.
- **`.github/workflows/ci.yml`** — new `powershell-tests` job (installs Pester, runs the suite above, fails the job on any red test) alongside `analyze`. Since `release.yml` calls `ci.yml` via `workflow_call` and gates on it (`needs: ci`), this also gates tagged releases.

## Testing

- Installed PowerShell 7.4.6 + Pester in a sandbox (this repo had no prior PowerShell/Pester test infra) and ran the new suite: 13/13 passing.
- Reproduced the `TryParse` bug in isolation (malformed `SIMPLYSIGN_TIMEOUT_SEC` → old code yields `timeoutSec = 0`; fixed code warns and falls back to 180) before and after the fix.
- Parsed both modified `.ps1` files with the PowerShell AST parser to confirm no syntax errors, and ran `simplysign-login.ps1` end-to-end (with/without the SimplySign env vars set) to confirm it still exits 0 gracefully outside Windows/without SimplySign installed.

## Not in scope

No file in this diff exceeds 1000 lines; no 3D/visual changes. The GUI-automation path (`SendKeys` against the SimplySign login dialog) remains genuinely untestable outside a real Windows box with SimplySign installed, exactly as #205 already documents.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1EDJ82Hn7AEoavqFqv7ML)_