### PR TITLE
fix: stop members flapping online/offline

### DIFF
--- a/lib/features/events/controllers/presence.dart
+++ b/lib/features/events/controllers/presence.dart
@@ -1,14 +1,67 @@
+import 'dart:async';
+
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'presence.g.dart';
 
-/// One connection's per-user presence cache, keyed by user ID and scoped to
-/// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-/// uses, and for the same reason: snowflake IDs are minted per server, so a
-/// single global map lets two servers' users collide.
+/// One connection's presence cache, keyed by **qualified** user ID.
+///
+/// The gateway broadcasts `presence.update` with a bare `user_id`, while a
+/// member seen through a federated space carries a qualified `id@domain` — so
+/// an exact-key lookup never matched and those members read permanently offline
+/// (#209). Both sides are normalised through [qualify] here instead: bare IDs
+/// are suffixed with the connection's [homeDomain], already-qualified IDs are
+/// left alone. That is [isSameUser] semantics expressed as a map key, and it
+/// keeps a remote `123@b.example` from colliding with a local `123` — which a
+/// bare [localPart] fallback would not, since snowflakes are only unique per
+/// home server.
+@immutable
+class PresenceMap {
+  const PresenceMap({this.byUser = const {}, this.homeDomain = ''});
+
+  /// Presences by qualified user ID (or by raw ID while [homeDomain] is still
+  /// unknown — [withDomain] re-keys them as soon as it is).
+  final Map<String, AccordPresence> byUser;
+
+  /// The connection's home domain (`a.example`), empty until the first write
+  /// supplies it.
+  final String homeDomain;
+
+  bool get isEmpty => byUser.isEmpty;
+  bool get isNotEmpty => byUser.isNotEmpty;
+  int get length => byUser.length;
+
+  /// The cache key for [userId]. [qualify] is idempotent, so passing an
+  /// already-qualified ID is a no-op.
+  String keyFor(String userId) =>
+      homeDomain.isEmpty ? userId : qualify(userId, homeDomain);
+
+  /// The presence for [userId], given bare or qualified, or null when none has
+  /// been received.
+  AccordPresence? operator [](String userId) => byUser[keyFor(userId)];
+
+  /// This map re-keyed for [domain]. Returns `this` when nothing changes; an
+  /// empty [domain] means "not known yet" and never un-qualifies keys.
+  PresenceMap withDomain(String domain) {
+    if (domain.isEmpty || domain == homeDomain) return this;
+    return PresenceMap(
+      byUser: {
+        for (final entry in byUser.entries)
+          qualify(entry.key, domain): entry.value,
+      },
+      homeDomain: domain,
+    );
+  }
+}
+
+/// One connection's per-user presence cache, scoped to [serverKey]
+/// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+/// same reason: snowflake IDs are minted per server, so a single global map lets
+/// two servers' users collide.
 ///
 /// Every connection (active *or* background) seeds this from its gateway READY
 /// payload's `presences` array and keeps it current from `presence.update`
@@ -17,47 +70,146 @@ part 'presence.g.dart';
 /// nothing for a background connection to clobber, and gating was what left a
 /// backgrounded server permanently showing everyone as offline (#191).
 ///
+/// Offline transitions are held for [offlineGrace] before they reach the state
+/// (#210). Presence is purely socket-lifetime driven server-side — one socket
+/// drop on a peer's client is one visible offline/online flip for everyone — so
+/// without smoothing a momentary blip re-buckets that member into the roster's
+/// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+/// never delayed, and a pending offline is cancelled the moment the user comes
+/// back, so a blip shorter than the window is never rendered at all.
+///
 /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
 /// an absent entry means "offline" (the gateway only pushes presence for
 /// non-offline users). Read the active connection's map through
 /// [activePresencesProvider] rather than picking a key by hand.
 @Riverpod(keepAlive: true)
 class PresenceController extends _$PresenceController {
-  @override
-  Map<String, AccordPresence> build(String serverKey) => const {};
+  /// How long an offline transition is held before it is rendered. Long enough
+  /// to swallow a reconnect blip, short enough that a real sign-off still feels
+  /// immediate.
+  @visibleForTesting
+  static Duration offlineGrace = const Duration(seconds: 8);
 
-  /// Inserts or replaces the presence for [presence.userId].
-  void upsert(AccordPresence presence) {
+  /// Offline transitions waiting out [offlineGrace], by cache key.
+  final _pendingOffline = <String, Timer>{};
+
+  @override
+  PresenceMap build(String serverKey) {
+    ref.onDispose(_cancelPending);
+    return const PresenceMap();
+  }
+
+  /// Inserts or replaces the presence for `presence.userId`, holding an
+  /// offline transition for [offlineGrace].
+  ///
+  /// [homeDomain] is the connection's own domain, used to qualify bare IDs; it
+  /// defaults to the one the map already holds, so callers with no domain in
+  /// hand (the self status picker, the AFK monitor) don't need one.
+  void upsert(AccordPresence presence, {String? homeDomain}) {
     if (presence.userId.isEmpty) return;
-    state = {...state, presence.userId: presence};
+    final map = _rekeyed(homeDomain);
+    final key = map.keyFor(presence.userId);
+
+    // Coming online is never delayed, and it cancels a pending offline — a
+    // drop-and-reconnect inside the window renders as no change at all.
+    if (presence.status != 'offline') {
+      _pendingOffline.remove(key)?.cancel();
+      state = _with(map, key, presence);
+      return;
+    }
+    // Nothing visible changes when they already read as offline, so there is
+    // nothing to smooth — apply it so activities stay current.
+    final existing = map.byUser[key];
+    if (existing == null || existing.status == 'offline') {
+      state = _with(map, key, presence);
+      return;
+    }
+    state = map;
+    _holdOffline(key, presence);
   }
 
   /// Replaces *this server's* presences with [presences] (used to seed from
   /// READY). Replacing rather than merging is deliberate: READY carries every
-  /// online user we can see, so anyone absent from it has since gone offline
-  /// and their stale entry must not survive a reconnect. Other servers'
-  /// caches are separate provider instances and are untouched — a second
-  /// connection READYing can no longer wipe the first's presences.
-  void seed(Iterable<AccordPresence> presences) {
-    state = {
+  /// online user we can see, so anyone absent from it has since gone offline.
+  /// Other servers' caches are separate provider instances and are untouched —
+  /// a second connection READYing can no longer wipe the first's presences.
+  ///
+  /// Those implied offline transitions go through the same [offlineGrace] hold
+  /// as an explicit one. A re-seed is almost always *our own* reconnect, and
+  /// dropping every absent user on the spot blanked the whole roster for as
+  /// long as the handshake took (#210).
+  void seed(Iterable<AccordPresence> presences, {String? homeDomain}) {
+    final map = _rekeyed(homeDomain);
+    final seeded = <String, AccordPresence>{
       for (final p in presences)
-        if (p.userId.isNotEmpty) p.userId: p,
+        if (p.userId.isNotEmpty) map.keyFor(p.userId): p,
     };
+
+    final next = <String, AccordPresence>{};
+    for (final entry in map.byUser.entries) {
+      if (seeded.containsKey(entry.key)) continue;
+      if (entry.value.status == 'offline') continue;
+      next[entry.key] = entry.value;
+      _holdOffline(entry.key, null);
+    }
+    for (final key in seeded.keys) {
+      _pendingOffline.remove(key)?.cancel();
+    }
+    next.addAll(seeded);
+    state = PresenceMap(byUser: next, homeDomain: map.homeDomain);
   }
 
-  /// Merges [presences] into the existing map, leaving untouched users alone.
-  /// For partial payloads (a backfill for one space's roster), where absence
-  /// carries no "went offline" meaning.
-  void merge(Iterable<AccordPresence> presences) {
-    if (presences.isEmpty) return;
-    state = {
-      ...state,
-      for (final p in presences)
-        if (p.userId.isNotEmpty) p.userId: p,
-    };
+  void clear() {
+    _cancelPending();
+    state = PresenceMap(homeDomain: state.homeDomain);
   }
 
-  void clear() => state = const {};
+  /// Renders the offline transition for [key] once [offlineGrace] elapses:
+  /// [offline] is the presence to store, or null to drop the entry entirely
+  /// (how a seed says "absent from READY"). An already-pending hold wins, so a
+  /// repeated offline can't keep pushing the transition further out.
+  void _holdOffline(String key, AccordPresence? offline) {
+    if (_pendingOffline.containsKey(key)) return;
+    _pendingOffline[key] = Timer(offlineGrace, () {
+      _pendingOffline.remove(key);
+      final next = {...state.byUser};
+      if (offline == null) {
+        next.remove(key);
+      } else {
+        next[key] = offline;
+      }
+      state = PresenceMap(byUser: next, homeDomain: state.homeDomain);
+    });
+  }
+
+  /// The current map re-keyed for [homeDomain] when it differs. A null or empty
+  /// domain means the caller doesn't know ours (the self status picker, the AFK
+  /// monitor) and leaves the keys alone. Pending holds are keyed by the old form
+  /// and can't survive a re-key, so they're dropped — in practice this only
+  /// fires on the first write, before any hold exists.
+  PresenceMap _rekeyed(String? homeDomain) {
+    final map = state;
+    if (homeDomain == null ||
+        homeDomain.isEmpty ||
+        homeDomain == map.homeDomain) {
+      return map;
+    }
+    _cancelPending();
+    return map.withDomain(homeDomain);
+  }
+
+  PresenceMap _with(PresenceMap map, String key, AccordPresence presence) =>
+      PresenceMap(
+        byUser: {...map.byUser, key: presence},
+        homeDomain: map.homeDomain,
+      );
+
+  void _cancelPending() {
+    for (final timer in _pendingOffline.values) {
+      timer.cancel();
+    }
+    _pendingOffline.clear();
+  }
 }
 
 /// The presence map of the connection currently driving the panes, or an empty
@@ -65,11 +217,11 @@ class PresenceController extends _$PresenceController {
 /// connection's own (already-seeded, already-live) cache, so presence is
 /// correct immediately on a switch with no reconnect.
 @Riverpod(keepAlive: true)
-Map<String, AccordPresence> activePresences(Ref ref) {
+PresenceMap activePresences(Ref ref) {
   final key = ref.watch(
     connectionsControllerProvider.select((s) => s.activeKey),
   );
-  if (key == null) return const {};
+  if (key == null) return const PresenceMap();
   return ref.watch(presenceControllerProvider(key));
 }
 
@@ -83,19 +235,15 @@ PresenceController? activePresenceNotifier(WidgetRef ref) {
 }
 
 /// The status string ('online' / 'idle' / 'dnd' / 'offline') for [userId],
-/// defaulting to 'offline' when no presence has been received.
-String accordPresenceStatus(
-  Map<String, AccordPresence> presences,
-  String userId,
-) => presences[userId]?.status ?? 'offline';
+/// defaulting to 'offline' when no presence has been received. [userId] may be
+/// bare or qualified — see [PresenceMap].
+String accordPresenceStatus(PresenceMap presences, String userId) =>
+    presences[userId]?.status ?? 'offline';
 
 /// The user's custom status text (the first activity's name), or null when
 /// none is set. Custom statuses are sent as a presence `activity` whose `name`
 /// carries the (optionally emoji-prefixed) text.
-String? accordCustomStatus(
-  Map<String, AccordPresence> presences,
-  String userId,
-) {
+String? accordCustomStatus(PresenceMap presences, String userId) {
   final activities = presences[userId]?.activities ?? const [];
   for (final a in activities) {
     if (a.name.trim().isNotEmpty) return a.name.trim();

--- a/lib/features/events/controllers/presence.g.dart
+++ b/lib/features/events/controllers/presence.g.dart
@@ -8,10 +8,10 @@ part of 'presence.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// One connection's per-user presence cache, keyed by user ID and scoped to
-/// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-/// uses, and for the same reason: snowflake IDs are minted per server, so a
-/// single global map lets two servers' users collide.
+/// One connection's per-user presence cache, scoped to [serverKey]
+/// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+/// same reason: snowflake IDs are minted per server, so a single global map lets
+/// two servers' users collide.
 ///
 /// Every connection (active *or* background) seeds this from its gateway READY
 /// payload's `presences` array and keeps it current from `presence.update`
@@ -19,6 +19,14 @@ part of 'presence.dart';
 /// connection being the active one: with the cache keyed per server there is
 /// nothing for a background connection to clobber, and gating was what left a
 /// backgrounded server permanently showing everyone as offline (#191).
+///
+/// Offline transitions are held for [offlineGrace] before they reach the state
+/// (#210). Presence is purely socket-lifetime driven server-side — one socket
+/// drop on a peer's client is one visible offline/online flip for everyone — so
+/// without smoothing a momentary blip re-buckets that member into the roster's
+/// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+/// never delayed, and a pending offline is cancelled the moment the user comes
+/// back, so a blip shorter than the window is never rendered at all.
 ///
 /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
 /// an absent entry means "offline" (the gateway only pushes presence for
@@ -28,10 +36,10 @@ part of 'presence.dart';
 @ProviderFor(PresenceController)
 const presenceControllerProvider = PresenceControllerFamily._();
 
-/// One connection's per-user presence cache, keyed by user ID and scoped to
-/// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-/// uses, and for the same reason: snowflake IDs are minted per server, so a
-/// single global map lets two servers' users collide.
+/// One connection's per-user presence cache, scoped to [serverKey]
+/// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+/// same reason: snowflake IDs are minted per server, so a single global map lets
+/// two servers' users collide.
 ///
 /// Every connection (active *or* background) seeds this from its gateway READY
 /// payload's `presences` array and keeps it current from `presence.update`
@@ -40,16 +48,24 @@ const presenceControllerProvider = PresenceControllerFamily._();
 /// nothing for a background connection to clobber, and gating was what left a
 /// backgrounded server permanently showing everyone as offline (#191).
 ///
+/// Offline transitions are held for [offlineGrace] before they reach the state
+/// (#210). Presence is purely socket-lifetime driven server-side — one socket
+/// drop on a peer's client is one visible offline/online flip for everyone — so
+/// without smoothing a momentary blip re-buckets that member into the roster's
+/// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+/// never delayed, and a pending offline is cancelled the moment the user comes
+/// back, so a blip shorter than the window is never rendered at all.
+///
 /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
 /// an absent entry means "offline" (the gateway only pushes presence for
 /// non-offline users). Read the active connection's map through
 /// [activePresencesProvider] rather than picking a key by hand.
 final class PresenceControllerProvider
-    extends $NotifierProvider<PresenceController, Map<String, AccordPresence>> {
-  /// One connection's per-user presence cache, keyed by user ID and scoped to
-  /// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-  /// uses, and for the same reason: snowflake IDs are minted per server, so a
-  /// single global map lets two servers' users collide.
+    extends $NotifierProvider<PresenceController, PresenceMap> {
+  /// One connection's per-user presence cache, scoped to [serverKey]
+  /// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+  /// same reason: snowflake IDs are minted per server, so a single global map lets
+  /// two servers' users collide.
   ///
   /// Every connection (active *or* background) seeds this from its gateway READY
   /// payload's `presences` array and keeps it current from `presence.update`
@@ -57,6 +73,14 @@ final class PresenceControllerProvider
   /// connection being the active one: with the cache keyed per server there is
   /// nothing for a background connection to clobber, and gating was what left a
   /// backgrounded server permanently showing everyone as offline (#191).
+  ///
+  /// Offline transitions are held for [offlineGrace] before they reach the state
+  /// (#210). Presence is purely socket-lifetime driven server-side — one socket
+  /// drop on a peer's client is one visible offline/online flip for everyone — so
+  /// without smoothing a momentary blip re-buckets that member into the roster's
+  /// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+  /// never delayed, and a pending offline is cancelled the moment the user comes
+  /// back, so a blip shorter than the window is never rendered at all.
   ///
   /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
   /// an absent entry means "offline" (the gateway only pushes presence for
@@ -88,10 +112,10 @@ final class PresenceControllerProvider
   PresenceController create() => PresenceController();
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Map<String, AccordPresence> value) {
+  Override overrideWithValue(PresenceMap value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<Map<String, AccordPresence>>(value),
+      providerOverride: $SyncValueProvider<PresenceMap>(value),
     );
   }
 
@@ -107,12 +131,12 @@ final class PresenceControllerProvider
 }
 
 String _$presenceControllerHash() =>
-    r'8f6150eb46df1eaf7ffa212ab7d6fd5fa0e9b464';
+    r'e788b9684a26aede0da70e56346c6f6a94e92345';
 
-/// One connection's per-user presence cache, keyed by user ID and scoped to
-/// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-/// uses, and for the same reason: snowflake IDs are minted per server, so a
-/// single global map lets two servers' users collide.
+/// One connection's per-user presence cache, scoped to [serverKey]
+/// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+/// same reason: snowflake IDs are minted per server, so a single global map lets
+/// two servers' users collide.
 ///
 /// Every connection (active *or* background) seeds this from its gateway READY
 /// payload's `presences` array and keeps it current from `presence.update`
@@ -120,6 +144,14 @@ String _$presenceControllerHash() =>
 /// connection being the active one: with the cache keyed per server there is
 /// nothing for a background connection to clobber, and gating was what left a
 /// backgrounded server permanently showing everyone as offline (#191).
+///
+/// Offline transitions are held for [offlineGrace] before they reach the state
+/// (#210). Presence is purely socket-lifetime driven server-side — one socket
+/// drop on a peer's client is one visible offline/online flip for everyone — so
+/// without smoothing a momentary blip re-buckets that member into the roster's
+/// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+/// never delayed, and a pending offline is cancelled the moment the user comes
+/// back, so a blip shorter than the window is never rendered at all.
 ///
 /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
 /// an absent entry means "offline" (the gateway only pushes presence for
@@ -130,9 +162,9 @@ final class PresenceControllerFamily extends $Family
     with
         $ClassFamilyOverride<
           PresenceController,
-          Map<String, AccordPresence>,
-          Map<String, AccordPresence>,
-          Map<String, AccordPresence>,
+          PresenceMap,
+          PresenceMap,
+          PresenceMap,
           String
         > {
   const PresenceControllerFamily._()
@@ -144,10 +176,10 @@ final class PresenceControllerFamily extends $Family
         isAutoDispose: false,
       );
 
-  /// One connection's per-user presence cache, keyed by user ID and scoped to
-  /// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-  /// uses, and for the same reason: snowflake IDs are minted per server, so a
-  /// single global map lets two servers' users collide.
+  /// One connection's per-user presence cache, scoped to [serverKey]
+  /// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+  /// same reason: snowflake IDs are minted per server, so a single global map lets
+  /// two servers' users collide.
   ///
   /// Every connection (active *or* background) seeds this from its gateway READY
   /// payload's `presences` array and keeps it current from `presence.update`
@@ -155,6 +187,14 @@ final class PresenceControllerFamily extends $Family
   /// connection being the active one: with the cache keyed per server there is
   /// nothing for a background connection to clobber, and gating was what left a
   /// backgrounded server permanently showing everyone as offline (#191).
+  ///
+  /// Offline transitions are held for [offlineGrace] before they reach the state
+  /// (#210). Presence is purely socket-lifetime driven server-side — one socket
+  /// drop on a peer's client is one visible offline/online flip for everyone — so
+  /// without smoothing a momentary blip re-buckets that member into the roster's
+  /// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+  /// never delayed, and a pending offline is cancelled the moment the user comes
+  /// back, so a blip shorter than the window is never rendered at all.
   ///
   /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
   /// an absent entry means "offline" (the gateway only pushes presence for
@@ -168,10 +208,10 @@ final class PresenceControllerFamily extends $Family
   String toString() => r'presenceControllerProvider';
 }
 
-/// One connection's per-user presence cache, keyed by user ID and scoped to
-/// [serverKey] (`userId@baseUrl`) — the same scoping [ReadStateController]
-/// uses, and for the same reason: snowflake IDs are minted per server, so a
-/// single global map lets two servers' users collide.
+/// One connection's per-user presence cache, scoped to [serverKey]
+/// (`userId@baseUrl`) — the same scoping [ReadStateController] uses, and for the
+/// same reason: snowflake IDs are minted per server, so a single global map lets
+/// two servers' users collide.
 ///
 /// Every connection (active *or* background) seeds this from its gateway READY
 /// payload's `presences` array and keeps it current from `presence.update`
@@ -180,32 +220,34 @@ final class PresenceControllerFamily extends $Family
 /// nothing for a background connection to clobber, and gating was what left a
 /// backgrounded server permanently showing everyone as offline (#191).
 ///
+/// Offline transitions are held for [offlineGrace] before they reach the state
+/// (#210). Presence is purely socket-lifetime driven server-side — one socket
+/// drop on a peer's client is one visible offline/online flip for everyone — so
+/// without smoothing a momentary blip re-buckets that member into the roster's
+/// "Offline" section and back, and rows visibly jump. Going *non*-offline is
+/// never delayed, and a pending offline is cancelled the moment the user comes
+/// back, so a blip shorter than the window is never rendered at all.
+///
 /// Consumers resolve a member's status by user ID via [accordPresenceStatus];
 /// an absent entry means "offline" (the gateway only pushes presence for
 /// non-offline users). Read the active connection's map through
 /// [activePresencesProvider] rather than picking a key by hand.
 
-abstract class _$PresenceController
-    extends $Notifier<Map<String, AccordPresence>> {
+abstract class _$PresenceController extends $Notifier<PresenceMap> {
   late final _$args = ref.$arg as String;
   String get serverKey => _$args;
 
-  Map<String, AccordPresence> build(String serverKey);
+  PresenceMap build(String serverKey);
   @$mustCallSuper
   @override
   void runBuild() {
     final created = build(_$args);
-    final ref =
-        this.ref
-            as $Ref<Map<String, AccordPresence>, Map<String, AccordPresence>>;
+    final ref = this.ref as $Ref<PresenceMap, PresenceMap>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<
-                Map<String, AccordPresence>,
-                Map<String, AccordPresence>
-              >,
-              Map<String, AccordPresence>,
+              AnyNotifier<PresenceMap, PresenceMap>,
+              PresenceMap,
               Object?,
               Object?
             >;
@@ -227,13 +269,8 @@ const activePresencesProvider = ActivePresencesProvider._();
 /// correct immediately on a switch with no reconnect.
 
 final class ActivePresencesProvider
-    extends
-        $FunctionalProvider<
-          Map<String, AccordPresence>,
-          Map<String, AccordPresence>,
-          Map<String, AccordPresence>
-        >
-    with $Provider<Map<String, AccordPresence>> {
+    extends $FunctionalProvider<PresenceMap, PresenceMap, PresenceMap>
+    with $Provider<PresenceMap> {
   /// The presence map of the connection currently driving the panes, or an empty
   /// map when no server is active. Switching servers re-reads the new
   /// connection's own (already-seeded, already-live) cache, so presence is
@@ -254,22 +291,21 @@ final class ActivePresencesProvider
 
   @$internal
   @override
-  $ProviderElement<Map<String, AccordPresence>> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
+  $ProviderElement<PresenceMap> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
-  Map<String, AccordPresence> create(Ref ref) {
+  PresenceMap create(Ref ref) {
     return activePresences(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Map<String, AccordPresence> value) {
+  Override overrideWithValue(PresenceMap value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<Map<String, AccordPresence>>(value),
+      providerOverride: $SyncValueProvider<PresenceMap>(value),
     );
   }
 }
 
-String _$activePresencesHash() => r'f9e957be30d12be3772e383f81b825fddd90e29a';
+String _$activePresencesHash() => r'cf19e8f8ef668b7b0bade324eaea6e93682c21d8';

--- a/lib/features/events/services/accord_event_handler.dart
+++ b/lib/features/events/services/accord_event_handler.dart
@@ -106,7 +106,12 @@ VoidCallback handleAccordEvents(
     // connection too — a background server that READYs while you're looking at
     // another one used to be left permanently showing its whole roster as
     // offline, with no re-seed on switch (#191).
-    seedPresencesFromReady(ref, data, serverKey: serverKey);
+    seedPresencesFromReady(
+      ref,
+      data,
+      serverKey: serverKey,
+      homeDomain: selfDomain,
+    );
     if (isActive()) {
       _seedVoiceStates(ref, data);
     }
@@ -151,8 +156,13 @@ VoidCallback handleAccordEvents(
   // these while inactive is what made a user who was demonstrably online read
   // as offline after a server switch (#191) — there is no re-request path, the
   // gateway only re-sends presence in READY.
+  // The `user_id` on the wire is bare; a member seen through a federated space
+  // is qualified. [selfDomain] is what lets the cache key both the same way
+  // (#209).
   subs.add(client.onPresenceUpdate.listen((presence) {
-    ref.read(presenceControllerProvider(serverKey).notifier).upsert(presence);
+    ref
+        .read(presenceControllerProvider(serverKey).notifier)
+        .upsert(presence, homeDomain: selfDomain);
   }));
 
   // ── User cache (profile changes) ─────────────────────────────────────────
@@ -741,6 +751,7 @@ void seedPresencesFromReady(
   Ref ref,
   Map<String, dynamic> ready, {
   required String serverKey,
+  String homeDomain = '',
 }) {
   final raw = ready['presences'];
   if (raw is! List) return;
@@ -748,7 +759,9 @@ void seedPresencesFromReady(
     for (final entry in raw)
       if (entry is Map<String, dynamic>) AccordPresence.fromJson(entry),
   ];
-  ref.read(presenceControllerProvider(serverKey).notifier).seed(presences);
+  ref
+      .read(presenceControllerProvider(serverKey).notifier)
+      .seed(presences, homeDomain: homeDomain);
 }
 
 /// Fetches the connection's spaces over REST and seeds its rail cache. The

--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -146,7 +146,7 @@ const int _offlinePosition = -2;
 List<_RosterSection> _buildSections(
   List<AccordMember> members,
   List<AccordRole> roles,
-  Map<String, AccordPresence> presences,
+  PresenceMap presences,
 ) {
   final byKey = <String, _RosterSection>{};
   final defaultSection =

--- a/lib/features/voice/controllers/voice.dart
+++ b/lib/features/voice/controllers/voice.dart
@@ -602,7 +602,7 @@ class VoiceController extends _$VoiceController {
     String serverKey,
     String userId,
     String status,
-    Map<String, AccordPresence> presences,
+    PresenceMap presences,
   ) {
     final custom = accordCustomStatus(presences, userId);
     client.gateway.updatePresence(

--- a/lib/features/voice/controllers/voice.g.dart
+++ b/lib/features/voice/controllers/voice.g.dart
@@ -53,7 +53,7 @@ final class VoiceControllerProvider
   }
 }
 
-String _$voiceControllerHash() => r'61f07d81fbd956bdb8239cfc759c497c963a66b7';
+String _$voiceControllerHash() => r'418cd737015a29ba2cc87221707ab52c1e0a5963';
 
 /// Orchestrates voice channel join/leave and media toggles, the Dart port of
 /// the reference `client_voice.gd` + the voice slice of its `AppState`. Owns a

--- a/packages/accordkit/lib/src/gateway/gateway_socket.dart
+++ b/packages/accordkit/lib/src/gateway/gateway_socket.dart
@@ -36,12 +36,17 @@ class GatewaySocket {
   final GatewayConnectionFactory _factory;
   final Future<void> Function(Duration) _sleep;
   final double Function() _random;
+  final DateTime Function() _now;
   final String _osName;
   final int maxReconnectAttempts;
 
   /// How long [ensureConnected] waits for a heartbeat ACK before declaring a
   /// nominally-connected socket dead and forcing a reconnect.
   final Duration probeTimeout;
+
+  /// How long a session must survive past READY before it counts as *stable*
+  /// and earns back a fresh reconnect budget. See [_creditStableSession].
+  final Duration stableSessionThreshold;
 
   AccordConfig? _config;
   GatewayConnection? _conn;
@@ -58,20 +63,25 @@ class GatewaySocket {
   bool _reconnectCancelled = false;
   bool _resumePending = false;
   bool _probePending = false;
+  bool _resumeSupported = false;
+  DateTime? _sessionStartedAt;
 
   GatewaySocket({
     GatewayConnectionFactory? connectionFactory,
     Future<void> Function(Duration)? sleep,
     double Function()? random,
+    DateTime Function()? now,
     String osName = 'dart',
     this.maxReconnectAttempts = 10,
     this.probeTimeout = const Duration(seconds: 5),
+    this.stableSessionThreshold = const Duration(seconds: 30),
     this.token = '',
     this.tokenType = 'Bot',
     List<String>? intents,
   })  : _factory = connectionFactory ?? WebSocketGatewayConnection.connect,
         _sleep = sleep ?? Future.delayed,
         _random = random ?? Random().nextDouble,
+        _now = now ?? DateTime.now,
         _osName = osName,
         intents = intents ?? [];
 
@@ -285,6 +295,15 @@ class GatewaySocket {
   /// Current resumable session ID (empty when none).
   String get sessionId => _sessionId;
 
+  /// Whether the connected server has advertised RESUME (op 3) support.
+  ///
+  /// Off until a HELLO or READY says otherwise: accordserver's pre-identify
+  /// loop only inspects `op == IDENTIFY` and silently drops everything else, so
+  /// a speculative RESUME just idles until the server's 30-second identify
+  /// timeout fires — during which we are broadcast offline to everyone who can
+  /// see us (#208).
+  bool get resumeSupported => _resumeSupported;
+
   /// The effective heartbeat interval in ms, after capping the server-advertised
   /// value at [AccordConfig.heartbeatIntervalMax]. Set on HELLO.
   int get heartbeatIntervalMs => _heartbeatIntervalMs;
@@ -334,7 +353,8 @@ class GatewaySocket {
   ///
   /// - Disconnected: reconnects immediately with a fresh backoff budget, even
   ///   when earlier automatic reconnects exhausted [maxReconnectAttempts].
-  ///   Resumes the previous session when one is held, else re-identifies.
+  ///   Resumes the previous session when one is held *and* the server supports
+  ///   resuming ([resumeSupported]), else re-identifies.
   /// - Nominally connected: the socket may be dead without a close frame ever
   ///   having been delivered, so send an out-of-band heartbeat and force-close
   ///   (triggering the normal reconnect path) if no ACK arrives within
@@ -346,9 +366,7 @@ class GatewaySocket {
     if (_reconnectCancelled || _gatewayUrl.isEmpty) return;
     if (_state == GatewayState.disconnected) {
       _reconnectAttempts = 0;
-      _openConnection(_sessionId.isNotEmpty
-          ? GatewayState.resuming
-          : GatewayState.connecting);
+      _openConnection(_handshakeState());
       return;
     }
     // Only probe a fully-established connection; if we're mid-handshake
@@ -484,9 +502,49 @@ class GatewaySocket {
     _conn = null;
   }
 
+  /// The state to open a (re)connect in.
+  ///
+  /// RESUME is only attempted against a server that advertised support for it;
+  /// otherwise the held session is dropped up front so the handshake goes
+  /// straight to IDENTIFY rather than stalling on a RESUME the server never
+  /// answers (#208).
+  GatewayState _handshakeState() {
+    if (_sessionId.isEmpty) return GatewayState.connecting;
+    if (_resumeSupported) return GatewayState.resuming;
+    _sessionId = '';
+    _sequence = 0;
+    return GatewayState.connecting;
+  }
+
+  /// Whether [data] (a HELLO or READY payload) advertises RESUME support,
+  /// either as `resumable: true` or via a `capabilities` entry.
+  bool _advertisesResume(Map<String, dynamic> data) {
+    if (asBool(data['resumable'])) return true;
+    final caps = asList(data['capabilities']) ?? const [];
+    return caps.any((c) => asString(c) == 'resume');
+  }
+
+  /// Returns the reconnect budget to full when the session that just ended had
+  /// been up for at least [stableSessionThreshold].
+  ///
+  /// Resetting on READY itself (as this used to) meant a connect → READY → die
+  /// loop reconnected at the 1–2s base delay forever: the backoff never
+  /// escalated and the budget was never spent, so a broken socket hammered the
+  /// server and broadcast an offline+online pair to every observer every few
+  /// seconds (#208).
+  void _creditStableSession() {
+    final startedAt = _sessionStartedAt;
+    _sessionStartedAt = null;
+    if (startedAt == null) return;
+    if (_now().difference(startedAt) >= stableSessionThreshold) {
+      _reconnectAttempts = 0;
+    }
+  }
+
   void _onClosed() {
     final code = _conn?.closeCode ?? 1006;
     final reason = _conn?.closeReason ?? '';
+    _creditStableSession();
     if (_resumePending) {
       _sessionId = '';
       _sequence = 0;
@@ -518,9 +576,7 @@ class GatewaySocket {
         baseDelay * pow(2.0, min(_reconnectAttempts - 1, 5)) + _random();
     await _sleep(Duration(milliseconds: (delay * 1000).round()));
     if (_reconnectCancelled) return;
-    final initial =
-        _sessionId.isNotEmpty ? GatewayState.resuming : GatewayState.connecting;
-    _openConnection(initial);
+    _openConnection(_handshakeState());
   }
 
   // ── Heartbeat ────────────────────────────────────────────────────────────
@@ -617,9 +673,17 @@ class GatewaySocket {
         );
         _heartbeatAckReceived = true;
         _startHeartbeat();
-        if (_sessionId.isNotEmpty && _state == GatewayState.resuming) {
+        if (_advertisesResume(dataMap)) _resumeSupported = true;
+        if (_sessionId.isNotEmpty &&
+            _state == GatewayState.resuming &&
+            _resumeSupported) {
           _sendResume();
         } else {
+          // Never speculatively RESUME: a server without a handler for op 3
+          // drops it silently and we sit dead until its identify timeout (#208).
+          _sessionId = '';
+          _sequence = 0;
+          if (_state == GatewayState.resuming) _state = GatewayState.connected;
           _sendIdentify();
         }
         break;
@@ -670,12 +734,15 @@ class GatewaySocket {
     switch (eventType) {
       case 'ready':
         _sessionId = asString(data['session_id']);
-        _reconnectAttempts = 0;
+        if (_advertisesResume(data)) _resumeSupported = true;
+        // The backoff budget is credited on *close*, once the session has
+        // proven it can stay up (see [_creditStableSession]) — not here.
+        _sessionStartedAt = _now();
         _resumePending = false;
         _readyReceived.add(data);
         break;
       case 'resumed':
-        _reconnectAttempts = 0;
+        _sessionStartedAt = _now();
         _resumePending = false;
         _resumed.add(null);
         break;

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -273,13 +273,15 @@ void main() {
       socket.connectToGateway('ws://x');
       await pump();
 
-      // Establish a session.
+      // Establish a session. `resumable` is what licenses the RESUME below —
+      // without it the socket re-identifies instead (#208).
       factory.last.receive(jsonEncode({
         'op': GatewayOpcodes.event,
         'type': 'ready',
-        'data': {'session_id': 'S1'},
+        'data': {'session_id': 'S1', 'resumable': true},
       }));
       await pump();
+      expect(socket.resumeSupported, isTrue);
 
       // Unexpected drop.
       factory.last.simulateClose(1006);
@@ -298,6 +300,76 @@ void main() {
       final sent = lastSent(factory.last);
       expect(sent['op'], GatewayOpcodes.resume);
       expect(sent['data']['session_id'], 'S1');
+      await socket.dispose();
+    });
+
+    test('re-identifies against a server that never advertised resume',
+        () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      // A plain READY — no `resumable`, no `capabilities`. accordserver's
+      // pre-identify loop ignores op 3 entirely, so a speculative RESUME would
+      // idle until its 30-second identify timeout with us broadcast offline
+      // the whole time (#208).
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'data': {'session_id': 'S1'},
+      }));
+      await pump();
+      expect(socket.resumeSupported, isFalse);
+
+      factory.last.simulateClose(1006);
+      await pump();
+
+      // The stale session is dropped up front rather than gambled on, so the
+      // reconnect opens as a plain connect (never `resuming`).
+      expect(socket.sessionId, '');
+      expect(socket.state, isNot(GatewayState.resuming));
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 60000},
+      }));
+      await pump();
+
+      expect(lastSent(factory.last)['op'], GatewayOpcodes.identify);
+      await socket.dispose();
+    });
+
+    test('a HELLO capability list also enables resuming', () async {
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      socket.connectToGateway('ws://x');
+      await pump();
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {
+          'heartbeat_interval': 60000,
+          'capabilities': ['resume'],
+        },
+      }));
+      await pump();
+      expect(socket.resumeSupported, isTrue);
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'ready',
+        'data': {'session_id': 'S1'},
+      }));
+      await pump();
+
+      factory.last.simulateClose(1006);
+      await pump();
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.hello,
+        'data': {'heartbeat_interval': 60000},
+      }));
+      await pump();
+
+      expect(lastSent(factory.last)['op'], GatewayOpcodes.resume);
       await socket.dispose();
     });
 
@@ -355,6 +427,66 @@ void main() {
       expect(socket.sessionId, '');
       expect(factory.connections.length, 2);
       await socket.dispose();
+    });
+  });
+
+  group('backoff', () {
+    /// Drives [rounds] connect → READY → die cycles, holding each session up
+    /// for [sessionLifetime] on the injected clock, and returns the delay the
+    /// socket waited before each reconnect.
+    Future<List<int>> flap({
+      required int rounds,
+      required Duration sessionLifetime,
+    }) async {
+      final delays = <Duration>[];
+      var clock = DateTime.utc(2024);
+      final factory = FakeConnectionFactory();
+      final socket = GatewaySocket(
+        connectionFactory: factory.call,
+        sleep: (d) async {
+          delays.add(d);
+        },
+        random: () => 0.0,
+        now: () => clock,
+        token: 'tok',
+        tokenType: 'Bot',
+      );
+      socket.setup(AccordConfig(), 'tok', intentList: ['messages']);
+      socket.connectToGateway('ws://x');
+      await pump();
+
+      for (var i = 0; i < rounds; i++) {
+        factory.last.receive(jsonEncode({
+          'op': GatewayOpcodes.event,
+          'type': 'ready',
+          'data': {'session_id': 'S$i'},
+        }));
+        await pump();
+        clock = clock.add(sessionLifetime);
+        factory.last.simulateClose(1006);
+        await pump();
+      }
+      await socket.dispose();
+      return [for (final d in delays) d.inMilliseconds];
+    }
+
+    test('escalates when the session keeps dying before it is stable',
+        () async {
+      // The #208 cadence: READY, alive for five seconds, dead. The budget used
+      // to be reset on READY, so this looped at 1–2s forever — one visible
+      // offline/online flip per cycle for everyone watching the roster.
+      expect(
+        await flap(rounds: 4, sessionLifetime: const Duration(seconds: 5)),
+        [1000, 2000, 4000, 8000],
+      );
+    });
+
+    test('a session that stays up past the threshold earns the budget back',
+        () async {
+      expect(
+        await flap(rounds: 3, sessionLifetime: const Duration(seconds: 45)),
+        [1000, 1000, 1000],
+      );
     });
   });
 
@@ -445,7 +577,7 @@ void main() {
         'op': GatewayOpcodes.event,
         'type': 'ready',
         'seq': 3,
-        'data': {'session_id': 'S1'},
+        'data': {'session_id': 'S1', 'resumable': true},
       }));
       await pump();
 

--- a/test/features/events/presence_controller_test.dart
+++ b/test/features/events/presence_controller_test.dart
@@ -11,6 +11,15 @@ final _refProvider = Provider<Ref>((ref) => ref);
 
 const _keyA = 'u1@https://a.example';
 const _keyB = 'u2@https://b.example';
+const _domainA = 'a.example';
+
+/// A grace window short enough to wait out in a test but long enough that the
+/// "still held" assertions aren't racing it.
+const _grace = Duration(milliseconds: 30);
+
+/// Waits past [PresenceController.offlineGrace] so held transitions land.
+Future<void> pastGrace() =>
+    Future<void>.delayed(PresenceController.offlineGrace * 3);
 
 AccordPresence presence(String userId, String status, {String? custom}) =>
     AccordPresence(
@@ -30,6 +39,10 @@ Map<String, dynamic> readyEntry(String userId, String status) => {
     };
 
 void main() {
+  setUp(() => PresenceController.offlineGrace = _grace);
+  tearDown(() =>
+      PresenceController.offlineGrace = const Duration(seconds: 8));
+
   ProviderContainer makeContainer() {
     final c = ProviderContainer();
     addTearDown(c.dispose);
@@ -38,7 +51,7 @@ void main() {
 
   PresenceController ctl(ProviderContainer c, String serverKey) =>
       c.read(presenceControllerProvider(serverKey).notifier);
-  Map<String, AccordPresence> stateOf(ProviderContainer c, String serverKey) =>
+  PresenceMap stateOf(ProviderContainer c, String serverKey) =>
       c.read(presenceControllerProvider(serverKey));
 
   void setActive(ProviderContainer c, String? key) =>
@@ -47,7 +60,7 @@ void main() {
   group('PresenceController (per-connection)', () {
     test('starts empty', () {
       final c = makeContainer();
-      expect(stateOf(c, _keyA), isEmpty);
+      expect(stateOf(c, _keyA).byUser, isEmpty);
     });
 
     test('upsert stores a presence for that server only', () {
@@ -61,7 +74,7 @@ void main() {
     test('upsert ignores an empty user id', () {
       final c = makeContainer();
       ctl(c, _keyA).upsert(presence('', 'online'));
-      expect(stateOf(c, _keyA), isEmpty);
+      expect(stateOf(c, _keyA).byUser, isEmpty);
     });
 
     test('seeding two connections does not clobber either', () {
@@ -77,23 +90,32 @@ void main() {
       expect(accordPresenceStatus(stateOf(c, _keyB), 'alice'), 'offline');
     });
 
-    test('seed replaces this server\'s map (a dropped user goes offline)', () {
+    test('seed replaces this server\'s map (a dropped user goes offline)',
+        () async {
       final c = makeContainer();
       ctl(c, _keyA)
         ..seed([presence('alice', 'online'), presence('bob', 'idle')])
         ..seed([presence('alice', 'idle')]);
       expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'idle');
+      // Bob is absent from the re-seed, but the roster isn't blanked on the
+      // spot — the implied offline waits out the grace window like any other
+      // (#210).
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'bob'), 'idle');
+      await pastGrace();
       expect(accordPresenceStatus(stateOf(c, _keyA), 'bob'), 'offline');
     });
 
-    test('merge keeps users absent from the payload', () {
+    test('a user re-seeded inside the grace window never goes offline',
+        () async {
       final c = makeContainer();
       ctl(c, _keyA)
         ..seed([presence('alice', 'online'), presence('bob', 'idle')])
-        ..merge([presence('carol', 'dnd')]);
-      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'online');
+        // Our own reconnect: a first READY that hasn't caught up with bob yet…
+        ..seed([presence('alice', 'online')])
+        // …then a live update putting him back before the window elapses.
+        ..upsert(presence('bob', 'idle'));
+      await pastGrace();
       expect(accordPresenceStatus(stateOf(c, _keyA), 'bob'), 'idle');
-      expect(accordPresenceStatus(stateOf(c, _keyA), 'carol'), 'dnd');
     });
 
     test('clear empties only that server', () {
@@ -101,8 +123,128 @@ void main() {
       ctl(c, _keyA).seed([presence('alice', 'online')]);
       ctl(c, _keyB).seed([presence('carol', 'dnd')]);
       ctl(c, _keyA).clear();
-      expect(stateOf(c, _keyA), isEmpty);
+      expect(stateOf(c, _keyA).byUser, isEmpty);
       expect(accordPresenceStatus(stateOf(c, _keyB), 'carol'), 'dnd');
+    });
+  });
+
+  group('offline smoothing (#210)', () {
+    test('an offline update is held for the grace window', () async {
+      final c = makeContainer();
+      ctl(c, _keyA)
+        ..upsert(presence('alice', 'online'))
+        ..upsert(presence('alice', 'offline'));
+
+      // A peer's socket blip must not re-bucket them into "Offline" instantly.
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'online');
+      await pastGrace();
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'offline');
+    });
+
+    test('a reconnect inside the window renders as no change at all', () async {
+      final c = makeContainer();
+      final seen = <String>[];
+      c.listen(
+        presenceControllerProvider(_keyA),
+        (_, next) => seen.add(accordPresenceStatus(next, 'alice')),
+      );
+
+      ctl(c, _keyA).upsert(presence('alice', 'online'));
+      ctl(c, _keyA).upsert(presence('alice', 'offline'));
+      ctl(c, _keyA).upsert(presence('alice', 'online'));
+      await pastGrace();
+
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'online');
+      expect(seen, everyElement('online'),
+          reason: 'the offline flip should never have reached a listener');
+    });
+
+    test('coming online is never delayed', () {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('alice', 'online'));
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'online');
+    });
+
+    test('a repeated offline does not push the transition further out',
+        () async {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('alice', 'online'));
+      ctl(c, _keyA).upsert(presence('alice', 'offline'));
+      await Future<void>.delayed(_grace ~/ 2);
+      ctl(c, _keyA).upsert(presence('alice', 'offline'));
+      await pastGrace();
+      expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'offline');
+    });
+
+    test('an offline for someone already offline applies immediately', () {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('alice', 'offline', custom: 'Away'));
+      expect(accordCustomStatus(stateOf(c, _keyA), 'alice'), 'Away');
+    });
+
+    test('disposing the connection cancels pending holds', () async {
+      final c = makeContainer();
+      ctl(c, _keyA)
+        ..upsert(presence('alice', 'online'))
+        ..upsert(presence('alice', 'offline'));
+      c.invalidate(presenceControllerProvider(_keyA));
+      await pastGrace();
+      // No lingering timer wrote into a disposed notifier.
+      expect(stateOf(c, _keyA).byUser, isEmpty);
+    });
+  });
+
+  group('federated IDs (#209)', () {
+    test('a bare broadcast matches a member qualified to our own domain', () {
+      final c = makeContainer();
+      // accordserver broadcasts presence with a bare user_id…
+      ctl(c, _keyA).upsert(presence('123', 'online'), homeDomain: _domainA);
+      // …while a member seen through a federated space carries `id@domain`.
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123@$_domainA'), 'online');
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123'), 'online');
+    });
+
+    test('the same snowflake on another home server does not collide', () {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('123', 'online'), homeDomain: _domainA);
+      // Snowflakes are only unique per home server — a `localPart` fallback
+      // would report this remote user as online off our own user's presence.
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123@b.example'),
+          'offline');
+    });
+
+    test('a qualified broadcast is stored under the same key', () {
+      final c = makeContainer();
+      ctl(c, _keyA)
+          .upsert(presence('123@b.example', 'dnd'), homeDomain: _domainA);
+      expect(
+          accordPresenceStatus(stateOf(c, _keyA), '123@b.example'), 'dnd');
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123'), 'offline');
+    });
+
+    test('entries written before the domain was known are re-keyed', () {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('123', 'idle'));
+      ctl(c, _keyA).upsert(presence('456', 'online'), homeDomain: _domainA);
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123@$_domainA'), 'idle');
+    });
+
+    test('a write without a domain leaves qualified keys alone', () {
+      final c = makeContainer();
+      ctl(c, _keyA).upsert(presence('123', 'online'), homeDomain: _domainA);
+      // The self status picker and the AFK monitor write without a domain in
+      // hand; that must not un-qualify the map.
+      ctl(c, _keyA).upsert(presence('456', 'idle'));
+      final map = stateOf(c, _keyA);
+      expect(map.homeDomain, _domainA);
+      expect(accordPresenceStatus(map, '123@$_domainA'), 'online');
+      expect(accordPresenceStatus(map, '456@$_domainA'), 'idle');
+    });
+
+    test('seed qualifies too', () {
+      final c = makeContainer();
+      ctl(c, _keyA).seed([presence('123', 'online')], homeDomain: _domainA);
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123@$_domainA'), 'online');
     });
   });
 
@@ -110,7 +252,7 @@ void main() {
     test('is empty when no connection is active', () {
       final c = makeContainer();
       ctl(c, _keyA).seed([presence('alice', 'online')]);
-      expect(c.read(activePresencesProvider), isEmpty);
+      expect(c.read(activePresencesProvider).byUser, isEmpty);
     });
 
     test('reads the active connection', () {
@@ -183,7 +325,19 @@ void main() {
       );
       expect(accordPresenceStatus(stateOf(c, _keyA), 'alice'), 'online');
       expect(accordPresenceStatus(stateOf(c, _keyA), 'bob'), 'idle');
-      expect(stateOf(c, _keyB), isEmpty);
+      expect(stateOf(c, _keyB).byUser, isEmpty);
+    });
+
+    test('qualifies the seeded IDs with the connection home domain', () {
+      final c = makeContainer();
+      final ref = c.read(_refProvider);
+      seedPresencesFromReady(
+        ref,
+        ready([readyEntry('123', 'online')]),
+        serverKey: _keyA,
+        homeDomain: _domainA,
+      );
+      expect(accordPresenceStatus(stateOf(c, _keyA), '123@$_domainA'), 'online');
     });
 
     test('two connections READYing in sequence keep their own presences', () {
@@ -197,12 +351,14 @@ void main() {
       expect(accordPresenceStatus(stateOf(c, _keyB), 'carol'), 'dnd');
     });
 
-    test('an empty presences array clears the server (everyone offline)', () {
+    test('an empty presences array clears the server (everyone offline)',
+        () async {
       final c = makeContainer();
       final ref = c.read(_refProvider);
       ctl(c, _keyA).seed([presence('alice', 'online')]);
       seedPresencesFromReady(ref, ready(const []), serverKey: _keyA);
-      expect(stateOf(c, _keyA), isEmpty);
+      await pastGrace();
+      expect(stateOf(c, _keyA).byUser, isEmpty);
     });
 
     test('a missing presences field leaves the previous seed alone', () {
@@ -216,12 +372,12 @@ void main() {
 
   group('status helpers', () {
     test('unknown user defaults to offline with no custom status', () {
-      expect(accordPresenceStatus(const {}, 'nobody'), 'offline');
-      expect(accordCustomStatus(const {}, 'nobody'), isNull);
+      expect(accordPresenceStatus(const PresenceMap(), 'nobody'), 'offline');
+      expect(accordCustomStatus(const PresenceMap(), 'nobody'), isNull);
     });
 
     test('custom status returns the first non-blank activity name', () {
-      final map = {
+      final map = PresenceMap(byUser: {
         'alice': AccordPresence(
           userId: 'alice',
           status: 'online',
@@ -230,7 +386,7 @@ void main() {
             AccordActivity(name: ' Deploying ', type: 'custom'),
           ],
         ),
-      };
+      });
       expect(accordCustomStatus(map, 'alice'), 'Deploying');
     });
   });

--- a/test/features/voice/voice_participants_afk_test.dart
+++ b/test/features/voice/voice_participants_afk_test.dart
@@ -72,7 +72,7 @@ Widget _host({
           _channelId: {for (final id in userIds) id: _state(id)},
         }),
       ),
-      activePresencesProvider.overrideWithValue(presences),
+      activePresencesProvider.overrideWithValue(PresenceMap(byUser: presences)),
     ],
     child: MaterialApp(
       theme: buildAppTheme(AppThemePreset.dark),


### PR DESCRIPTION
Fixes the roster flap end to end: the gateway defects that made peers' sockets drop often and stay down for 30+ seconds, the lookup bug that pinned federated members at offline, and the lack of any smoothing that made every blip visible.

Closes #208, closes #209, closes #210.

## #208 — gateway (`packages/accordkit`)

**RESUME is capability-gated.** accordserver's pre-identify loop only inspects `op == IDENTIFY` and silently drops everything else, so the op 3 we sent on every reconnect went unanswered until the server's 30-second identify timeout fired — the user was broadcast offline that entire time. `_resumeSupported` now stays false until a HELLO or READY advertises `resumable: true` (or `"resume"` in `capabilities`); otherwise the stale session is dropped up front and the handshake goes straight to IDENTIFY. The RESUME path is kept intact behind the flag (and exposed as `GatewaySocket.resumeSupported`) for when the server implements it — no client change needed then.

**Backoff escalates on a READY → die loop.** The budget is no longer reset on READY; READY/RESUMED stamp the session start and the budget is credited on close only if the session survived `stableSessionThreshold` (30s, injectable). A session dying at 5s old now backs off 1s → 2s → 4s → 8s instead of looping at 1–2s forever. A new `now` constructor seam sits alongside the existing `sleep`/`random` ones, so the delay sequence is asserted deterministically rather than with real timers.

## #209 — presence keyed by qualified ID

The cache was an exact-key map, but the wire carries a bare `user_id` while a federated member's `AccordMember.userId` is qualified — the keys never matched. Presences now live in a `PresenceMap` that carries the connection's home domain and normalises **both** writes and lookups through `qualify()`, i.e. `isSameUser` semantics expressed as a map key. `123` and `123@a.example` resolve to the same entry; `123@b.example` stays distinct, which a bare `localPart` fallback would not. `handleAccordEvents` threads its existing `selfDomain` into `upsert`/`seed`.

## #210 — smoothing, seeding, dead code

- Offline transitions are held for a grace window (8s) before reaching state. Going non-offline is never delayed and cancels a pending hold, so a drop-and-reconnect inside the window emits **no** state change at all — asserted with a listener test.
- Users absent from a READY re-seed go through the same hold, so our own reconnect keeps rendering last-known presence instead of blanking the roster.
- `merge` is dropped — no callers, and with no presence REST endpoint in accordkit there is no backfill path to wire it to.

Not done (listed as optional in #210): rendering last-known presence *dimmed* while disconnected. That's UI work across the avatar/roster widgets, and the graced re-seed already covers the reported symptom.

## Notes for the reviewer

A genuinely flapping socket can now **exhaust** `maxReconnectAttempts`, which it previously never could. The in-app Retry buttons call `ensureConnected()`, but `AccordAuth.ensureConnectedAll()` still has no caller — there is no app-lifecycle/foreground hook wiring it up. Worth a follow-up issue.

## Testing

- `dart analyze` + `dart test` in `packages/accordkit` — clean, 151 passing, including new `re-identifies against a server that never advertised resume` and a `backoff` group asserting the escalation and the stable-session credit.
- `flutter analyze --no-fatal-infos` — no errors.
- `flutter test` — green except `test/features/voice/voice_dm_state_update_test.dart`, which fails identically on `master` (audioplayers `MissingPluginException`) and is untouched here.
- `test/features/events/presence_controller_test.dart` gains federation and smoothing groups (31 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)