### PR TITLE
ci: dispatch an accordwebsite rebuild after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,6 +633,42 @@ jobs:
           files: artifacts/*
 
   # ---------------------------------------------------------------------------
+  # Rebuild daccord.gg. The website image bakes in the `daccord-web.zip` asset
+  # from *this* repo's latest release and serves it at daccord.gg/chat/, so a new
+  # release does nothing for web users until accordwebsite rebuilds. Its workflow
+  # already listens for a `web-export-updated` repository_dispatch; nothing was
+  # sending one, so /chat/ sat on v0.2.6 for the whole v0.2.7–v0.2.9 window and
+  # only ever refreshed when someone happened to push to accordwebsite.
+  #
+  # Needs ACCORDWEBSITE_DISPATCH_TOKEN: a PAT (or GitHub App token) with
+  # `contents: write` on DaccordProject/accordwebsite. GITHUB_TOKEN can't be used
+  # — it's scoped to this repo and can't dispatch to another one.
+  # ---------------------------------------------------------------------------
+  website-rebuild:
+    name: Rebuild daccord.gg /chat/
+    needs: release
+    runs-on: ubuntu-latest
+    # As elsewhere in this workflow, a missing secret must never fail a tagged
+    # release: without the token this job is skipped, and the website just keeps
+    # serving the previous client until someone rebuilds it by hand.
+    if: ${{ success() && github.event_name == 'push' && github.repository == 'DaccordProject/daccord' }}
+    steps:
+      - name: Notify accordwebsite of the new web export
+        env:
+          GH_TOKEN: ${{ secrets.ACCORDWEBSITE_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::ACCORDWEBSITE_DISPATCH_TOKEN not set — skipping the daccord.gg rebuild. Trigger accordwebsite's 'Build and publish Docker image' workflow by hand to ship ${{ github.ref_name }} to /chat/."
+            exit 0
+          fi
+          gh api --method POST \
+            repos/DaccordProject/accordwebsite/dispatches \
+            -f event_type=web-export-updated \
+            -f 'client_payload[tag]=${{ github.ref_name }}'
+          echo "Dispatched web-export-updated for ${{ github.ref_name }}."
+
+  # ---------------------------------------------------------------------------
   # App Store deploys. These run on a tag push and on workflow_dispatch (gated
   # by the deploy_ios / deploy_mac inputs). They build the *store* variants
   # (App Sandbox / no self-updater via --dart-define=APP_STORE=true) and upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -656,17 +656,23 @@ jobs:
       - name: Notify accordwebsite of the new web export
         env:
           GH_TOKEN: ${{ secrets.ACCORDWEBSITE_DISPATCH_TOKEN }}
+          # Routed through env rather than interpolated into the script below —
+          # github.ref_name is attacker-influenceable (whoever can push a tag
+          # controls its value) and untrusted expressions must never be spliced
+          # directly into a run: block. See GitHub's script-injection hardening
+          # guidance.
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::ACCORDWEBSITE_DISPATCH_TOKEN not set — skipping the daccord.gg rebuild. Trigger accordwebsite's 'Build and publish Docker image' workflow by hand to ship ${{ github.ref_name }} to /chat/."
+            echo "::warning::ACCORDWEBSITE_DISPATCH_TOKEN not set — skipping the daccord.gg rebuild. Trigger accordwebsite's 'Build and publish Docker image' workflow by hand to ship $TAG to /chat/."
             exit 0
           fi
           gh api --method POST \
             repos/DaccordProject/accordwebsite/dispatches \
             -f event_type=web-export-updated \
-            -f 'client_payload[tag]=${{ github.ref_name }}'
-          echo "Dispatched web-export-updated for ${{ github.ref_name }}."
+            -f "client_payload[tag]=$TAG"
+          echo "Dispatched web-export-updated for $TAG."
 
   # ---------------------------------------------------------------------------
   # App Store deploys. These run on a tag push and on workflow_dispatch (gated


### PR DESCRIPTION
## Problem

`daccord.gg/chat/` was serving the **v0.2.6** web client — two releases behind — while v0.2.9 had been out since 2026-08-05.

The website image bakes in this repo's latest `daccord-web.zip` release asset and serves it under `/chat/`. accordwebsite's build workflow already listens for a `web-export-updated` `repository_dispatch`, but **nothing has ever sent one**. So `/chat/` only refreshed when an unrelated commit happened to land on accordwebsite — the last one was 2026-07-09, which is exactly where the live client was pinned.

Verified by md5-matching the live `flutter_bootstrap.js` against each release's export:

| | `flutter_bootstrap.js` |
|---|---|
| live `daccord.gg/chat/` | `dc1fbe3dc30c` |
| v0.2.6 | `dc1fbe3dc30c` ← |
| v0.2.7 | `d954feea3516` |
| v0.2.9 | `64c852fc05a1` |

## Change

Adds a `website-rebuild` job that fires the dispatch after `release:` completes on a tag push, closing the loop.

Gated on a new `ACCORDWEBSITE_DISPATCH_TOKEN` secret. Consistent with every other optional secret in this workflow, a missing token **warns and skips** rather than failing a tagged release — the website just keeps serving the previous client until someone rebuilds by hand. `GITHUB_TOKEN` can't be used here; it's scoped to this repo and can't dispatch to another one.

## Before this merges

Add repo secret `ACCORDWEBSITE_DISPATCH_TOKEN` — a PAT (or GitHub App token) with `contents: write` on `DaccordProject/accordwebsite`. Until then the job is a no-op warning.

## Out of scope

v0.2.9 has already been shipped to `/chat/` manually: accordwebsite build [31154997290](https://github.com/DaccordProject/accordwebsite/actions/runs/31154997290) published a `:latest` verified to contain the v0.2.9 export with `<base href="/chat/">`. That image still needs redeploying and a Cloudflare `/chat/*` purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)