### PR TITLE
test(e2e): add the multi-instance suite (layer 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ name: CI
 # - `ui-e2e`   : the real app driven on Linux under xvfb against the same
 #                server image. GitHub-hosted (see the job's own note) and also
 #                non-blocking; see integration_test/README.md.
+# - `multi`   : two real app processes driven over the in-app MCP surface,
+#                against the same server image. Non-blocking; the most
+#                expensive suite (release build + two apps).
+#                See multi_instance/README.md.
 # - `build`    : release builds for web / Android / Linux / Windows, uploaded
 #                as artifacts. Only runs on manual `workflow_dispatch` — PRs
 #                don't need four release builds to merge, and tagged releases
@@ -246,6 +250,67 @@ jobs:
             xvfb-run -a flutter test "$f" -d linux || status=1
             echo "::endgroup::"
           done
+          exit $status
+
+  multi-instance:
+    name: Multi-instance (two clients)
+    # GitHub-hosted for the same reason as ui-e2e: it builds and runs the Linux
+    # desktop app, which the Ubuntu 20.04 self-hosted runners can't do.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache pub + native deps
+        uses: actions/cache@v4
+        with:
+          key: pub-${{ runner.os }}-${{ env.FLUTTER_CHANNEL }}-${{ hashFiles('pubspec.lock') }}
+          path: ${{ github.workspace }}/.pub-cache
+          restore-keys: |
+            pub-${{ runner.os }}-${{ env.FLUTTER_CHANNEL }}-
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            clang cmake ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libunwind-dev libdw-dev \
+            libmpv-dev mpv \
+            xvfb xdg-user-dirs
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Code generation (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Pull accordserver image
+        run: docker pull ghcr.io/daccordproject/accordserver:latest
+
+      - name: Build the app
+        # Release, not debug: a debug bundle launched directly never runs its
+        # Dart entrypoint. See multi_instance/README.md.
+        run: flutter build linux --release
+
+      - name: Multi-instance tests
+        shell: bash
+        run: |
+          set -uo pipefail
+          xvfb-run -a flutter test multi_instance/ 2>&1 | tee /tmp/multi.log
+          status=${PIPESTATUS[0]}
+          if grep -qE "^0 tests passed|🎉 0 tests passed" /tmp/multi.log; then
+            echo "::error::No multi-instance tests ran — no server or no app bundle. See multi_instance/README.md."
+            exit 1
+          fi
           exit $status
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ name: CI
 # - `ui-e2e`   : the real app driven on Linux under xvfb against the same
 #                server image. GitHub-hosted (see the job's own note) and also
 #                non-blocking; see integration_test/README.md.
-# - `multi`   : two real app processes driven over the in-app MCP surface,
-#                against the same server image. Non-blocking; the most
-#                expensive suite (release build + two apps).
+# - `multi-instance`: two real app processes driven over the in-app MCP
+#                surface, against the same server image. Non-blocking; the
+#                most expensive suite (release build + two apps).
 #                See multi_instance/README.md.
 # - `build`    : release builds for web / Android / Linux / Windows, uploaded
 #                as artifacts. Only runs on manual `workflow_dispatch` — PRs

--- a/multi_instance/README.md
+++ b/multi_instance/README.md
@@ -1,0 +1,94 @@
+# Multi-instance tests
+
+Layer 3 of #217: **two real app processes**, one server, both sides of every
+interaction asserted.
+
+Layers 1 (`integration/`) and 2 (`integration_test/`) both run inside a single
+process, so they can only check what one client believes. These launch two
+actual clients and drive them through the MCP server the app already exposes in
+Developer Mode — the same JSON-RPC tool surface a developer or an agent would
+use (`lib/features/developer/services/mcp_tools.dart`). No synthetic input: no
+xdotool, no fake clicks.
+
+```bash
+flutter build linux --release          # required — see "Release, not debug"
+flutter test multi_instance/
+```
+
+`flutter test` on its own doesn't pick these up; it only walks `test/`.
+
+## How an instance is made
+
+Per instance, `AppInstance.launch`:
+
+1. Creates a throwaway `HOME` and gives it the XDG layout (see below).
+2. Seeds `accord-settings` with Developer Mode + MCP on, a unique `mcpPort`,
+   and every tool group enabled — the default is `read`/`navigate` only, so
+   anything else 404s.
+3. Seeds `accord-session` with a token from an account the layer-1 harness
+   registered, which is what makes the app come up already signed in: the login
+   screen restores it on its first frame.
+4. Launches the app and waits for its MCP server to answer.
+
+Storage isolation is what keeps two instances from fighting over the same Hive
+boxes, and it's also what stops a test run touching your real profile.
+
+## Four things that cost real time
+
+**Release, not debug.** A *debug* bundle launched directly never runs its Dart
+entrypoint. The engine starts, native plugins register, the GTK loop idles — and
+`main()` never executes, so no Hive box is opened and no MCP server starts. It
+presents as a window that simply does nothing, with no error anywhere.
+`flutter test -d linux` drives debug bundles fine because the tool attaches and
+injects the entrypoint; nothing does that here. `resolveBinary()` prefers
+release for this reason.
+
+**`XDG_DOCUMENTS_DIR` is not what decides where data goes.** Flutter's
+`getApplicationDocumentsDirectory()` on Linux calls `xdg.getUserDirectory`,
+which shells out to the **`xdg-user-dir` executable** and ignores the
+environment variable entirely. Under a fresh `HOME` with no
+`.config/user-dirs.dirs`, that returns `$HOME` itself — not `$HOME/Documents` —
+so seeding the obvious path writes somewhere the app never reads, and the app
+comes up with default settings and no MCP server. `prepareHome` writes a
+`user-dirs.dirs`, and `documentsDirFor` asks `xdg-user-dir` the same question
+the app will, rather than assuming.
+
+**`select_channel` needs the space selected first.** It resolves the id against
+the selected space's channel list, so calling it cold answers "Channel not
+found" for a channel that plainly exists. `openChannel` in the test does both.
+
+**Don't reuse HTTP connections.** A pooled socket the app has since dropped
+fails the next call with "Connection closed before full header was received" —
+it flaked roughly one run in two. Each call now opens its own connection, and
+retries once on a transport error.
+
+## Adding a scenario
+
+`AppInstance.call(tool, args)` unwraps both layers of the response (JSON-RPC
+`result.content[0].text` holds the tool's JSON as a string) and throws on a
+tool-level error. Never assert straight after an action that crosses the
+gateway — use `callUntil`, which polls and fails with a timeout carrying the
+last result it saw.
+
+Note that tool payloads don't always match the REST shapes: `list_members`
+flattens the member onto the user (`id`, `username`, …) where REST nests a
+`user` object under `user_id`.
+
+## Not covered yet: voice
+
+Voice is the strongest reason to have this layer — who hears whom is inherently
+multi-process — but the current tool surface can't express the assertion. The
+`voice` group exposes `join_voice_channel`, `leave_voice` and `toggle_mute`, and
+`get_current_state` reports only the caller's **own** `voice_channel_id` /
+`voice_self_mute`. There's no tool that reports the voice states of *other*
+members, so B has no way to say what it thinks A is doing.
+
+Closing that needs a small addition to `mcp_tools.dart` — a `list_voice_states`
+in the `read` group, say — and then the scenarios (A joins, B sees them; A
+mutes, B sees the mute) are a handful of lines each. Tracked in #222.
+
+## CI
+
+Runs as its own non-blocking job on Linux under xvfb, after a release build. It
+is the most expensive of the three suites (a release build plus two app
+processes), so it's deliberately separate from the merge gate.

--- a/multi_instance/support/app_instance.dart
+++ b/multi_instance/support/app_instance.dart
@@ -182,6 +182,14 @@ class AppInstance {
         'XDG_DATA_HOME': '${home.path}/.local/share',
         'XDG_CONFIG_HOME': '${home.path}/.config',
         'XDG_CACHE_HOME': '${home.path}/.cache',
+        // Under xvfb there's no DRI device ("libEGL warning: DRI3 error"),
+        // and the app can't get a GL context, so it never reaches a first
+        // frame — and the MCP server only starts once the widget tree builds.
+        // llvmpipe is slower but always available.
+        'LIBGL_ALWAYS_SOFTWARE': '1',
+        // Silences "Atk-CRITICAL atk_socket_embed" spam on headless runners,
+        // where there's no accessibility bus to embed into.
+        'NO_AT_BRIDGE': '1',
         if (Platform.environment['DISPLAY'] != null)
           'DISPLAY': Platform.environment['DISPLAY']!,
         if (Platform.environment['WAYLAND_DISPLAY'] != null)
@@ -200,7 +208,10 @@ class AppInstance {
     );
     instance._captureOutput();
 
-    if (!await instance._waitForMcp(const Duration(seconds: 60))) {
+    // Generous because a headless runner on llvmpipe is far slower to a first
+    // frame than a desktop with a GPU, and the MCP server doesn't exist until
+    // the widget tree builds.
+    if (!await instance._waitForMcp(const Duration(seconds: 150))) {
       final log = instance.log;
       await instance.dispose();
       throw AppUnavailable(

--- a/multi_instance/support/app_instance.dart
+++ b/multi_instance/support/app_instance.dart
@@ -1,0 +1,422 @@
+/// Launches real Daccord app processes and drives them through the MCP server
+/// the app already exposes in Developer Mode.
+///
+/// This is how layer 3 (#222) sees both sides of an interaction: two actual
+/// clients, each with its own storage and gateway connection, talking to one
+/// server. No synthetic input — every action goes through the same JSON-RPC
+/// tool surface a developer or an agent would use (`mcp_tools.dart`).
+///
+/// Each instance gets a throwaway `HOME`, so instances can't collide over Hive
+/// boxes and none of them can touch your real profile data. Settings and the
+/// session are seeded before launch, which is what makes the app come up
+/// already signed in with its MCP server listening.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bonfire/features/profiles/services/profile_store.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:hive_ce/hive.dart';
+
+import '../../integration/support/harness.dart';
+
+/// Thrown when no app bundle is available to launch.
+class AppUnavailable implements Exception {
+  AppUnavailable(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'AppUnavailable: $message';
+}
+
+/// One running app process, addressable over its MCP port.
+class AppInstance {
+  AppInstance._({
+    required this.label,
+    required this.port,
+    required this.account,
+    required Directory home,
+    required Process process,
+  })  : _home = home,
+        _process = process;
+
+  /// Human-readable name used in failure messages ("alice", "bob").
+  final String label;
+
+  /// Loopback port this instance's MCP server is listening on.
+  final int port;
+
+  final TestAccount account;
+
+  final Directory _home;
+  final Process _process;
+  final HttpClient _http = HttpClient();
+  final StringBuffer _log = StringBuffer();
+
+  /// Everything the process wrote to stdout/stderr, for failure messages.
+  String get log => _log.toString();
+
+  // ── Driving ───────────────────────────────────────────────────────────────
+
+  /// Calls an MCP tool and returns the tool's own result map.
+  ///
+  /// The transport wraps results twice — JSON-RPC `result.content[0].text`
+  /// holds the tool's JSON as a string — so this unwraps both layers and
+  /// surfaces a tool-level `error` as a thrown [StateError], since every call
+  /// site treats one as a failure.
+  Future<Map<String, dynamic>> call(
+    String tool, [
+    Map<String, dynamic> arguments = const {},
+  ]) async {
+    final response = await _rpc({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'tools/call',
+      'params': {'name': tool, 'arguments': arguments},
+    });
+
+    final error = response['error'];
+    if (error != null) {
+      throw StateError('$label: MCP call $tool failed: $error');
+    }
+
+    final content = (response['result'] as Map)['content'] as List;
+    final decoded =
+        jsonDecode((content.first as Map)['text'] as String) as Map;
+    final result = Map<String, dynamic>.from(decoded);
+    if (result['error'] != null) {
+      throw StateError('$label: tool $tool returned ${result['error']}');
+    }
+    return result;
+  }
+
+  /// Polls [call] until [until] holds.
+  ///
+  /// Anything crossing the gateway takes time to arrive, and a bare call would
+  /// assert against whatever happened to be true in the first millisecond.
+  Future<Map<String, dynamic>> callUntil(
+    String tool,
+    bool Function(Map<String, dynamic> result) until, {
+    Map<String, dynamic> arguments = const {},
+    Duration timeout = const Duration(seconds: 20),
+    Duration interval = const Duration(milliseconds: 250),
+    String? description,
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    Map<String, dynamic>? last;
+    while (DateTime.now().isBefore(deadline)) {
+      last = await call(tool, arguments);
+      if (until(last)) return last;
+      await Future<void>.delayed(interval);
+    }
+    throw TimeoutException(
+      '$label: ${description ?? tool} never satisfied within $timeout '
+      '(last result: $last)',
+    );
+  }
+
+  Future<Map<String, dynamic>> _rpc(Map<String, dynamic> body) async {
+    // One retry, because a keep-alive socket can be closed by the app between
+    // our reuse of it and the request landing — "Connection closed before full
+    // header was received". `persistentConnection: false` below makes that
+    // rare; the retry covers the rest rather than failing a test over a
+    // transport hiccup that says nothing about the app.
+    for (var attempt = 0;; attempt++) {
+      try {
+        return await _rpcOnce(body);
+      } on HttpException {
+        if (attempt >= 1) rethrow;
+      } on SocketException {
+        if (attempt >= 1) rethrow;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  Future<Map<String, dynamic>> _rpcOnce(Map<String, dynamic> body) async {
+    final request =
+        await _http.postUrl(Uri.parse('http://127.0.0.1:$port/mcp'));
+    // Each call gets its own connection: the driver is chatty and long-lived,
+    // and a pooled socket that the app has since dropped fails the next call.
+    request.persistentConnection = false;
+    request.headers.contentType = ContentType.json;
+    request.add(utf8.encode(jsonEncode(body)));
+    final response = await request.close();
+    final text = await response.transform(utf8.decoder).join();
+    if (response.statusCode != 200) {
+      throw StateError('$label: MCP HTTP ${response.statusCode}: $text');
+    }
+    return Map<String, dynamic>.from(jsonDecode(text) as Map);
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /// Seeds a throwaway profile for [account], launches the app against it, and
+  /// waits for the MCP server to answer.
+  static Future<AppInstance> launch({
+    required TestAccount account,
+    required String label,
+    required int port,
+  }) async {
+    final binary = resolveBinary();
+    final home =
+        Directory.systemTemp.createTempSync('accord-instance-$label-');
+    prepareHome(home);
+    await seedProfile(home: home, account: account, port: port);
+
+    final process = await Process.start(
+      binary,
+      const [],
+      environment: {
+        // Everything the app resolves through path_provider hangs off these,
+        // so they're what actually isolates one instance from another — and
+        // from your real profile.
+        'HOME': home.path,
+        // Not what path_provider reads (see documentsDirFor), but keep it
+        // consistent for anything else that honours it.
+        'XDG_DOCUMENTS_DIR': documentsDirFor(home),
+        'XDG_DATA_HOME': '${home.path}/.local/share',
+        'XDG_CONFIG_HOME': '${home.path}/.config',
+        'XDG_CACHE_HOME': '${home.path}/.cache',
+        if (Platform.environment['DISPLAY'] != null)
+          'DISPLAY': Platform.environment['DISPLAY']!,
+        if (Platform.environment['WAYLAND_DISPLAY'] != null)
+          'WAYLAND_DISPLAY': Platform.environment['WAYLAND_DISPLAY']!,
+        if (Platform.environment['XAUTHORITY'] != null)
+          'XAUTHORITY': Platform.environment['XAUTHORITY']!,
+      },
+    );
+
+    final instance = AppInstance._(
+      label: label,
+      port: port,
+      account: account,
+      home: home,
+      process: process,
+    );
+    instance._captureOutput();
+
+    if (!await instance._waitForMcp(const Duration(seconds: 60))) {
+      final log = instance.log;
+      await instance.dispose();
+      throw AppUnavailable(
+        "$label: the app's MCP server never answered on port $port.\n"
+        '--- app output ---\n$log',
+      );
+    }
+    return instance;
+  }
+
+  /// The app bundle to launch: `DACCORD_APP_BIN`, else a local release build,
+  /// else debug.
+  ///
+  /// Release first on purpose. A *debug* bundle launched directly never runs
+  /// its Dart entrypoint — the engine starts, native plugins register and the
+  /// GTK loop idles, but `main()` never executes, so no Hive box is ever
+  /// opened and the MCP server never starts. It presents as a window that
+  /// simply does nothing. `flutter test -d linux` drives debug bundles fine
+  /// because the tool attaches and injects the entrypoint; nothing does that
+  /// here.
+  static String resolveBinary() {
+    final explicit = Platform.environment['DACCORD_APP_BIN'];
+    if (explicit != null && explicit.trim().isNotEmpty) {
+      if (File(explicit).existsSync()) return explicit;
+      throw AppUnavailable('DACCORD_APP_BIN=$explicit does not exist.');
+    }
+    for (final mode in const ['release', 'debug']) {
+      final candidate = File('build/linux/x64/$mode/bundle/daccord').absolute;
+      if (candidate.existsSync()) return candidate.path;
+    }
+    throw AppUnavailable(
+      'No Daccord app bundle found. Build one first:\n'
+      '  flutter build linux --release\n'
+      'or point DACCORD_APP_BIN at an existing bundle.',
+    );
+  }
+
+  /// Where the app will put its data for an instance rooted at [home].
+  ///
+  /// Resolved the same way the app resolves it, rather than assumed: Flutter's
+  /// `getApplicationDocumentsDirectory()` on Linux calls
+  /// `xdg.getUserDirectory('DOCUMENTS')`, which shells out to the
+  /// `xdg-user-dir` **executable** and ignores `XDG_DOCUMENTS_DIR` entirely.
+  /// Under a fresh HOME with no `user-dirs.dirs`, that returns `$HOME` itself,
+  /// not `$HOME/Documents` — so seeding the obvious path silently writes
+  /// somewhere the app never reads, and the app comes up with default settings
+  /// and no MCP server. [prepareHome] writes a `user-dirs.dirs` to make this
+  /// deterministic; this asks the same question the app will.
+  static String documentsDirFor(Directory home) {
+    try {
+      final result = Process.runSync(
+        'xdg-user-dir',
+        ['DOCUMENTS'],
+        environment: {'HOME': home.path},
+        includeParentEnvironment: true,
+      );
+      final path = (result.stdout as String).split('\n').first.trim();
+      if (path.isNotEmpty) return path;
+    } on ProcessException {
+      // xdg-user-dir isn't installed; fall through.
+    }
+    return '${home.path}/Documents';
+  }
+
+  /// Gives an instance home the XDG layout `xdg-user-dir` needs to resolve
+  /// DOCUMENTS inside it.
+  static void prepareHome(Directory home) {
+    Directory('${home.path}/.config').createSync(recursive: true);
+    File('${home.path}/.config/user-dirs.dirs')
+        .writeAsStringSync('XDG_DOCUMENTS_DIR="\$HOME/Documents"\n');
+    Directory('${home.path}/Documents').createSync(recursive: true);
+    // Fontconfig warns loudly on every launch without a writable cache dir.
+    Directory('${home.path}/.cache/fontconfig').createSync(recursive: true);
+  }
+
+  /// Writes the settings and session boxes the app reads at startup.
+  ///
+  /// Hive's home path is process-global, so this initialises, writes and closes
+  /// one instance's storage before the next is seeded. Fine here because
+  /// seeding always happens before any app is launched.
+  @visibleForTesting
+  static Future<void> seedProfile({
+    required Directory home,
+    required TestAccount account,
+    required int port,
+  }) async {
+    final dataDir = Directory('${documentsDirFor(home)}/daccord/data')
+      ..createSync(recursive: true);
+
+    Hive.init(dataDir.path);
+    // The default profile keeps its boxes at the root data dir (see
+    // ProfileStore), so writing them here is what the app will read.
+    final settings = await Hive.openBox(ProfileStore.settingsBoxName);
+    await settings.put('settings', <String, dynamic>{
+      // Developer Mode + MCP are both required before the server runs, and the
+      // default allowed groups are read/navigate only — the rest have to be
+      // asked for explicitly or every other tool 404s.
+      'developerMode': true,
+      'mcpEnabled': true,
+      'mcpPort': port,
+      'mcpToken': '',
+      'mcpAllowedGroups': AccordSettings.mcpToolGroups,
+      // Same first-launch suppressions the other layers need: dialogs would
+      // sit on top of the UI, and the updater would stage a real download.
+      'notificationsEnabled': false,
+      'autoUpdateCheck': false,
+      'errorReportingConsentShown': true,
+      'soundsEnabled': false,
+    });
+    await settings.put('onboarding-seen-version', '99.0.0');
+    await settings.put('release-notes-seen-version', '99.0.0');
+
+    // Persisting a session is what makes the app come up signed in: the login
+    // screen restores it on its first frame.
+    final session = await Hive.openBox(ProfileStore.sessionBoxName);
+    final json = account.session.toJson();
+    await session.put('session', json);
+    await session.put('accounts', [json]);
+
+    await Hive.close();
+  }
+
+  void _captureOutput() {
+    void sink(Stream<List<int>> stream) {
+      stream.transform(utf8.decoder).listen(_log.write, onError: (_) {});
+    }
+
+    sink(_process.stdout);
+    sink(_process.stderr);
+  }
+
+  Future<bool> _waitForMcp(Duration timeout) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      try {
+        final response = await _rpc({
+          'jsonrpc': '2.0',
+          'id': 0,
+          'method': 'initialize',
+          'params': <String, dynamic>{},
+        });
+        if (response['result'] != null) return true;
+      } on Object {
+        // Not listening yet.
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+    }
+    return false;
+  }
+
+  /// Kills the process and removes its throwaway home.
+  Future<void> dispose() async {
+    _http.close(force: true);
+    _process.kill(ProcessSignal.sigterm);
+    await _process.exitCode.timeout(
+      const Duration(seconds: 10),
+      onTimeout: () {
+        _process.kill(ProcessSignal.sigkill);
+        return -1;
+      },
+    );
+    if (_home.existsSync()) _home.deleteSync(recursive: true);
+  }
+}
+
+/// A set of app instances sharing one server, torn down together.
+class AppFleet {
+  AppFleet._(this.harness, this.skipReason);
+
+  final IntegrationHarness harness;
+
+  /// Non-null when the fleet can't run — pass as a group's `skip:`.
+  final String? skipReason;
+
+  final List<AppInstance> _instances = [];
+  int _nextPort = 39150;
+
+  /// Resolves a server and an app bundle, or explains why it can't.
+  static Future<AppFleet> resolve() async {
+    final harness = await IntegrationHarness.resolve();
+    if (harness.skipReason != null) {
+      return AppFleet._(harness, harness.skipReason);
+    }
+    try {
+      AppInstance.resolveBinary();
+    } on AppUnavailable catch (e) {
+      return AppFleet._(harness, e.message);
+    }
+    if (Platform.environment['DISPLAY'] == null &&
+        Platform.environment['WAYLAND_DISPLAY'] == null) {
+      return AppFleet._(
+        harness,
+        'No DISPLAY. These launch real app windows — run under xvfb '
+        '(`xvfb-run -a flutter test multi_instance/`) or on a desktop session.',
+      );
+    }
+    return AppFleet._(harness, null);
+  }
+
+  /// Registers an account and launches an app signed in as it.
+  Future<AppInstance> spawn(String label, {TestAccount? account}) async {
+    final resolved = account ?? await harness.newAccount(label);
+    final instance = await AppInstance.launch(
+      account: resolved,
+      label: label,
+      port: _nextPort++,
+    );
+    _instances.add(instance);
+    return instance;
+  }
+
+  Future<void> dispose() async {
+    for (final instance in _instances) {
+      await instance.dispose();
+    }
+    _instances.clear();
+    await harness.dispose();
+  }
+}

--- a/multi_instance/support/app_instance.dart
+++ b/multi_instance/support/app_instance.dart
@@ -229,9 +229,21 @@ class AppInstance {
     // the widget tree builds.
     if (!await instance._waitForMcp(const Duration(seconds: 150))) {
       final log = instance.log;
+      // The usual cause is a seed/read mismatch on where the app keeps its
+      // data, which is invisible from the app's own output — so report both
+      // sides of it here rather than leaving the next person to rediscover it.
+      final documents = documentsDirFor(home);
+      final dataDir = Directory('$documents/daccord/data');
+      final seeded = dataDir.existsSync()
+          ? dataDir.listSync().map((e) => e.uri.pathSegments.last).toList()
+          : const <String>[];
       await instance.dispose();
       throw AppUnavailable(
         "$label: the app's MCP server never answered on port $port.\n"
+        'documents dir: $documents\n'
+        'files there:   $seeded\n'
+        '(if that list is empty or lacks accord-settings.hive, the app and '
+        'this launcher disagree about where data lives)\n'
         '--- app output ---\n$log',
       );
     }
@@ -296,7 +308,16 @@ class AppInstance {
       final result = Process.runSync(
         'xdg-user-dir',
         ['DOCUMENTS'],
-        environment: {'HOME': home.path},
+        // The same XDG environment the app is launched with, or the two
+        // disagree: `xdg-user-dir` reads `$XDG_CONFIG_HOME/user-dirs.dirs`,
+        // and a runner that exports its own XDG_CONFIG_HOME would send this
+        // lookup to the runner's config while the app reads the instance's.
+        // Seeding one path and reading another is silent — the app just comes
+        // up with default settings and no MCP server.
+        environment: {
+          'HOME': home.path,
+          'XDG_CONFIG_HOME': '${home.path}/.config',
+        },
         includeParentEnvironment: true,
       );
       final path = (result.stdout as String).split('\n').first.trim();

--- a/multi_instance/support/app_instance.dart
+++ b/multi_instance/support/app_instance.dart
@@ -23,6 +23,22 @@ import 'package:hive_ce/hive.dart';
 
 import '../../integration/support/harness.dart';
 
+/// Which bundle (if any) [AppInstance.resolveBinary] should launch, given
+/// what's on disk. Split out as a pure decision so the "release only, never
+/// debug" policy can be exercised without touching the filesystem — see
+/// [AppInstance.resolveBinary] for why debug is never an acceptable fallback.
+enum BundleChoice { release, debugOnly, none }
+
+@visibleForTesting
+BundleChoice chooseBundle({
+  required bool releaseExists,
+  required bool debugExists,
+}) {
+  if (releaseExists) return BundleChoice.release;
+  if (debugExists) return BundleChoice.debugOnly;
+  return BundleChoice.none;
+}
+
 /// Thrown when no app bundle is available to launch.
 class AppUnavailable implements Exception {
   AppUnavailable(this.message);
@@ -211,31 +227,46 @@ class AppInstance {
     return instance;
   }
 
-  /// The app bundle to launch: `DACCORD_APP_BIN`, else a local release build,
-  /// else debug.
+  /// The app bundle to launch: `DACCORD_APP_BIN`, else a local release build.
   ///
-  /// Release first on purpose. A *debug* bundle launched directly never runs
-  /// its Dart entrypoint — the engine starts, native plugins register and the
-  /// GTK loop idles, but `main()` never executes, so no Hive box is ever
-  /// opened and the MCP server never starts. It presents as a window that
-  /// simply does nothing. `flutter test -d linux` drives debug bundles fine
-  /// because the tool attaches and injects the entrypoint; nothing does that
-  /// here.
+  /// Release only — a debug build is never picked, even as a fallback. A
+  /// *debug* bundle launched directly never runs its Dart entrypoint — the
+  /// engine starts, native plugins register and the GTK loop idles, but
+  /// `main()` never executes, so no Hive box is ever opened and the MCP
+  /// server never starts. It presents as a window that simply does nothing.
+  /// `flutter test -d linux` drives debug bundles fine because the tool
+  /// attaches and injects the entrypoint; nothing does that here — so
+  /// resolving to one would only trade an immediate, actionable error for
+  /// [launch] burning its full 60s startup timeout on a bundle that was never
+  /// going to answer.
   static String resolveBinary() {
     final explicit = Platform.environment['DACCORD_APP_BIN'];
     if (explicit != null && explicit.trim().isNotEmpty) {
       if (File(explicit).existsSync()) return explicit;
       throw AppUnavailable('DACCORD_APP_BIN=$explicit does not exist.');
     }
-    for (final mode in const ['release', 'debug']) {
-      final candidate = File('build/linux/x64/$mode/bundle/daccord').absolute;
-      if (candidate.existsSync()) return candidate.path;
+    final release = File('build/linux/x64/release/bundle/daccord').absolute;
+    final debug = File('build/linux/x64/debug/bundle/daccord').absolute;
+    switch (chooseBundle(
+      releaseExists: release.existsSync(),
+      debugExists: debug.existsSync(),
+    )) {
+      case BundleChoice.release:
+        return release.path;
+      case BundleChoice.debugOnly:
+        throw AppUnavailable(
+          'Only a debug build exists at ${debug.path}, and a debug bundle '
+          "launched directly never runs main() — its MCP server would never "
+          'start (see resolveBinary). Build a release bundle instead:\n'
+          '  flutter build linux --release',
+        );
+      case BundleChoice.none:
+        throw AppUnavailable(
+          'No Daccord app bundle found. Build one first:\n'
+          '  flutter build linux --release\n'
+          'or point DACCORD_APP_BIN at an existing bundle.',
+        );
     }
-    throw AppUnavailable(
-      'No Daccord app bundle found. Build one first:\n'
-      '  flutter build linux --release\n'
-      'or point DACCORD_APP_BIN at an existing bundle.',
-    );
   }
 
   /// Where the app will put its data for an instance rooted at [home].

--- a/multi_instance/two_clients_test.dart
+++ b/multi_instance/two_clients_test.dart
@@ -1,0 +1,222 @@
+/// Two real app processes, one server, both sides of every interaction
+/// asserted (#222).
+///
+/// Layers 1 and 2 both run inside a single process, so they can only ever
+/// check what one client believes. These launch two actual clients and drive
+/// them through the MCP surface the app already exposes, which is the only way
+/// to assert that what A did is what B sees.
+///
+/// See `multi_instance/README.md`.
+library;
+
+import 'package:accordkit/accordkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/app_instance.dart';
+
+Future<void> main() async {
+  final fleet = await AppFleet.resolve();
+
+  group('two clients', () {
+    late AppInstance alice;
+    late AppInstance bob;
+    late String spaceId;
+    late String channelId;
+
+    setUpAll(() async {
+      // Accounts and the space are set up over REST first: an app instance
+      // that starts before its user is a member would come up with an empty
+      // rail, and the point here is to drive UI state, not to test joining.
+      final aliceAccount = await fleet.harness.newAccount('alice');
+      final bobAccount = await fleet.harness.newAccount('bob');
+
+      final space = await aliceAccount.client.spaces.create({
+        'name': 'Fleet Space',
+        'public': true,
+      });
+      expect(space.ok, isTrue, reason: '${space.error}');
+      spaceId = (space.data! as AccordSpace).id;
+
+      final channels = await aliceAccount.client.spaces.listChannels(spaceId);
+      channelId = (channels.data! as List)
+          .cast<AccordChannel>()
+          .firstWhere((c) => c.type == 'text')
+          .id;
+
+      final joined = await bobAccount.client.spaces.join(spaceId);
+      expect(joined.ok, isTrue, reason: '${joined.error}');
+
+      alice = await fleet.spawn('alice', account: aliceAccount);
+      bob = await fleet.spawn('bob', account: bobAccount);
+    });
+
+    tearDownAll(fleet.dispose);
+
+    /// Opens the shared channel on [client].
+    ///
+    /// `select_channel` resolves the id against the *selected space's* channel
+    /// list, so selecting the space first isn't optional — without it the tool
+    /// answers "Channel not found" for a channel that plainly exists.
+    Future<void> openChannel(AppInstance client) async {
+      await client.call('select_space', {'space_id': spaceId});
+      await client.callUntil(
+        'get_current_state',
+        (r) => r['space_id'] == spaceId,
+        description: 'the space to be selected',
+      );
+      await client.call('select_channel', {'channel_id': channelId});
+      await client.callUntil(
+        'get_current_state',
+        (r) => r['channel_id'] == channelId,
+        description: 'the channel to be selected',
+      );
+    }
+
+    test('both clients come up signed in and see the space', () async {
+      for (final client in [alice, bob]) {
+        final spaces = await client.callUntil(
+          'list_spaces',
+          (r) => (r['spaces'] as List?)?.any((s) => s['id'] == spaceId) ?? false,
+          description: 'the shared space in list_spaces',
+        );
+        expect(spaces['ok'], isTrue);
+      }
+    }, timeout: _generous);
+
+    test('navigation moves the real UI, and the client reports it', () async {
+      await openChannel(alice);
+
+      final state = await alice.call('get_current_state');
+      expect(state['channel_id'], channelId);
+      expect(state['space_id'], spaceId);
+    }, timeout: _generous);
+
+    test("a message alice sends arrives in bob's client", () async {
+      await openChannel(alice);
+      await openChannel(bob);
+
+      const content = 'sent from one app process to another';
+      await alice.call('send_message', {
+        'channel_id': channelId,
+        'content': content,
+      });
+
+      // Nothing in bob's process refetched — this arrives over his own
+      // gateway connection, into his own cache, in his own process.
+      final messages = await bob.callUntil(
+        'list_messages',
+        (r) => (r['messages'] as List?)
+                ?.any((m) => m['content'] == content) ??
+            false,
+        arguments: {'channel_id': channelId, 'limit': 20},
+        description: "alice's message in bob's list_messages",
+      );
+
+      final delivered = (messages['messages'] as List)
+          .firstWhere((m) => m['content'] == content) as Map;
+      expect(delivered['author_id'], alice.account.userId);
+    }, timeout: _generous);
+
+    test("a message bob sends arrives in alice's client", () async {
+      const content = 'and back the other way';
+      await bob.call('send_message', {
+        'channel_id': channelId,
+        'content': content,
+      });
+
+      await alice.callUntil(
+        'list_messages',
+        (r) => (r['messages'] as List?)
+                ?.any((m) => m['content'] == content) ??
+            false,
+        arguments: {'channel_id': channelId, 'limit': 20},
+        description: "bob's message in alice's list_messages",
+      );
+    }, timeout: _generous);
+
+    test('each client sees the other in the member list', () async {
+      final fromAlice = await alice.callUntil(
+        'list_members',
+        (r) => (r['members'] as List?)
+                ?.any((m) => _memberId(m) == bob.account.userId) ??
+            false,
+        arguments: {'space_id': spaceId},
+        description: 'bob in alice\'s member list',
+      );
+      expect(fromAlice['ok'], isTrue);
+
+      await bob.callUntil(
+        'list_members',
+        (r) => (r['members'] as List?)
+                ?.any((m) => _memberId(m) == alice.account.userId) ??
+            false,
+        arguments: {'space_id': spaceId},
+        description: 'alice in bob\'s member list',
+      );
+    }, timeout: _generous);
+
+    test('an edit by alice reaches bob, and so does a delete', () async {
+      const original = 'before the edit';
+      const edited = 'after the edit';
+
+      await alice.call('send_message', {
+        'channel_id': channelId,
+        'content': original,
+      });
+
+      final seen = await bob.callUntil(
+        'list_messages',
+        (r) => (r['messages'] as List?)
+                ?.any((m) => m['content'] == original) ??
+            false,
+        arguments: {'channel_id': channelId, 'limit': 20},
+        description: 'the original message in bob\'s client',
+      );
+      final messageId = ((seen['messages'] as List)
+          .firstWhere((m) => m['content'] == original) as Map)['id'] as String;
+
+      await alice.call('edit_message', {
+        'message_id': messageId,
+        'content': edited,
+      });
+      await bob.callUntil(
+        'list_messages',
+        (r) => (r['messages'] as List?)?.any(
+              (m) => m['id'] == messageId && m['content'] == edited,
+            ) ??
+            false,
+        arguments: {'channel_id': channelId, 'limit': 20},
+        description: 'the edit in bob\'s client',
+      );
+
+      await alice.call('delete_message', {'message_id': messageId});
+      await bob.callUntil(
+        'list_messages',
+        (r) =>
+            (r['messages'] as List?)?.every((m) => m['id'] != messageId) ??
+            false,
+        arguments: {'channel_id': channelId, 'limit': 20},
+        description: 'the delete in bob\'s client',
+      );
+    }, timeout: _generous);
+  }, skip: fleet.skipReason);
+}
+
+/// Cross-process assertions poll two app processes over the gateway, which the
+/// 30-second default doesn't comfortably cover.
+const _generous = Timeout(Duration(minutes: 3));
+
+/// The user a member entry refers to.
+///
+/// `list_members` flattens the member onto the user (`id`, `username`,
+/// `display_name`, `roles`), unlike the REST shape which nests a `user` object
+/// under `user_id`. Both are accepted so this keeps working if the tool is
+/// ever changed to match REST.
+String? _memberId(Object? member) {
+  if (member is! Map) return null;
+  final id = member['id'];
+  if (id != null) return id.toString();
+  final user = member['user'];
+  if (user is Map && user['id'] != null) return user['id'].toString();
+  return member['user_id']?.toString();
+}

--- a/multi_instance/two_clients_test.dart
+++ b/multi_instance/two_clients_test.dart
@@ -15,6 +15,35 @@ import 'package:flutter_test/flutter_test.dart';
 import 'support/app_instance.dart';
 
 Future<void> main() async {
+  // Always runs, unlike the rest of this file: no fleet, no display, no
+  // server. `list_members` flattens the member onto the user, unlike the
+  // REST shape which nests it under `user_id` — this is the one piece of
+  // parsing logic in the suite worth covering directly.
+  group('_memberId', () {
+    test('flattened id (the shape list_members actually returns)', () {
+      expect(_memberId({'id': 'u1', 'username': 'alice'}), 'u1');
+    });
+
+    test('nested user.id (REST shape, kept for resilience)', () {
+      expect(
+        _memberId({
+          'user_id': 'u1',
+          'user': {'id': 'u1', 'username': 'alice'},
+        }),
+        'u1',
+      );
+    });
+
+    test('user_id fallback with no nested user object', () {
+      expect(_memberId({'user_id': 'u1'}), 'u1');
+    });
+
+    test('not a map', () {
+      expect(_memberId('u1'), isNull);
+      expect(_memberId(null), isNull);
+    });
+  });
+
   final fleet = await AppFleet.resolve();
 
   group('two clients', () {
@@ -156,6 +185,12 @@ Future<void> main() async {
     }, timeout: _generous);
 
     test('an edit by alice reaches bob, and so does a delete', () async {
+      // Self-contained rather than relying on an earlier test having left the
+      // channel selected: tests within a group run in declaration order, but
+      // nothing here should depend on that order being preserved.
+      await openChannel(alice);
+      await openChannel(bob);
+
       const original = 'before the edit';
       const edited = 'after the edit';
 

--- a/test/multi_instance/app_instance_test.dart
+++ b/test/multi_instance/app_instance_test.dart
@@ -1,6 +1,8 @@
 /// Unit coverage for the pure decisions in
 /// `multi_instance/support/app_instance.dart` — fast and hermetic, unlike the
 /// suite itself which needs a display, a built release bundle, and a server.
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../multi_instance/support/app_instance.dart';

--- a/test/multi_instance/app_instance_test.dart
+++ b/test/multi_instance/app_instance_test.dart
@@ -1,0 +1,42 @@
+/// Unit coverage for the pure decisions in
+/// `multi_instance/support/app_instance.dart` — fast and hermetic, unlike the
+/// suite itself which needs a display, a built release bundle, and a server.
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../multi_instance/support/app_instance.dart';
+
+void main() {
+  group('chooseBundle', () {
+    test('prefers release when both exist', () {
+      expect(
+        chooseBundle(releaseExists: true, debugExists: true),
+        BundleChoice.release,
+      );
+    });
+
+    test('release only', () {
+      expect(
+        chooseBundle(releaseExists: true, debugExists: false),
+        BundleChoice.release,
+      );
+    });
+
+    test(
+      'never falls back to debug — a debug bundle launched directly never '
+      'runs main(), so it is reported distinctly rather than picked',
+      () {
+        expect(
+          chooseBundle(releaseExists: false, debugExists: true),
+          BundleChoice.debugOnly,
+        );
+      },
+    );
+
+    test('neither exists', () {
+      expect(
+        chooseBundle(releaseExists: false, debugExists: false),
+        BundleChoice.none,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Layer 3 of #217. Completes the three-layer plan: layers 1 and 2 landed in #219.

Two real app processes against one server, driven through the MCP server the app already exposes in Developer Mode (`mcp_tools.dart`). Layers 1 and 2 both run inside a single process, so they can only check what one client believes — this asserts that what A did is what B sees. No synthetic input: no xdotool, no fake clicks.

**Six scenarios, ~9s** once the app is built: both clients come up signed in, navigation moves the real UI, a message crosses in each direction, each client sees the other in the member list, and an edit and a delete propagate. Five consecutive clean runs locally.

## How an instance is made

Throwaway `HOME`, with `accord-settings` (Developer Mode + MCP + a unique port + all tool groups — the default is `read`/`navigate` only) and `accord-session` (a token from a layer-1 account) seeded before launch. The app comes up already signed in with its MCP server listening. Isolation keeps the two instances off each other's Hive boxes and off your real profile.

## Four findings worth reading

1. **A debug bundle launched directly never runs its Dart entrypoint.** The engine starts, native plugins register, the GTK loop idles — `main()` never executes, so no Hive box opens and no MCP server starts. No error anywhere; it presents as a window that does nothing. `flutter test -d linux` works only because the tool attaches and injects the entrypoint. Release is now preferred, and this is why the CI job builds release.
2. **`XDG_DOCUMENTS_DIR` doesn't decide where app data goes.** `getApplicationDocumentsDirectory()` shells out to the **`xdg-user-dir` executable** and ignores the env var. Under a fresh `HOME` with no `user-dirs.dirs` it returns `$HOME`, not `$HOME/Documents` — so seeding the obvious path wrote where the app never looks, and it came up with default settings and no MCP. The launcher now writes a `user-dirs.dirs` and asks `xdg-user-dir` the same question the app will.
3. **`select_channel` must follow `select_space`** — it resolves against the selected space's channel list, and answers "Channel not found" for a channel that plainly exists otherwise.
4. **HTTP keep-alive flaked ~1 run in 2** ("Connection closed before full header was received") — a pooled socket the app had dropped. Each call now opens its own connection, with one retry on transport errors.

## Voice is deliberately not covered

It's the strongest reason to have this layer, and the current tool surface can't express the assertion: `get_current_state` reports only the caller's **own** `voice_channel_id`/`voice_self_mute`, and nothing reports other members' voice states. B has no way to say what it thinks A is doing.

A small addition to `mcp_tools.dart` — a `list_voice_states` in the `read` group — makes the scenarios a handful of lines each. Left out rather than faked; noted in the README and on #222.

## CI

New non-blocking `multi-instance` job on Linux under xvfb, after a release build, with the same no-op guard as `integration` (a suite that skips everything must not report success). GitHub-hosted for the same reason as `ui-e2e`: the self-hosted runners are Ubuntu 20.04 and can't build the Linux desktop app.

Refs #217, #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)