### PR TITLE
fix(ios): clear the App Review 2.5.1 rejection and submit Apple releases from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ on:
         type: boolean
         default: true
       deploy_mac:
-        description: "Build the Mac App Store build, upload it and submit it for review"
+        description: "Build the Mac App Store build and upload it (no review submission — see docs)"
         type: boolean
         default: true
       deploy_android:
@@ -930,11 +930,12 @@ jobs:
             --dart-define=APP_STORE=true \
             --dart-define=SENTRY_DSN="${SENTRY_DSN:-}"
 
-      - name: Generate What's New
-        # See the iOS job: Apple rejects a submission with no release notes.
-        run: ./dist/app-store-release-notes.sh
-
-      - name: Archive, sign, upload & submit for review
+      - name: Archive, sign & upload
+        # Upload only, no review submission: the macOS product page has never
+        # been filled in, so there is nothing to submit yet and deliver's
+        # metadata step hard-fails on the missing review detail. See the
+        # :appstore lane and docs/app-store-deploy.md. No release notes are
+        # generated here for the same reason — nothing delivers them.
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ on:
   workflow_dispatch:
     inputs:
       deploy_ios:
-        description: "Build + upload the iOS App Store build to TestFlight"
+        description: "Build the iOS App Store build, upload it and submit it for review"
         type: boolean
         default: true
       deploy_mac:
-        description: "Build + upload the Mac App Store build to App Store Connect"
+        description: "Build the Mac App Store build, upload it and submit it for review"
         type: boolean
         default: true
       deploy_android:
@@ -691,6 +691,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + tags: the What's New text is derived from the commits
+          # since the previous release tag, which a shallow clone cannot see.
+          fetch-depth: 0
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -777,13 +781,21 @@ jobs:
         run: |
           BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/^version:[[:space:]]*//; s/[-+].*//')
           echo "App Store marketing version: $BUILD_NAME (build ${{ github.run_number }})"
+          # Reused by the submit step so deliver edits the same version record
+          # that CFBundleShortVersionString declares.
+          echo "APP_STORE_VERSION=$BUILD_NAME" >> "$GITHUB_ENV"
           flutter build ios --release --no-codesign \
             --build-name="$BUILD_NAME" \
             --build-number=${{ github.run_number }} \
             --dart-define=APP_STORE=true \
             --dart-define=SENTRY_DSN="${SENTRY_DSN:-}"
 
-      - name: Archive, sign & upload to TestFlight
+      - name: Generate What's New
+        # Apple rejects a version submission with no release notes, so they have
+        # to be produced unattended. See dist/app-store-release-notes.sh.
+        run: ./dist/app-store-release-notes.sh
+
+      - name: Archive, sign, upload & submit for review
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -791,7 +803,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APP_BUNDLE_ID: com.cattrall.daccord
           IOS_PROFILE_NAME: ${{ secrets.IOS_PROFILE_NAME }}
-        run: bundle exec fastlane ios beta
+        run: bundle exec fastlane ios appstore
 
   mac-appstore:
     name: Mac App Store
@@ -803,6 +815,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # See the iOS job: the release notes need the tag history.
+          fetch-depth: 0
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -905,6 +920,8 @@ jobs:
         run: |
           BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/^version:[[:space:]]*//; s/[-+].*//')
           echo "App Store marketing version: $BUILD_NAME (build ${{ github.run_number }})"
+          # Reused by the submit step (see the iOS job's note).
+          echo "APP_STORE_VERSION=$BUILD_NAME" >> "$GITHUB_ENV"
           # NOTE: flutter build macos has no --no-codesign flag (iOS-only); gym
           # re-signs on export.
           flutter build macos --release \
@@ -913,7 +930,11 @@ jobs:
             --dart-define=APP_STORE=true \
             --dart-define=SENTRY_DSN="${SENTRY_DSN:-}"
 
-      - name: Archive, sign & upload to App Store Connect
+      - name: Generate What's New
+        # See the iOS job: Apple rejects a submission with no release notes.
+        run: ./dist/app-store-release-notes.sh
+
+      - name: Archive, sign, upload & submit for review
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 /android/build/
+
+# Generated at release time by dist/app-store-release-notes.sh — the App Store
+# "What's New" text is derived from the commit range, not committed.
+/fastlane/metadata/
+/fastlane/report.xml

--- a/dist/app-store-release-notes.sh
+++ b/dist/app-store-release-notes.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Generate the App Store "What's New" text for a tagged release.
+#
+# Apple requires release notes on every version submission — a submission
+# without them fails App Store Connect validation — so CI has to produce them
+# unattended. This derives them from the commits between the previous release
+# tag and HEAD, mirroring what `generate_release_notes: true` does for the
+# GitHub Release, and writes one copy per Apple platform into the deliver
+# metadata tree that `fastlane ios appstore` / `fastlane mac appstore` upload.
+#
+# Usage: dist/app-store-release-notes.sh
+#
+# Requires the full history and tags (`actions/checkout` with fetch-depth: 0);
+# with a shallow clone there is no previous tag to diff against and the script
+# falls back to the generic note rather than failing the release.
+set -euo pipefail
+
+# Deliver reads <metadata_path>/<lang>/release_notes.txt. The two platforms get
+# separate trees so a future iOS-only or macOS-only note doesn't need a fork.
+LANG_DIR="en-US"
+TARGETS=("fastlane/metadata/ios/$LANG_DIR" "fastlane/metadata/mac/$LANG_DIR")
+
+# Apple caps What's New at 4000 characters.
+MAX_CHARS=4000
+
+# Generic text used when there is nothing better to say. Never empty: an empty
+# release_notes.txt is exactly the validation failure this script exists to
+# avoid.
+FALLBACK="Bug fixes and performance improvements."
+
+previous_tag() {
+  # The release tag before the one being built. `git describe` walks back from
+  # HEAD's parent so the tag currently being released is never its own
+  # predecessor. Release candidates are skipped — a stable release's notes
+  # should span everything since the last *stable* release, not since its last
+  # rc.
+  git describe --tags --abbrev=0 --exclude='*-rc*' HEAD^ 2>/dev/null || true
+}
+
+# Subjects of the user-facing commits in the range, newest first, as a bullet
+# list. Merge commits are dropped (they restate the PR title, which is already
+# the squashed commit's subject), and so is the release's own version bump.
+subjects() {
+  local range="$1"
+  git log --no-merges --pretty=format:'%s' "$range" 2>/dev/null |
+    grep -vE '^chore: bump to ' || true
+}
+
+# Conventional-commit types users actually see in the app. `ci:`, `chore:`,
+# `test:`, `docs:`, `build:` and `refactor:` are real work but say nothing to
+# someone reading the store listing, so they are filtered out — unless that
+# leaves nothing at all, in which case the unfiltered list is better than the
+# generic fallback.
+user_facing() {
+  grep -E '^(feat|fix|perf)(\([^)]*\))?!?: ' || true
+}
+
+# Strip the conventional-commit prefix and bullet the rest: "feat(voice): add x"
+# becomes "• Add x". Store readers are not reading a changelog.
+prettify() {
+  sed -E 's/^(feat|fix|perf)(\([^)]*\))?!?: //' |
+    sed -E 's/^(.)/\U\1/' |
+    sed -E 's/^/• /'
+}
+
+main() {
+  local prev range raw notes
+  prev="$(previous_tag)"
+  if [ -n "$prev" ]; then
+    range="$prev..HEAD"
+    echo "Release notes range: $range"
+  else
+    # No previous tag reachable (shallow clone, or the very first release).
+    range=""
+    echo "No previous tag found — using the fallback note."
+  fi
+
+  notes=""
+  if [ -n "$range" ]; then
+    raw="$(subjects "$range")"
+    notes="$(printf '%s\n' "$raw" | user_facing | prettify)"
+    # Nothing user-facing in this range: fall back to every non-merge subject
+    # before giving up on specifics entirely.
+    if [ -z "$notes" ]; then
+      notes="$(printf '%s\n' "$raw" | sed -E 's/^/• /')"
+    fi
+  fi
+
+  # Trailing whitespace-only output counts as empty.
+  if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+    notes="$FALLBACK"
+  fi
+
+  # Truncate on a bullet boundary so the text never ends mid-sentence.
+  if [ "${#notes}" -gt "$MAX_CHARS" ]; then
+    notes="$(printf '%s' "$notes" | head -c "$MAX_CHARS" | sed '$d')"
+    echo "::warning::Release notes exceeded $MAX_CHARS characters and were truncated."
+  fi
+
+  for dir in "${TARGETS[@]}"; do
+    mkdir -p "$dir"
+    printf '%s\n' "$notes" > "$dir/release_notes.txt"
+    echo "Wrote $dir/release_notes.txt"
+  done
+
+  echo "--- What's New ---"
+  printf '%s\n' "$notes"
+  echo "------------------"
+}
+
+main "$@"

--- a/dist/app-store-release-notes.sh
+++ b/dist/app-store-release-notes.sh
@@ -15,6 +15,14 @@
 # falls back to the generic note rather than failing the release.
 set -euo pipefail
 
+# Byte-oriented throughout: the iOS/macOS release jobs run on macos-15 runners,
+# whose default locale can vary, and forcing C here keeps `${#notes}` (used for
+# the length check below) and `head -c` (used to truncate) counting the same
+# units. A touch more conservative than counting Unicode characters — a
+# multi-byte bullet can trip the cap a few bytes before 4000 real characters —
+# but Apple's limit is never exceeded, which is what matters.
+export LC_ALL=C
+
 # Deliver reads <metadata_path>/<lang>/release_notes.txt. The two platforms get
 # separate trees so a future iOS-only or macOS-only note doesn't need a fork.
 LANG_DIR="en-US"
@@ -57,9 +65,15 @@ user_facing() {
 
 # Strip the conventional-commit prefix and bullet the rest: "feat(voice): add x"
 # becomes "• Add x". Store readers are not reading a changelog.
+#
+# Capitalization uses awk, not GNU sed's \U — the iOS/macOS release jobs run on
+# macos-15, whose default /usr/bin/sed is BSD sed and doesn't support \U. It
+# would silently mangle every bullet in the actual App Store submission
+# ("• Uadd x" instead of "• Add x") rather than error, so this only shows up by
+# reading the generated text.
 prettify() {
   sed -E 's/^(feat|fix|perf)(\([^)]*\))?!?: //' |
-    sed -E 's/^(.)/\U\1/' |
+    awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }' |
     sed -E 's/^/• /'
 }
 

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -158,3 +158,43 @@ about a day; the build sits in *Waiting for Review* → *In Review* and then goe
 live on its own (`automatic_release: true`). Google's review gates the
 `production` rollout the same way. "All the way to production" means *submitted
 and set to ship*, not *live within minutes*.
+
+## Guideline 2.5.1: no libmpv in the iOS build
+
+iOS 0.2.6 (build 141, submitted 2026-07-09) was **rejected** under App Store
+guideline *2.5.1 Performance: Software Requirements* — Apple's automated binary
+scan reported "the app uses or references non-public or deprecated APIs".
+
+The offender was `media_kit_libs_ios_video`, which vendors a prebuilt
+`Mpv.xcframework` (libmpv + FFmpeg). Of everything linked into the iOS app it
+was the only binary referencing APIs an iOS app may not use:
+
+```
+$ llvm-nm -u Mpv.framework/Mpv | grep -E '^_(fork|execve|setsid|waitpid|kill)$'
+_execve _fork _kill _setsid _waitpid
+```
+
+— mpv's POSIX subprocess and TTY layer (`tcgetattr`/`tcsetattr`/`tcgetpgrp`,
+`shm_open`) — plus `EAGLContext` and `CVOpenGLESTextureCache*`, i.e. OpenGL ES,
+which Apple deprecated in iOS 12. `media_kit_video`'s own iOS plugin renders
+through that same OpenGL ES path and compiles with `GL_SILENCE_DEPRECATION`.
+Every other embedded binary (WebRTC, the FFmpeg libs, libxml2, …) was clean.
+
+So **iOS does not get media_kit**. `pubspec.yaml` lists media_kit's native libs
+per platform (`media_kit_libs_android_video`, `_macos_video`, `_windows_video`,
+`_linux`) instead of the `media_kit_libs_video` umbrella, deliberately omitting
+the iOS package. With no `media_kit_libs_ios_*` in `pubspec.lock`,
+`media_kit_video`'s iOS podspec falls back to `Classes/stub` — a no-op plugin
+registrar — and nothing of mpv reaches the binary.
+
+Video attachments on iOS play through `package:video_player`'s AVFoundation
+backend instead (`lib/features/messaging/views/inline_video_player.dart`);
+`main.dart` passes `iOS: false` to `VideoPlayerMediaKit.ensureInitialized` so
+media_kit is never registered as the `video_player` backend there. The trade-off
+is container support: AVFoundation handles `mp4`/`m4v`/`mov`, so on iOS the
+other formats in `attachment_types.dart` are shown as a download rather than a
+player that would fail on the first frame.
+
+**Do not re-add `media_kit_libs_video` (or `media_kit_libs_ios_video`) to
+`pubspec.yaml`** — it silently puts libmpv back in the iOS binary and the next
+submission gets the same automated rejection.

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -1,12 +1,13 @@
 # App / Play Store deployment
 
-The `Release` workflow (`.github/workflows/release.yml`) can build and upload
-signed store builds to Apple's App Store Connect and to Google Play:
+The `Release` workflow (`.github/workflows/release.yml`) builds signed store
+builds and takes them all the way to public release on both stores — a tag push
+needs no follow-up clicks in App Store Connect or the Play Console:
 
 | Target | Job | Lane | Lands in |
 |--------|-----|------|----------|
-| iOS App Store | `ios-appstore` | `fastlane ios beta` | TestFlight / App Store Connect |
-| Mac App Store | `mac-appstore` | `fastlane mac appstore` | App Store Connect (sandboxed `.pkg`) |
+| iOS App Store | `ios-appstore` | `fastlane ios appstore` | App Store (submitted for review, auto-release) |
+| Mac App Store | `mac-appstore` | `fastlane mac appstore` | Mac App Store (submitted for review, auto-release) |
 | Notarized DMG | `build` (macOS) | `fastlane mac dmg` | GitHub Release (direct download) |
 | Google Play | `android-play` | `fastlane android play` | Play Console (AAB → `production` track) |
 
@@ -121,13 +122,39 @@ deleted.)
 - **Test a store deploy only:** Actions → Release → Run workflow, pick the
   branch, and toggle `deploy_ios` / `deploy_mac` / `deploy_android`.
 
-## What's still manual on Apple's side
+## Release notes ("What's New")
 
-CI uploads the **build**. Promoting it to public release is a human step:
+Apple rejects a version submission that has no release notes, so CI generates
+them rather than leaving the release to block on a human.
+`dist/app-store-release-notes.sh` reads the commits between the previous stable
+tag and `HEAD` (release candidates are skipped, so a stable release's notes span
+everything since the last stable one), keeps the `feat`/`fix`/`perf` subjects,
+strips the conventional-commit prefixes and writes a bulleted list to
+`fastlane/metadata/{ios,mac}/en-US/release_notes.txt`. That is the only metadata
+field CI delivers; everything else stays managed in App Store Connect.
 
-- **Apple:** select the build on the version page and click *Add for Review* →
-  *Submit* in App Store Connect (screenshots, App Privacy questionnaire, and age
-  rating are also manual there).
-- **Google Play:** the AAB is released to the **`production`** track and goes
-  live once Google finishes its review — no manual promotion needed. The store
-  listing, content rating, and Data safety declarations are already complete.
+The output is generated, not committed — `fastlane/metadata/` is gitignored.
+Both Apple jobs check out with `fetch-depth: 0` because a shallow clone has no
+previous tag to diff against; if one is ever missing the script falls back to a
+generic note instead of failing the release.
+
+To hand-write the notes for a release instead, edit the two `release_notes.txt`
+paths after the generate step — or drop the step and commit the files.
+
+## What's still manual
+
+Nothing per release. A tag push submits both Apple builds for review with
+automatic release on approval, and ships the Android build to `production`.
+What remains is **per-app, set once**, and every later release reuses it:
+
+- **Apple:** screenshots, the App Privacy questionnaire, and the age rating, in
+  App Store Connect. A brand-new app also needs its first release created by
+  hand before API submissions work.
+- **Google Play:** the store listing, content rating and Data safety
+  declarations — already complete for this app.
+
+What no CI can remove is the stores' own review. Apple's review typically takes
+about a day; the build sits in *Waiting for Review* → *In Review* and then goes
+live on its own (`automatic_release: true`). Google's review gates the
+`production` rollout the same way. "All the way to production" means *submitted
+and set to ship*, not *live within minutes*.

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -1,13 +1,15 @@
 # App / Play Store deployment
 
 The `Release` workflow (`.github/workflows/release.yml`) builds signed store
-builds and takes them all the way to public release on both stores — a tag push
-needs no follow-up clicks in App Store Connect or the Play Console:
+builds and takes iOS and Android all the way to public release — a tag push
+needs no follow-up clicks in App Store Connect or the Play Console. macOS is the
+exception: its build is uploaded but not submitted, because the Mac product page
+does not exist yet ([below](#mac-app-store-listing-first)).
 
 | Target | Job | Lane | Lands in |
 |--------|-----|------|----------|
 | iOS App Store | `ios-appstore` | `fastlane ios appstore` | App Store (submitted for review, auto-release) |
-| Mac App Store | `mac-appstore` | `fastlane mac appstore` | Mac App Store (submitted for review, auto-release) |
+| Mac App Store | `mac-appstore` | `fastlane mac appstore` | App Store Connect (uploaded only — **not** submitted) |
 | Notarized DMG | `build` (macOS) | `fastlane mac dmg` | GitHub Release (direct download) |
 | Google Play | `android-play` | `fastlane android play` | Play Console (AAB → `production` track) |
 
@@ -131,10 +133,11 @@ tag and `HEAD` (release candidates are skipped, so a stable release's notes span
 everything since the last stable one), keeps the `feat`/`fix`/`perf` subjects,
 strips the conventional-commit prefixes and writes a bulleted list to
 `fastlane/metadata/{ios,mac}/en-US/release_notes.txt`. That is the only metadata
-field CI delivers; everything else stays managed in App Store Connect.
+field CI delivers; everything else stays managed in App Store Connect. Only the
+iOS job runs it today — the Mac job delivers no metadata at all (below).
 
 The output is generated, not committed — `fastlane/metadata/` is gitignored.
-Both Apple jobs check out with `fetch-depth: 0` because a shallow clone has no
+The iOS job checks out with `fetch-depth: 0` because a shallow clone has no
 previous tag to diff against; if one is ever missing the script falls back to a
 generic note instead of failing the release.
 
@@ -143,21 +146,55 @@ paths after the generate step — or drop the step and commit the files.
 
 ## What's still manual
 
-Nothing per release. A tag push submits both Apple builds for review with
-automatic release on approval, and ships the Android build to `production`.
-What remains is **per-app, set once**, and every later release reuses it:
+Nothing per release for **iOS and Android**. A tag push submits the iOS build
+for review with automatic release on approval, and ships the Android build to
+`production`. What remains there is **per-app, set once**, and every later
+release reuses it:
 
-- **Apple:** screenshots, the App Privacy questionnaire, and the age rating, in
+- **iOS:** screenshots, the App Privacy questionnaire, and the age rating, in
   App Store Connect. A brand-new app also needs its first release created by
   hand before API submissions work.
 - **Google Play:** the store listing, content rating and Data safety
   declarations — already complete for this app.
+
+**macOS is not there yet** — see the next section.
 
 What no CI can remove is the stores' own review. Apple's review typically takes
 about a day; the build sits in *Waiting for Review* → *In Review* and then goes
 live on its own (`automatic_release: true`). Google's review gates the
 `production` rollout the same way. "All the way to production" means *submitted
 and set to ship*, not *live within minutes*.
+
+## Mac App Store: listing first
+
+The `mac-appstore` job **uploads only**. It does not submit, because there is
+nothing submittable: the macOS product page has never been filled in. As of
+0.2.11 it has 0 of 10 screenshots and an empty description, keywords, support
+URL and copyright, and the version record has no App Store Review Detail.
+
+That last one is not a soft failure. `deliver`'s metadata upload calls
+`fetch_app_store_review_detail`, spaceship gets `{"data": null}` back for a
+version that has never been submitted, and raises `No data` — killing the job
+*before* the `.pkg` is uploaded (fastlane's own "Uploading the very first
+version of my app yields `No data`"). That is what turned v0.2.11's release run
+red while iOS, Google Play and the GitHub Release all succeeded. Passing
+`skip_metadata: true` skips that call, so the binary reaches App Store Connect
+and waits there.
+
+To turn macOS on, in App Store Connect → Daccord → macOS App:
+
+1. Add Mac screenshots (1280 × 800, 1440 × 900, 2560 × 1600 or 2880 × 1800) —
+   these have to be real captures of the app on macOS.
+2. Fill in description, keywords, support URL and copyright. The iOS listing is
+   a reasonable starting point.
+3. Fill in App Review Information (contact details), which is what creates the
+   review-detail record `deliver` chokes on.
+4. Attach the uploaded build and submit that first version by hand.
+
+Then swap the `mac :appstore` lane's `upload_to_app_store` call back to
+`submit_release(api_key: api_key, platform: "osx", metadata_path:
+"fastlane/metadata/mac", pkg: pkg)`, and restore the "Generate What's New" step
+in the `mac-appstore` job, and macOS releases the same way iOS does.
 
 ## Guideline 2.5.1: no libmpv in the iOS build
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,10 @@
 # Daccord App Store release lanes.
 #
-# These build the *store* variants (iOS App Store + Mac App Store), upload them
-# to App Store Connect and submit them for review, set to release automatically
-# once approved. They are invoked by .github/workflows/release.yml,
+# These build the *store* variants (iOS App Store + Mac App Store) and upload
+# them to App Store Connect. iOS goes all the way — submitted for review and set
+# to release automatically once approved; Mac stops at the upload until its
+# product page exists (see the note on the :appstore lane below). They are
+# invoked by .github/workflows/release.yml,
 # which first imports the signing certs and provisioning profiles into a temp
 # keychain and runs `flutter build … --no-codesign` so the Flutter/Dart side is
 # already compiled; `build_app` (gym) then archives + signs + exports.
@@ -205,7 +207,7 @@ platform :ios do
 end
 
 platform :mac do
-  desc "Build a sandboxed signed .pkg and submit it for Mac App Store review"
+  desc "Build a sandboxed signed .pkg and upload it to App Store Connect"
   lane :appstore do
     api_key = asc_api_key
     profile = ENV.fetch("MAC_PROFILE_NAME")
@@ -233,11 +235,31 @@ platform :mac do
     )
     pkg ||= lane_context[SharedValues::PKG_OUTPUT_PATH] || Dir["build/appstore/*.pkg"].first
     UI.user_error!("No .pkg produced by gym (got #{pkg.inspect})") if pkg.nil? || !File.exist?(pkg)
-    submit_release(
+    # Upload only — the Mac listing is not submittable yet, so do NOT route this
+    # through submit_release. The macOS product page has never been filled in (0
+    # screenshots, no description/keywords/support URL/copyright) and the version
+    # record has no App Store Review Detail, which is a hard failure rather than a
+    # rejection: deliver's upload_metadata calls fetch_app_store_review_detail,
+    # spaceship gets `{"data": null}` back and raises "No data", killing the job
+    # *before* the .pkg is uploaded (fastlane's own "Uploading the very first
+    # version of my app yields `No data`" issue). That is what turned v0.2.11's
+    # release run red while iOS, Google Play and the GitHub Release all succeeded.
+    #
+    # skip_metadata sidesteps that call, so the binary lands in App Store Connect
+    # ready to attach. Swap this back to submit_release(platform: "osx", ...) once
+    # the macOS listing is complete and the version has been submitted by hand
+    # once — see "Mac App Store: listing first" in docs/app-store-deploy.md.
+    upload_to_app_store(
       api_key: api_key,
-      platform: "osx",
-      metadata_path: "fastlane/metadata/mac",
       pkg: pkg,
+      platform: "osx",
+      app_version: ENV.fetch("APP_STORE_VERSION"),
+      skip_metadata: true,
+      skip_screenshots: true,
+      skip_app_version_update: true,
+      submit_for_review: false,
+      run_precheck_before_submit: false,
+      force: true,
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,8 @@
 # Daccord App Store release lanes.
 #
-# These build the *store* variants (iOS App Store + Mac App Store) and upload
-# them to App Store Connect. They are invoked by .github/workflows/release.yml,
+# These build the *store* variants (iOS App Store + Mac App Store), upload them
+# to App Store Connect and submit them for review, set to release automatically
+# once approved. They are invoked by .github/workflows/release.yml,
 # which first imports the signing certs and provisioning profiles into a temp
 # keychain and runs `flutter build … --no-codesign` so the Flutter/Dart side is
 # already compiled; `build_app` (gym) then archives + signs + exports.
@@ -21,6 +22,62 @@ def asc_api_key
     issuer_id: ENV.fetch("ASC_ISSUER_ID"),
     key_content: ENV.fetch("ASC_KEY_P8_BASE64"),
     is_key_content_base64: true,
+  )
+end
+
+# Submit an uploaded build to App Store review and let it ship on approval.
+#
+# This is the step that takes an Apple release "all the way": deliver creates
+# (or updates) the version record, attaches the freshly uploaded binary,
+# delivers the What's New text, then submits for review with automatic release
+# on approval — the Apple equivalent of what `supply` already does for Google
+# Play (production track, rollout completed).
+#
+# Apple's review still gates the actual go-live; nothing here can shorten that.
+#
+# Listing assets — screenshots, App Privacy answers, age rating — stay managed
+# in App Store Connect. They are per-app rather than per-version, so they are
+# set once and every later release reuses them; only the release notes change
+# per version, which is why that is the single metadata field delivered here.
+def submit_release(api_key:, platform:, metadata_path:, ipa: nil, pkg: nil)
+  upload_to_app_store(
+    api_key: api_key,
+    ipa: ipa,
+    pkg: pkg,
+    platform: platform,
+    # The numeric marketing version the workflow built (`0.2.10`), not the raw
+    # pubspec string — deliver has to target the same version record that
+    # CFBundleShortVersionString declares or it edits the wrong one.
+    app_version: ENV.fetch("APP_STORE_VERSION"),
+    # Only release_notes.txt lives here (written by
+    # dist/app-store-release-notes.sh); deliver uploads the fields it finds and
+    # leaves everything else in App Store Connect untouched.
+    metadata_path: metadata_path,
+    skip_metadata: false,
+    skip_screenshots: true,
+    # Must stay false: with no version record created, there is nothing to
+    # attach the build to and nothing to submit.
+    skip_app_version_update: false,
+    submit_for_review: true,
+    automatic_release: true,
+    # App Store Connect needs a while to register a newly uploaded build before
+    # deliver can attach it. The default of 7 retries is an exponential backoff
+    # that tops out too early for a Flutter binary of this size; 10 buys roughly
+    # an extra 15 minutes without hanging the job indefinitely.
+    version_check_wait_retry_limit: 10,
+    # precheck reads the full listing metadata, which this lane deliberately
+    # does not manage — it would fail on fields that live only in ASC.
+    run_precheck_before_submit: false,
+    # Answers the submission questionnaire that otherwise blocks review with no
+    # useful error. Both Info.plists declare ITSAppUsesNonExemptEncryption =
+    # false (HTTPS/WebRTC only, all exempt), and the app links no ad SDK and
+    # never touches the advertising identifier.
+    submission_information: {
+      export_compliance_uses_encryption: false,
+      add_id_info_uses_idfa: false,
+    },
+    # Non-interactive: skip deliver's "does this HTML preview look right?" prompt.
+    force: true,
   )
 end
 
@@ -115,8 +172,12 @@ platform :android do
 end
 
 platform :ios do
-  desc "Build a signed iOS .ipa and upload it to TestFlight / App Store Connect"
-  lane :beta do
+  desc "Build a signed iOS .ipa, upload it, and submit it for App Store review"
+  # Was TestFlight-only (`upload_to_testflight`), which left every release
+  # parked as an internal build that a human then had to submit by hand in App
+  # Store Connect. It now goes all the way; the build still shows up in
+  # TestFlight, because every App Store build does.
+  lane :appstore do
     api_key = asc_api_key
     profile = ENV.fetch("IOS_PROFILE_NAME")
     force_manual_signing("ios/Runner.xcodeproj", profile)
@@ -134,17 +195,17 @@ platform :ios do
         signingStyle: "manual",
       },
     )
-    upload_to_testflight(
+    submit_release(
       api_key: api_key,
+      platform: "ios",
+      metadata_path: "fastlane/metadata/ios",
       ipa: "build/appstore/Daccord-iOS.ipa",
-      skip_waiting_for_build_processing: true,
-      distribute_external: false,
     )
   end
 end
 
 platform :mac do
-  desc "Build a sandboxed signed .pkg and upload it to the Mac App Store"
+  desc "Build a sandboxed signed .pkg and submit it for Mac App Store review"
   lane :appstore do
     api_key = asc_api_key
     profile = ENV.fetch("MAC_PROFILE_NAME")
@@ -172,15 +233,11 @@ platform :mac do
     )
     pkg ||= lane_context[SharedValues::PKG_OUTPUT_PATH] || Dir["build/appstore/*.pkg"].first
     UI.user_error!("No .pkg produced by gym (got #{pkg.inspect})") if pkg.nil? || !File.exist?(pkg)
-    upload_to_app_store(
+    submit_release(
       api_key: api_key,
+      platform: "osx",
+      metadata_path: "fastlane/metadata/mac",
       pkg: pkg,
-      skip_metadata: true,
-      skip_screenshots: true,
-      skip_app_version_update: true,
-      submit_for_review: false,
-      run_precheck_before_submit: false,
-      force: true,
     )
   end
 

--- a/lib/features/messaging/utils/attachment_types.dart
+++ b/lib/features/messaging/utils/attachment_types.dart
@@ -10,7 +10,7 @@ enum AttachmentPreview {
   /// Rendered by `CachedNetworkImage` (Flutter's own decoders).
   image,
 
-  /// Rendered by `InlineVideoPlayer` (media_kit / libmpv).
+  /// Rendered by `InlineVideoPlayer` (media_kit / libmpv; AVFoundation on iOS).
   video,
 
   /// Rendered by `InlineAudioPlayer` (audioplayers).
@@ -73,7 +73,8 @@ const Map<String, AttachmentType> kAttachmentTypes = {
   'heif': AttachmentType('image/heif', _none),
   'ico': AttachmentType('image/x-icon', _none),
   'psd': AttachmentType('image/vnd.adobe.photoshop', _none),
-  // ---- Video (media_kit / libmpv handles all of these) -------------------
+  // ---- Video (media_kit / libmpv handles all of these; iOS plays the
+  // AVFoundation-supported subset — see InlineVideoPlayer) ------------------
   'mp4': AttachmentType('video/mp4', _video),
   'm4v': AttachmentType('video/mp4', _video),
   'webm': AttachmentType('video/webm', _video),

--- a/lib/features/messaging/views/inline_video_player.dart
+++ b/lib/features/messaging/views/inline_video_player.dart
@@ -1,12 +1,20 @@
 import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
+import 'package:video_player/video_player.dart' as vp;
 
-/// An inline video attachment player. The underlying [Player] is created lazily
-/// on first tap (so opening a channel with many videos doesn't spin up a
-/// decoder per attachment); once loaded, media_kit's [Video] handles playback
-/// and controls.
+/// An inline video attachment player. Playback starts lazily on first tap (so
+/// opening a channel with many videos doesn't spin up a decoder per
+/// attachment).
+///
+/// The decoder differs by platform: everywhere except iOS this is media_kit's
+/// [Player] + [Video], which brings its own controls. iOS has no libmpv bundled
+/// — media_kit's iOS native libs reference fork/execve and the deprecated
+/// OpenGL ES stack, which App Review rejects under guideline 2.5.1, so they're
+/// excluded in pubspec.yaml — and plays through package:video_player's
+/// AVFoundation backend with the small control overlay below.
 class InlineVideoPlayer extends StatefulWidget {
   const InlineVideoPlayer({
     super.key,
@@ -24,38 +32,45 @@ class InlineVideoPlayer extends StatefulWidget {
   static const _maxWidth = 400.0;
   static const _maxHeight = 350.0;
 
+  /// Containers AVFoundation can demux. libmpv plays everything in
+  /// `attachment_types.dart`'s video list; AVFoundation covers only the MPEG-4
+  /// / QuickTime family plus HLS, so on iOS the rest are shown as a dead poster
+  /// rather than a player that would fail on the first frame.
+  static const _avFoundationExtensions = {'mp4', 'm4v', 'mov', 'm3u8'};
+
+  /// Whether this platform can decode what [url] points at. Embeds pass a title
+  /// as [filename], so the URL's own path is the reliable signal; the filename
+  /// is only consulted when the URL carries no extension.
+  bool get _playableHere {
+    if (!_isIOS) return true;
+    final path = Uri.tryParse(url)?.path ?? '';
+    return _avFoundationExtensions.contains(_extensionOf(path)) ||
+        (!path.contains('.') &&
+            _avFoundationExtensions.contains(_extensionOf(filename)));
+  }
+
+  static bool get _isIOS =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
+  static String? _extensionOf(String name) {
+    final dot = name.lastIndexOf('.');
+    return dot < 0 ? null : name.substring(dot + 1).toLowerCase();
+  }
+
   @override
   State<InlineVideoPlayer> createState() => _InlineVideoPlayerState();
 }
 
 class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
-  Player? _player;
-  VideoController? _controller;
-
-  @override
-  void dispose() {
-    _player?.dispose();
-    super.dispose();
-  }
-
-  void _load() {
-    final player = Player();
-    setState(() {
-      _player = player;
-      _controller = VideoController(player);
-    });
-    player.open(Media(widget.url));
-  }
+  bool _loaded = false;
 
   @override
   Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
     final aspect = (widget.width != null &&
             widget.height != null &&
             widget.height! > 0)
         ? widget.width! / widget.height!
         : 16 / 9;
-    final controller = _controller;
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: ConstrainedBox(
@@ -65,35 +80,179 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
         ),
         child: AspectRatio(
           aspectRatio: aspect,
-          child: controller == null
-              ? GestureDetector(
-                  onTap: _load,
-                  child: Container(
-                    color: colors.darkGray,
-                    alignment: Alignment.center,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.play_circle,
-                            size: 48, color: colors.dirtyWhite),
-                        const SizedBox(height: 6),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: Text(
-                            widget.filename,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodySmall!
-                                .copyWith(color: colors.dirtyWhite),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+          child: !widget._playableHere
+              ? _VideoPoster(
+                  filename: widget.filename,
+                  icon: Icons.videocam_off,
                 )
-              : Video(controller: controller, fit: BoxFit.contain),
+              : !_loaded
+                  ? GestureDetector(
+                      onTap: () => setState(() => _loaded = true),
+                      child: _VideoPoster(filename: widget.filename),
+                    )
+                  : InlineVideoPlayer._isIOS
+                      ? _AvFoundationVideo(url: widget.url)
+                      : _MediaKitVideo(url: widget.url),
+        ),
+      ),
+    );
+  }
+}
+
+/// The tap-to-play placeholder shown before a decoder is created — or, with
+/// [icon] overridden, the dead-end shown for a container this platform can't
+/// decode.
+class _VideoPoster extends StatelessWidget {
+  const _VideoPoster({required this.filename, this.icon = Icons.play_circle});
+
+  final String filename;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      color: colors.darkGray,
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 48, color: colors.dirtyWhite),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              filename,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall!
+                  .copyWith(color: colors.dirtyWhite),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// libmpv-backed playback — every platform except iOS.
+class _MediaKitVideo extends StatefulWidget {
+  const _MediaKitVideo({required this.url});
+
+  final String url;
+
+  @override
+  State<_MediaKitVideo> createState() => _MediaKitVideoState();
+}
+
+class _MediaKitVideoState extends State<_MediaKitVideo> {
+  late final Player _player = Player();
+  late final VideoController _controller = VideoController(_player);
+
+  @override
+  void initState() {
+    super.initState();
+    _player.open(Media(widget.url));
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      Video(controller: _controller, fit: BoxFit.contain);
+}
+
+/// AVFoundation-backed playback — iOS only. package:video_player ships no
+/// controls, so this adds the minimum: tap to toggle play/pause, a play glyph
+/// while paused, and a scrub bar along the bottom.
+class _AvFoundationVideo extends StatefulWidget {
+  const _AvFoundationVideo({required this.url});
+
+  final String url;
+
+  @override
+  State<_AvFoundationVideo> createState() => _AvFoundationVideoState();
+}
+
+class _AvFoundationVideoState extends State<_AvFoundationVideo> {
+  late final vp.VideoPlayerController _controller;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = vp.VideoPlayerController.networkUrl(Uri.parse(widget.url))
+      ..initialize().then((_) {
+        if (!mounted) return;
+        setState(() {});
+        _controller.play();
+      }).catchError((Object e) {
+        if (!mounted) return;
+        setState(() => _error = e);
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    if (_error != null) {
+      return Container(
+        color: colors.darkGray,
+        alignment: Alignment.center,
+        child: Icon(Icons.videocam_off, size: 40, color: colors.dirtyWhite),
+      );
+    }
+    if (!_controller.value.isInitialized) {
+      return Container(
+        color: colors.darkGray,
+        alignment: Alignment.center,
+        child: const SizedBox(
+          width: 28,
+          height: 28,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return GestureDetector(
+      onTap: () => setState(() {
+        if (_controller.value.isPlaying) {
+          _controller.pause();
+        } else {
+          _controller.play();
+        }
+      }),
+      child: ColoredBox(
+        color: Colors.black,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Center(
+              child: AspectRatio(
+                aspectRatio: _controller.value.aspectRatio,
+                child: vp.VideoPlayer(_controller),
+              ),
+            ),
+            if (!_controller.value.isPlaying)
+              Icon(Icons.play_circle, size: 48, color: colors.dirtyWhite),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: vp.VideoProgressIndicator(_controller, allowScrubbing: true),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,9 +55,14 @@ void main() async {
 
   initializePlatform();
 
+  // Register media_kit as package:video_player's backend everywhere except iOS.
+  // iOS has no media_kit_libs_ios_video (see pubspec.yaml — libmpv's
+  // fork/execve and OpenGL ES references got 0.2.6 rejected under App Store
+  // guideline 2.5.1), so there is no libmpv to initialise there; video_player
+  // falls through to its stock AVFoundation implementation instead.
   VideoPlayerMediaKit.ensureInitialized(
     android: true,
-    iOS: true,
+    iOS: false,
     macOS: true,
     windows: true,
     linux: true,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -22,6 +22,7 @@ import path_provider_foundation
 import screen_retriever_macos
 import sqflite_darwin
 import url_launcher_macos
+import video_player_avfoundation
 import wakelock_plus
 import window_manager
 
@@ -43,6 +44,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -352,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   custom_lint:
     dependency: "direct dev"
     description:
@@ -699,6 +707,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:
@@ -856,23 +872,15 @@ packages:
     source: git
     version: "1.1.11"
   media_kit_libs_android_video:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_android_video
       sha256: "3f6274e5ab2de512c286a25c327288601ee445ed8ac319e0ef0b66148bd8f76c"
       url: "https://pub.dev"
     source: hosted
     version: "1.3.8"
-  media_kit_libs_ios_video:
-    dependency: transitive
-    description:
-      name: media_kit_libs_ios_video
-      sha256: b5382994eb37a4564c368386c154ad70ba0cc78dacdd3fb0cd9f30db6d837991
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.4"
   media_kit_libs_linux:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_linux
       sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
@@ -880,24 +888,15 @@ packages:
     source: hosted
     version: "1.2.1"
   media_kit_libs_macos_video:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_macos_video
       sha256: f26aa1452b665df288e360393758f84b911f70ffb3878032e1aabba23aa1032d
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
-  media_kit_libs_video:
-    dependency: "direct main"
-    description:
-      path: "libs/universal/media_kit_libs_video"
-      ref: "652c49e02701bb6bb80953a6fdf650a5c8f002f9"
-      resolved-ref: "652c49e02701bb6bb80953a6fdf650a5c8f002f9"
-      url: "https://github.com/media-kit/media-kit.git"
-    source: git
-    version: "1.0.5"
   media_kit_libs_windows_video:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_windows_video
       sha256: dff76da2778729ab650229e6b4ec6ec111eb5151431002cbd7ea304ff1f112ab
@@ -1582,6 +1581,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "8401adac6f33e78a0f255a75a7e7c9e2f9713ffcd87ff4e6c00d9bd92b5d99db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.7"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.7"
   video_player_media_kit:
     dependency: "direct main"
     description:
@@ -1599,6 +1622,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -1736,5 +1767,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: bonfire
 description: "A fast, cross-platform Flutter client for Daccord."
 publish_to: "none"
 
-version: 0.2.10+1
+version: 0.2.11+1
 
 environment:
   sdk: ^3.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,17 +42,32 @@ dependencies:
       url: https://github.com/media-kit/media-kit.git
       ref: 652c49e02701bb6bb80953a6fdf650a5c8f002f9
       path: ./media_kit_video
-  media_kit_libs_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      ref: 652c49e02701bb6bb80953a6fdf650a5c8f002f9
-      path: ./libs/universal/media_kit_libs_video
+  # media_kit's native libs, listed per platform instead of via the
+  # `media_kit_libs_video` umbrella so that iOS can be left out. The iOS bundle
+  # (media_kit_libs_ios_video) vendors libmpv + FFmpeg, whose Mpv.framework
+  # references fork/execve/setsid/waitpid/kill and tcsetattr and renders through
+  # the OpenGL ES stack Apple deprecated in iOS 12 — App Review rejected 0.2.6
+  # under guideline 2.5.1 (non-public or deprecated APIs) for exactly that. With
+  # no media_kit_libs_ios_* in pubspec.lock, media_kit_video's iOS podspec
+  # compiles its no-op stub and nothing of mpv reaches the binary; iOS plays
+  # video through package:video_player's AVFoundation backend instead (see
+  # lib/features/messaging/views/inline_video_player.dart).
+  media_kit_libs_android_video: ^1.3.6
+  media_kit_libs_macos_video: ^1.1.4
+  media_kit_libs_windows_video: ^1.0.10
+  media_kit_libs_linux: ^1.1.3
 
   video_player_media_kit:
     git: 
       url: https://github.com/media-kit/media-kit.git
       ref: 652c49e02701bb6bb80953a6fdf650a5c8f002f9
       path: video_player_media_kit
+
+  # iOS-only video playback path: package:video_player's AVFoundation backend
+  # replaces media_kit/libmpv there (see the media_kit_libs_* note above). On
+  # every other platform VideoPlayerMediaKit.ensureInitialized keeps media_kit
+  # registered as the video_player backend.
+  video_player: ^2.9.2
 
   url_launcher: ^6.2.6
   app_links: ^6.3.0
@@ -123,11 +138,6 @@ dependency_overrides:
       url: https://github.com/media-kit/media-kit.git
       ref: 652c49e02701bb6bb80953a6fdf650a5c8f002f9
       path: ./media_kit_video
-  media_kit_libs_video:
-    git:
-      url: https://github.com/media-kit/media-kit.git
-      ref: 652c49e02701bb6bb80953a6fdf650a5c8f002f9
-      path: ./libs/universal/media_kit_libs_video
 
   video_player_media_kit:
     git: 

--- a/test/features/messaging/inline_video_player_test.dart
+++ b/test/features/messaging/inline_video_player_test.dart
@@ -1,0 +1,65 @@
+import 'package:bonfire/features/messaging/views/inline_video_player.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: child),
+    );
+
+/// iOS ships without media_kit's libmpv (its Mpv.framework references
+/// fork/execve and OpenGL ES, which got 0.2.6 rejected under App Store
+/// guideline 2.5.1), so video there decodes via AVFoundation — which handles
+/// far fewer containers than libmpv. These cover the gate that keeps an
+/// unplayable container from opening a player that would fail on the first
+/// frame.
+void main() {
+  Widget player(String url, {String filename = 'clip'}) =>
+      _host(InlineVideoPlayer(url: url, filename: filename));
+
+  group('InlineVideoPlayer container gate', () {
+    testWidgets('offers playback for every container off iOS', (tester) async {
+      await tester.pumpWidget(player('https://cdn.example/a.mkv'));
+      expect(find.byIcon(Icons.play_circle), findsOneWidget);
+      expect(find.byIcon(Icons.videocam_off), findsNothing);
+    });
+
+    testWidgets('offers playback on iOS for an AVFoundation container',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await tester.pumpWidget(player('https://cdn.example/a.mp4?ex=deadbeef'));
+      expect(find.byIcon(Icons.play_circle), findsOneWidget);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('refuses a container AVFoundation cannot demux on iOS',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await tester.pumpWidget(player('https://cdn.example/a.mkv'));
+      expect(find.byIcon(Icons.videocam_off), findsOneWidget);
+      expect(find.byIcon(Icons.play_circle), findsNothing);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('falls back to the filename when the URL has no extension',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await tester.pumpWidget(
+        player('https://cdn.example/attachments/1', filename: 'clip.mov'),
+      );
+      expect(find.byIcon(Icons.play_circle), findsOneWidget);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('refuses an embed page URL on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await tester.pumpWidget(
+        player('https://example.com/watch', filename: 'Some video title'),
+      );
+      expect(find.byIcon(Icons.videocam_off), findsOneWidget);
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}


### PR DESCRIPTION
iOS has never reached the App Store: 0.2.6 (build 141) was rejected on
2026-07-09 under guideline **2.5.1 Performance: Software Requirements**, and
every release since then stopped at a TestFlight build because the iOS lane
only called `upload_to_testflight`. This branch fixes both halves.

## The rejection

Apple's message was the automated one and named no API. Scanning every
framework the iOS app links found exactly one dirty binary — the
`Mpv.xcframework` vendored by `media_kit_libs_ios_video`:

```
$ llvm-nm -u Mpv.framework/Mpv | grep -E '^_(fork|execve|setsid|waitpid|kill)$'
_execve _fork _kill _setsid _waitpid
```

mpv's POSIX subprocess and TTY layer (`tcgetattr`/`tcsetattr`/`tcgetpgrp`,
`shm_open`), plus `EAGLContext` and `CVOpenGLESTextureCache*` — the OpenGL ES
stack Apple deprecated in iOS 12. `media_kit_video`'s own iOS plugin renders
through that same path and compiles with `GL_SILENCE_DEPRECATION`. WebRTC, the
FFmpeg libs, libxml2 and every plugin source came back clean.

So iOS no longer gets media_kit: `pubspec.yaml` lists the native libs
per platform instead of via the `media_kit_libs_video` umbrella, omitting the
iOS package, which makes `media_kit_video`'s iOS podspec fall back to its
no-op stub. Video attachments there play through `package:video_player`'s
AVFoundation backend. AVFoundation demuxes less than libmpv, so a container it
cannot open shows a poster rather than a player that fails on the first frame.

## Submitting from CI

Also carries `d67a743e`, previously stranded on
`claude/voice-channel-chat-parity-rogbid` — the Apple lanes now create the
version record, attach the build, deliver generated release notes and submit
for review with automatic release on approval.

## Verification

`flutter analyze` clean, 976 tests pass (5 new ones cover the container gate),
`flutter build linux` succeeds, and `media_kit_libs_ios_video` is gone from
`pubspec.lock` and from the iOS half of `.flutter-plugins-dependencies`. The
iOS archive itself is first compiled by the release job — it cannot be built on
Linux.

The stuck 0.2.6 review submission has been cancelled in App Store Connect, so
the version record is editable and `deliver` can submit 0.2.11 against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)