### PR TITLE
feat(dm): align messages with channel experience

### DIFF
--- a/.github/executable-files.txt
+++ b/.github/executable-files.txt
@@ -1,5 +1,6 @@
 dist/app-store-release-notes.sh
 dist/build-deb.sh
+dist/verify-android-signing.sh
 scripts/_common.sh
 scripts/bootstrap-signing.sh
 scripts/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           if [ "$status" -ne 0 ]; then
             exit "$status"
           fi
-          if ! grep -q "All tests passed!" /tmp/protocol-integration.log; then
+          if ! grep -Eq "All tests passed!|[1-9][0-9]* tests? passed\\." /tmp/protocol-integration.log; then
             echo "::error::The blocking protocol suite did not run to completion. See integration/README.md."
             exit 1
           fi
@@ -467,7 +467,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config \
-            libgtk-3-dev liblzma-dev libsecret-1-dev \
+            libgtk-3-dev liblzma-dev libsecret-1-dev gnome-keyring \
             libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             libunwind-dev libdw-dev \
             libmpv-dev mpv \
@@ -497,7 +497,10 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          xvfb-run -a flutter test multi_instance/ 2>&1 | tee /tmp/multi.log
+          dbus-run-session -- bash -c '
+            eval "$(printf "ci-test-vault" | gnome-keyring-daemon --unlock --components=secrets)"
+            xvfb-run -a flutter test multi_instance/
+          ' 2>&1 | tee /tmp/multi.log
           status=${PIPESTATUS[0]}
           if grep -qE "^0 tests passed|🎉 0 tests passed" /tmp/multi.log; then
             echo "::error::No multi-instance tests ran — no server or no app bundle. See multi_instance/README.md."
@@ -530,7 +533,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config \
-            libgtk-3-dev liblzma-dev libsecret-1-dev \
+            libgtk-3-dev liblzma-dev libsecret-1-dev gnome-keyring \
             libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             libunwind-dev libdw-dev \
             libmpv-dev mpv \
@@ -570,9 +573,11 @@ jobs:
       - name: Exercise real LiveKit session
         env:
           ACCORD_TEST_LIVEKIT: "1"
-        run: >-
-          xvfb-run -a flutter test multi_instance/livekit_voice_test.dart
-          --reporter expanded
+        run: |
+          dbus-run-session -- bash -c '
+            eval "$(printf "ci-test-vault" | gnome-keyring-daemon --unlock --components=secrets)"
+            xvfb-run -a flutter test multi_instance/livekit_voice_test.dart --reporter expanded
+          '
 
   build:
     name: Build ${{ matrix.name }}

--- a/docs/messaging/direct-messages.md
+++ b/docs/messaging/direct-messages.md
@@ -12,9 +12,9 @@ Direct messages (DMs) let you have private one-on-one or group conversations out
 ## Opening Direct Messages
 
 1. Click the **DM** button at the top of the space bar.
-2. The sidebar switches to show your DM conversation list.
+2. The Direct Messages panel opens with your conversation list.
 
-The DM panel has two tabs at the top: **Friends** and **Messages**.
+The DM panel has two tabs at the top: **Messages** and **Friends**.
 
 - **Friends** — shows your friends list and lets you start new DMs.
 - **Messages** — shows your existing DM conversations.
@@ -23,7 +23,7 @@ Each DM shows the other person's avatar, display name, a preview of the last mes
 
 ## Starting a Conversation
 
-Click on a user's name in a member list or message to start a DM with them. You can also start a DM from the Friends tab.
+Click on a user's name in a member list or open their right-click/long-press menu and choose **Direct message**. You can also start a DM from the Friends tab.
 
 ## Searching DMs
 
@@ -31,12 +31,18 @@ Use the search field at the top of the DM list to filter conversations by name.
 
 ## Closing a DM
 
-To remove a conversation from your DM list, hover over it and click the **×** button that appears. This hides the conversation but does not delete the messages.
+Right-click a conversation (or long-press it on touch) and choose **Close direct message**. This removes you from the conversation list; starting a DM with that user again restores access to its retained history. For a group DM, the equivalent action is **Leave group**.
 
 ## Group DMs
 
 Group DMs include more than two people. They display all participants' names separated by commas.
 
+The group menu lets the owner add or remove participants and rename the group. Other participants can view the member list or leave the group.
+
 ## Sending Messages
 
-Sending messages in a DM works exactly the same as in a channel -- type in the composer and press Enter. Replies, edits, and deletes work the same way too.
+Sending messages in a DM uses the same timeline and composer as a channel. Markdown, attachments, image/large-text paste, emoji, drafts, reactions, replies, threads, edits, deletes, pins, typing indicators, and older-history loading work the same way. DM voice and video calls remain available from the conversation header.
+
+## User menus
+
+Right-click or long-press a DM recipient, message author, friend, or group member to open their user menu. From there you can view their account profile, start a separate DM, manage the friendship or block state, and copy their user ID or username. Group owners can also remove participants from the group-member menu.

--- a/integration/messaging_cache_test.dart
+++ b/integration/messaging_cache_test.dart
@@ -58,7 +58,7 @@ Future<void> main() async {
       // only writes to channels the UI is actually showing (see
       // `activeMessageChannels`), so without this the cache never updates.
       container.listen(
-        accordMessagesControllerProvider('', channelId),
+        accordMessagesControllerProvider(alice.session.key, channelId),
         (_, _) {},
         fireImmediately: true,
       );
@@ -66,16 +66,23 @@ Future<void> main() async {
 
     tearDownAll(harness.dispose);
 
-    List<AccordMessage>? read() =>
-        container.read(accordMessagesControllerProvider('', channelId));
+    List<AccordMessage>? read() => container.read(
+      accordMessagesControllerProvider(alice.session.key, channelId),
+    );
 
     test('the controller loads channel history from the server', () async {
-      final created = await alice.client.messages
-          .create(channelId, {'content': 'seeded history'});
+      final created = await alice.client.messages.create(channelId, {
+        'content': 'seeded history',
+      });
       expect(created.ok, isTrue, reason: '${created.error}');
 
       await container
-          .read(accordMessagesControllerProvider('', channelId).notifier)
+          .read(
+            accordMessagesControllerProvider(
+              alice.session.key,
+              channelId,
+            ).notifier,
+          )
           .reload(alice.client);
 
       final messages = await waitForState(
@@ -89,8 +96,9 @@ Future<void> main() async {
     test("bob's message lands in alice's cache without a refetch", () async {
       const content = 'sent by bob over the gateway';
 
-      final created =
-          await bob.client.messages.create(channelId, {'content': content});
+      final created = await bob.client.messages.create(channelId, {
+        'content': content,
+      });
       expect(created.ok, isTrue, reason: '${created.error}');
 
       final messages = await waitForState(
@@ -104,33 +112,38 @@ Future<void> main() async {
       expect(delivered.channelId, channelId);
     });
 
-    test("an edit by bob updates the message already in alice's cache",
-        () async {
-      final created = await bob.client.messages
-          .create(channelId, {'content': 'bob before edit'});
-      final id = (created.data! as AccordMessage).id;
+    test(
+      "an edit by bob updates the message already in alice's cache",
+      () async {
+        final created = await bob.client.messages.create(channelId, {
+          'content': 'bob before edit',
+        });
+        final id = (created.data! as AccordMessage).id;
 
-      await waitForState(
-        read,
-        (m) => m != null && m.any((msg) => msg.id == id),
-        description: 'message to edit',
-      );
+        await waitForState(
+          read,
+          (m) => m != null && m.any((msg) => msg.id == id),
+          description: 'message to edit',
+        );
 
-      await bob.client.messages
-          .edit(channelId, id, {'content': 'bob after edit'});
+        await bob.client.messages.edit(channelId, id, {
+          'content': 'bob after edit',
+        });
 
-      await waitForState(
-        read,
-        (m) =>
-            m != null &&
-            m.any((msg) => msg.id == id && msg.content == 'bob after edit'),
-        description: 'edited message',
-      );
-    });
+        await waitForState(
+          read,
+          (m) =>
+              m != null &&
+              m.any((msg) => msg.id == id && msg.content == 'bob after edit'),
+          description: 'edited message',
+        );
+      },
+    );
 
     test("a delete by bob removes the message from alice's cache", () async {
-      final created = await bob.client.messages
-          .create(channelId, {'content': 'bob will delete this'});
+      final created = await bob.client.messages.create(channelId, {
+        'content': 'bob will delete this',
+      });
       final id = (created.data! as AccordMessage).id;
 
       await waitForState(

--- a/integration/support/harness.dart
+++ b/integration/support/harness.dart
@@ -27,8 +27,10 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/models/accord_session.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/events/controllers/connection.dart';
 import 'package:bonfire/features/events/services/accord_event_handler.dart';
 import 'package:bonfire/features/profiles/services/profile_store.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/server/models/accord_server.dart';
 import 'package:bonfire/shared/app_info.dart' show kAppVersion;
 import 'package:flutter/widgets.dart' show VoidCallback, Widget;
@@ -70,12 +72,12 @@ class TestAccount {
   final AccordServer server;
 
   AccordSession get session => AccordSession(
-        server: server,
-        token: token,
-        tokenType: 'Bearer',
-        userId: userId,
-        username: username,
-      );
+    server: server,
+    token: token,
+    tokenType: 'Bearer',
+    userId: userId,
+    username: username,
+  );
 }
 
 class IntegrationHarness {
@@ -252,10 +254,14 @@ class IntegrationHarness {
   ///
   /// (Returns the scope rather than a `List<Override>` because
   /// `flutter_riverpod` doesn't export the `Override` type.)
-  Widget scopeFor(TestAccount account, {required Widget child}) => ProviderScope(
+  Widget scopeFor(TestAccount account, {required Widget child}) =>
+      ProviderScope(
         overrides: [
           accordAuthProvider.overrideWith(
             () => _StubAccordAuth(account.client, account.session),
+          ),
+          connectionsControllerProvider.overrideWith(
+            () => _StubConnectionsController(account.session),
           ),
         ],
         child: child,
@@ -283,11 +289,17 @@ class IntegrationHarness {
   /// This is what makes controller-level assertions possible: reads go through
   /// the real controllers, and live gateway events land in the real caches —
   /// no widgets. Call [setupHive] first.
-  ProviderContainer containerFor(TestAccount account, {bool wireEvents = true}) {
+  ProviderContainer containerFor(
+    TestAccount account, {
+    bool wireEvents = true,
+  }) {
     final container = ProviderContainer(
       overrides: [
         accordAuthProvider.overrideWith(
           () => _StubAccordAuth(account.client, account.session),
+        ),
+        connectionsControllerProvider.overrideWith(
+          () => _StubConnectionsController(account.session),
         ),
       ],
     );
@@ -298,7 +310,10 @@ class IntegrationHarness {
     return container;
   }
 
-  AccordClient _newClient({String token = '', List<String> intents = const []}) {
+  AccordClient _newClient({
+    String token = '',
+    List<String> intents = const [],
+  }) {
     final client = AccordClient(
       token: token,
       tokenType: 'Bearer',
@@ -357,6 +372,27 @@ class _StubAccordAuth extends AccordAuth {
       AccordAuthLoggedIn(client: _client, session: _session);
 }
 
+/// Seeds the server registry that server-scoped controllers use for their
+/// family key. The production auth notifier does this while connecting; the
+/// auth override above intentionally bypasses that lifecycle.
+class _StubConnectionsController extends ConnectionsController {
+  _StubConnectionsController(this._session);
+
+  final AccordSession _session;
+
+  @override
+  ConnectionsState build() => ConnectionsState(
+    connections: [
+      AccordConnection(
+        session: _session,
+        status: ConnectionStatus.ready,
+        spacesReady: true,
+      ),
+    ],
+    activeKey: _session.key,
+  );
+}
+
 /// Waits for the first event on [stream] satisfying [matches].
 ///
 /// Gateway assertions need this rather than `stream.first`: the server may emit
@@ -368,7 +404,9 @@ Future<T> waitForEvent<T>(
   Duration timeout = const Duration(seconds: 10),
   String? description,
 }) {
-  return stream.firstWhere(matches).timeout(
+  return stream
+      .firstWhere(matches)
+      .timeout(
         timeout,
         onTimeout: () => throw TimeoutException(
           'No matching ${description ?? '$T'} event within $timeout',

--- a/integration_test/messaging_ui_test.dart
+++ b/integration_test/messaging_ui_test.dart
@@ -73,7 +73,10 @@ Future<void> main() async {
       await tester.pumpWidget(
         harness.scopeFor(alice, child: const MainWindow()),
       );
-      await tester.pumpAndSettle();
+      // The connected shell owns persistent animations, so pumpAndSettle can
+      // wait for its ten-minute timeout. The assertions below use bounded,
+      // network-aware polling and only need the first frame here.
+      await tester.pump();
 
       final container = ProviderScope.containerOf(
         tester.element(find.byType(MainWindow)),
@@ -87,7 +90,7 @@ Future<void> main() async {
       await harness.connectGateway(alice);
 
       routerController.go('/spaces?space=$spaceId');
-      await tester.pumpAndSettle();
+      await tester.pump();
     }
 
     /// `pumpAndSettle` can't wait on network or gateway traffic — it settles as

--- a/lib/features/channels/controllers/accord_channels.dart
+++ b/lib/features/channels/controllers/accord_channels.dart
@@ -23,15 +23,16 @@ class AccordChannelsController extends _$AccordChannelsController {
   }
 
   Future<void> _load(AccordClient client, String spaceId) async {
-    final channels = (await client.spaces.listChannels(spaceId))
-        .listOrLog<AccordChannel>('channels for $spaceId');
+    final channels = (await client.spaces.listChannels(
+      spaceId,
+    )).listOrLog<AccordChannel>('channels for $spaceId');
+    if (!ref.mounted) return;
     if (channels != null && ref.isCurrentAccordClient(serverKey, client)) {
       state = _sorted(channels);
     }
   }
 
-  void setChannels(List<AccordChannel> channels) =>
-      state = _sorted(channels);
+  void setChannels(List<AccordChannel> channels) => state = _sorted(channels);
 
   /// Inserts [channel], or replaces it in place if already present.
   void upsertChannel(AccordChannel channel) {
@@ -49,16 +50,23 @@ class AccordChannelsController extends _$AccordChannelsController {
   /// Creates a channel in this space. Returns the created channel on success,
   /// optimistically inserting it (the gateway create event is deduped by id).
   Future<AccordChannel?> createChannel(
-      AccordClient client, Map<String, dynamic> data) async {
-    final channel = (await client.spaces.createChannel(spaceId, data))
-        .dataOrLog<AccordChannel>('create channel in $spaceId');
+    AccordClient client,
+    Map<String, dynamic> data,
+  ) async {
+    final channel = (await client.spaces.createChannel(
+      spaceId,
+      data,
+    )).dataOrLog<AccordChannel>('create channel in $spaceId');
     if (channel != null) upsertChannel(channel);
     return channel;
   }
 
   /// Patches a channel's settings, replacing it in place on success.
   Future<bool> updateChannel(
-      AccordClient client, String channelId, Map<String, dynamic> data) async {
+    AccordClient client,
+    String channelId,
+    Map<String, dynamic> data,
+  ) async {
     final result = await client.channels.update(channelId, data);
     if (!result.ok) {
       debugPrint('Failed to update channel $channelId: ${result.error}');

--- a/lib/features/channels/controllers/accord_channels.g.dart
+++ b/lib/features/channels/controllers/accord_channels.g.dart
@@ -72,7 +72,7 @@ final class AccordChannelsControllerProvider
 }
 
 String _$accordChannelsControllerHash() =>
-    r'6a426225ad17abc9b4da9c0914a82c99a854a911';
+    r'9c642174eb1069f812ba880ac7e7b3c093a93f5f';
 
 /// A space's channel list, keyed by space ID. The Accord analogue of Bonfire's
 /// firebridge-backed channel list. Self-loads via `spaces.listChannels` the

--- a/lib/features/channels/controllers/dm_channels.dart
+++ b/lib/features/channels/controllers/dm_channels.dart
@@ -37,13 +37,66 @@ bool isValidRemoteHandle(String value) {
 /// dialog has ever opened are intentionally dropped (the next open refetches).
 @Riverpod(keepAlive: true)
 class DmChannelsController extends _$DmChannelsController {
+  final Map<String, String> _previews = {};
+
   @override
   List<AccordChannel>? build(String serverKey) => null;
 
   /// Replaces the cache with a freshly-fetched list.
   void setChannels(List<AccordChannel> channels) {
+    final ids = channels.map((channel) => channel.id).toSet();
+    _previews.removeWhere((id, _) => !ids.contains(id));
     state = List.unmodifiable(channels);
   }
+
+  /// Last-message text shown under a DM conversation. Attachment-only messages
+  /// use a human-readable fallback rather than leaving a blank row.
+  String? previewFor(String channelId) => _previews[channelId];
+
+  /// Seeds a preview loaded alongside the conversation list without changing
+  /// its server-provided order.
+  void setPreview(String channelId, AccordMessage message) {
+    _previews[channelId] = _messagePreview(message);
+    final current = state;
+    if (current != null) state = [...current];
+  }
+
+  /// Applies live DM activity: update the preview, last-message id, and move the
+  /// conversation to the front. The gateway calls this even when the DM dialog
+  /// is closed, provided its list cache has been initialized once.
+  void applyMessage(AccordMessage message) {
+    final current = state;
+    if (current == null) return;
+    final index = current.indexWhere(
+      (channel) => channel.id == message.channelId,
+    );
+    if (index < 0) return;
+    final channel = current[index]..lastMessageId = message.id;
+    _previews[channel.id] = _messagePreview(message);
+    state = [channel, ...current.where((item) => item.id != channel.id)];
+  }
+
+  void updateMessagePreview(AccordMessage message) {
+    final current = state;
+    if (current == null) return;
+    final channel = _findChannel(current, message.channelId);
+    if (channel?.lastMessageId != message.id) return;
+    _previews[message.channelId] = _messagePreview(message);
+    state = [...current];
+  }
+
+  void removeMessagePreview(String channelId, String messageId) {
+    final current = state;
+    if (current == null) return;
+    final channel = _findChannel(current, channelId);
+    if (channel?.lastMessageId != messageId) return;
+    channel?.lastMessageId = null;
+    _previews.remove(channelId);
+    state = [...current];
+  }
+
+  bool contains(String channelId) =>
+      state?.any((channel) => channel.id == channelId) ?? false;
 
   /// Inserts or replaces [channel] (matched by id). Brand-new channels go to the
   /// front so a just-created group DM surfaces at the top of the list.
@@ -64,6 +117,23 @@ class DmChannelsController extends _$DmChannelsController {
   void remove(String channelId) {
     final current = state;
     if (current == null) return;
+    _previews.remove(channelId);
     state = current.removeById(channelId, (c) => c.id);
   }
+}
+
+String _messagePreview(AccordMessage message) {
+  final content = message.content.trim().replaceAll(RegExp(r'\s+'), ' ');
+  if (content.isNotEmpty) return content;
+  final count = message.attachments.length;
+  if (count == 1) return 'Attachment';
+  if (count > 1) return '$count attachments';
+  return 'Message';
+}
+
+AccordChannel? _findChannel(List<AccordChannel> channels, String channelId) {
+  for (final channel in channels) {
+    if (channel.id == channelId) return channel;
+  }
+  return null;
 }

--- a/lib/features/channels/controllers/dm_channels.g.dart
+++ b/lib/features/channels/controllers/dm_channels.g.dart
@@ -89,7 +89,7 @@ final class DmChannelsControllerProvider
 }
 
 String _$dmChannelsControllerHash() =>
-    r'64af0e28a6ad4e7d248b88bb9577374ad9d8db5d';
+    r'da7c5e45e5953677fc5a74eba49e18cddddf663e';
 
 /// Per-server cache of the current user's direct-message and group-DM channels
 /// (the ones with no `spaceId`). The direct-messages dialog populates it from a

--- a/lib/features/channels/utils/mark_channel_read.dart
+++ b/lib/features/channels/utils/mark_channel_read.dart
@@ -1,4 +1,3 @@
-import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
@@ -30,9 +29,10 @@ void markChannelRead(
   if (key == null) return;
   ref.read(readStateControllerProvider(key).notifier).markRead(channelId);
 
-  final messages = ref.read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', channelId));
-  final lastId =
-      messages?.isNotEmpty == true ? messages!.last.id : fallbackMessageId;
+  final messages = ref.read(accordMessagesControllerProvider(key, channelId));
+  final lastId = messages?.isNotEmpty == true
+      ? messages!.last.id
+      : fallbackMessageId;
   if (lastId == null) return;
   ref
       .read(accordAuthProvider.notifier)

--- a/lib/features/events/services/accord_event_handler.dart
+++ b/lib/features/events/services/accord_event_handler.dart
@@ -347,7 +347,9 @@ VoidCallback handleAccordEvents(
     if (!isActive()) return;
     final spaceId = channel.spaceId;
     if (spaceId == null) {
-      ref.read(dmChannelsControllerProvider(serverKey).notifier).upsert(channel);
+      ref
+          .read(dmChannelsControllerProvider(serverKey).notifier)
+          .upsert(channel);
     } else {
       ref
           .read(accordChannelsControllerProvider(serverKey, spaceId).notifier)
@@ -370,7 +372,9 @@ VoidCallback handleAccordEvents(
       if (!isActive()) return;
       final spaceId = channel.spaceId;
       if (spaceId == null) {
-        ref.read(dmChannelsControllerProvider(serverKey).notifier).remove(channel.id);
+        ref
+            .read(dmChannelsControllerProvider(serverKey).notifier)
+            .remove(channel.id);
         return;
       }
       ref
@@ -414,8 +418,18 @@ VoidCallback handleAccordEvents(
             channelId: message.channelId,
           ))) {
         ref
-            .read(accordMessagesControllerProvider(serverKey, message.channelId).notifier)
+            .read(
+              accordMessagesControllerProvider(
+                serverKey,
+                message.channelId,
+              ).notifier,
+            )
             .addMessage(message);
+      }
+      if (message.spaceId == null) {
+        ref
+            .read(dmChannelsControllerProvider(serverKey).notifier)
+            .applyMessage(message);
       }
 
       // Thread views: a message carrying `thread_id` is a reply — route it into
@@ -452,7 +466,12 @@ VoidCallback handleAccordEvents(
             channelId: message.channelId,
           ))) {
         ref
-            .read(forumPostsControllerProvider(serverKey, message.channelId).notifier)
+            .read(
+              forumPostsControllerProvider(
+                serverKey,
+                message.channelId,
+              ).notifier,
+            )
             .addPost(message);
       }
 
@@ -530,13 +549,23 @@ VoidCallback handleAccordEvents(
   // above.
   subs.add(
     client.onMessageUpdate.listen((message) {
+      if (message.spaceId == null) {
+        ref
+            .read(dmChannelsControllerProvider(serverKey).notifier)
+            .updateMessagePreview(message);
+      }
       if (!isActive()) return;
       if (activeMessageChannels.contains((
         serverKey: serverKey,
         channelId: message.channelId,
       ))) {
         ref
-            .read(accordMessagesControllerProvider(serverKey, message.channelId).notifier)
+            .read(
+              accordMessagesControllerProvider(
+                serverKey,
+                message.channelId,
+              ).notifier,
+            )
             .updateMessage(message);
       }
       // Route edits into open thread views (replies) and forum boards (root
@@ -565,24 +594,37 @@ VoidCallback handleAccordEvents(
             channelId: message.channelId,
           ))) {
         ref
-            .read(forumPostsControllerProvider(serverKey, message.channelId).notifier)
+            .read(
+              forumPostsControllerProvider(
+                serverKey,
+                message.channelId,
+              ).notifier,
+            )
             .updatePost(message);
       }
     }),
   );
   subs.add(
     client.onMessageDelete.listen((data) {
-      if (!isActive()) return;
       final channelId = data['channel_id']?.toString();
       final messageId =
           data['id']?.toString() ?? data['message_id']?.toString();
       if (channelId == null || messageId == null) return;
+      final dmChannels = ref.read(
+        dmChannelsControllerProvider(serverKey).notifier,
+      );
+      if (dmChannels.contains(channelId)) {
+        dmChannels.removeMessagePreview(channelId, messageId);
+      }
+      if (!isActive()) return;
       if (activeMessageChannels.contains((
         serverKey: serverKey,
         channelId: channelId,
       ))) {
         ref
-            .read(accordMessagesControllerProvider(serverKey, channelId).notifier)
+            .read(
+              accordMessagesControllerProvider(serverKey, channelId).notifier,
+            )
             .removeMessage(messageId);
       }
       // The delete payload carries no `thread_id`, so fan the removal out to
@@ -728,7 +770,9 @@ VoidCallback handleAccordEvents(
         return;
       }
       if (isSelf(userId)) return; // don't show our own typing
-      ref.read(typingControllerProvider(serverKey, channelId).notifier).userTyping(userId);
+      ref
+          .read(typingControllerProvider(serverKey, channelId).notifier)
+          .userTyping(userId);
     }),
   );
 
@@ -744,7 +788,9 @@ VoidCallback handleAccordEvents(
       return;
     }
     ref
-        .read(accordMembersControllerProvider(serverKey, member.spaceId).notifier)
+        .read(
+          accordMembersControllerProvider(serverKey, member.spaceId).notifier,
+        )
         .upsertMember(member);
   }
 

--- a/lib/features/messaging/controllers/accord_emojis.dart
+++ b/lib/features/messaging/controllers/accord_emojis.dart
@@ -24,6 +24,7 @@ class AccordEmojisController extends _$AccordEmojisController {
     final emojis = (await client.emojis.list(
       spaceId,
     )).listOrLog<AccordEmoji>('emojis for $spaceId');
+    if (!ref.mounted) return;
     if (emojis != null && ref.isCurrentAccordClient(serverKey, client)) {
       state = emojis;
     }

--- a/lib/features/messaging/controllers/accord_emojis.g.dart
+++ b/lib/features/messaging/controllers/accord_emojis.g.dart
@@ -69,7 +69,7 @@ final class AccordEmojisControllerProvider
 }
 
 String _$accordEmojisControllerHash() =>
-    r'07a95433e5bb4b6f9b7a4ea4bb11864878740113';
+    r'3f85d1a5b5c12933f465d56448d4ed94a36ec98a';
 
 /// A space's custom emoji, keyed by space ID. Self-loads via `emojis.list` the
 /// first time it's watched (once logged in). `null` means "not loaded yet";

--- a/lib/features/messaging/views/message_author_header.dart
+++ b/lib/features/messaging/views/message_author_header.dart
@@ -81,7 +81,9 @@ class MessageAuthorHeader extends StatelessWidget {
       overflow: ellipsizeName ? TextOverflow.ellipsis : null,
       style: theme.textTheme.titleSmall!.copyWith(color: nameColor),
     );
-    if (onNameTap != null) {
+    if (onNameTap != null ||
+        onNameLongPressStart != null ||
+        onNameSecondaryTapUp != null) {
       nameWidget = MouseRegion(
         cursor: SystemMouseCursors.click,
         child: GestureDetector(

--- a/lib/features/messaging/views/message_author_header.dart
+++ b/lib/features/messaging/views/message_author_header.dart
@@ -33,6 +33,8 @@ class MessageAuthorHeader extends StatelessWidget {
     this.timeTooltip,
     this.smallTime = false,
     this.edited = false,
+    this.onNameLongPressStart,
+    this.onNameSecondaryTapUp,
   });
 
   /// The resolved author display name.
@@ -67,6 +69,8 @@ class MessageAuthorHeader extends StatelessWidget {
 
   /// Whether to append the "(edited)" marker.
   final bool edited;
+  final GestureLongPressStartCallback? onNameLongPressStart;
+  final GestureTapUpCallback? onNameSecondaryTapUp;
 
   @override
   Widget build(BuildContext context) {
@@ -80,14 +84,22 @@ class MessageAuthorHeader extends StatelessWidget {
     if (onNameTap != null) {
       nameWidget = MouseRegion(
         cursor: SystemMouseCursors.click,
-        child: GestureDetector(onTap: onNameTap, child: nameWidget),
+        child: GestureDetector(
+          onTap: onNameTap,
+          onLongPressStart: onNameLongPressStart,
+          onSecondaryTapUp: onNameSecondaryTapUp,
+          child: nameWidget,
+        ),
       );
     }
     if (ellipsizeName) nameWidget = Flexible(child: nameWidget);
     Widget timeWidget = Text(
       time,
-      style: (smallTime ? theme.textTheme.labelSmall : theme.textTheme.labelMedium)!
-          .copyWith(color: colors.gray),
+      style:
+          (smallTime
+                  ? theme.textTheme.labelSmall
+                  : theme.textTheme.labelMedium)!
+              .copyWith(color: colors.gray),
     );
     if (timeTooltip != null) {
       timeWidget = Tooltip(message: timeTooltip!, child: timeWidget);

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -82,6 +82,12 @@ class MessagePane extends ConsumerStatefulWidget {
     this.panel = false,
     this.panelTitle,
     this.onClosePanel,
+    this.headerLeading,
+    this.headerTitle,
+    this.headerActions = const [],
+    this.canManageMessagesOverride,
+    this.onUserTap,
+    this.onUserContextMenu,
   });
 
   final AccordChannel? channel;
@@ -107,6 +113,26 @@ class MessagePane extends ConsumerStatefulWidget {
   /// Closes the panel. When null (or outside [panel] mode) no close button is
   /// shown.
   final VoidCallback? onClosePanel;
+
+  /// Optional DM-style header pieces. Normal channels use the built-in channel
+  /// icon and name; callers such as the direct-message dialog can supply a back
+  /// button/avatar, recipient title, and call/group actions while retaining the
+  /// shared pin and notification controls.
+  final Widget? headerLeading;
+  final Widget? headerTitle;
+  final List<Widget> headerActions;
+
+  /// Explicit message-management capability for contexts without a space role
+  /// model. Accord grants DM participants channel permissions directly, so DM
+  /// panes pass true while space channels continue using resolved permissions.
+  final bool? canManageMessagesOverride;
+
+  /// User interactions for contexts that do not have a space member popout.
+  /// In a DM these open the account-level profile/context menu supplied by the
+  /// DM feature; normal channels keep using [showAccordMemberPopout].
+  final ValueChanged<AccordUser>? onUserTap;
+  final void Function(AccordUser user, Offset? globalPosition)?
+  onUserContextMenu;
 
   @override
   ConsumerState<MessagePane> createState() => _MessagePaneState();
@@ -190,7 +216,12 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
     setState(() => _bulkDeleting = true);
     final ids = _selectedMessageIds.toList();
     final ok = await ref
-        .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', channelId).notifier)
+        .read(
+          accordMessagesControllerProvider(
+            ref.readActiveServerKey() ?? '',
+            channelId,
+          ).notifier,
+        )
         .bulkDelete(client, ids);
     if (!mounted) return;
     setState(() {
@@ -219,7 +250,10 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
     final position = _scroll.position;
     if (position.maxScrollExtent - position.pixels > 240) return;
     final notifier = ref.read(
-      accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', channelId).notifier,
+      accordMessagesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        channelId,
+      ).notifier,
     );
     if (notifier.isLoadingOlder || !notifier.hasMoreOlder) return;
     final client = ref.read(
@@ -259,11 +293,23 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
       );
     }
 
-    final messages = ref.watch(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', channelId));
+    final messages = ref.watch(
+      accordMessagesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        channelId,
+      ),
+    );
     final members = spaceId == null
         ? null
-        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId));
-    final userCache = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
+        : ref.watch(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              spaceId,
+            ),
+          );
+    final userCache = ref.watch(
+      accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
+    );
     final space = spaceId == null
         ? null
         : ref.watch(
@@ -294,10 +340,9 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
       memberRoleIds: myRoles.toSet(),
       currentUserId: currentUserId ?? '',
     );
-    final canManageMessages = accordHasPermission(
-      perms,
-      AccordPermission.manageMessages,
-    );
+    final canManageMessages =
+        widget.canManageMessagesOverride ??
+        accordHasPermission(perms, AccordPermission.manageMessages);
     final canSend = accordHasPermission(perms, AccordPermission.sendMessages);
     final canMentionEveryone = accordHasPermission(
       perms,
@@ -429,25 +474,34 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
                   )
                 : Row(
                     children: [
-                      Icon(
-                        panel
-                            ? Icons.chat_bubble_outline
-                            : channel?.type == 'announcement'
-                            ? Icons.campaign
-                            : Icons.tag,
-                        size: panel ? 16 : 18,
-                        color: colors.dirtyWhite,
-                      ),
-                      const SizedBox(width: 6),
-                      Expanded(
-                        child: Text(
+                      if (widget.headerLeading != null)
+                        widget.headerLeading!
+                      else ...[
+                        Icon(
                           panel
-                              ? (widget.panelTitle ?? channel?.name ?? 'Chat')
-                              : channel?.name ?? '',
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.titleSmall,
+                              ? Icons.chat_bubble_outline
+                              : channel?.type == 'announcement'
+                              ? Icons.campaign
+                              : Icons.tag,
+                          size: panel ? 16 : 18,
+                          color: colors.dirtyWhite,
                         ),
+                        const SizedBox(width: 6),
+                      ],
+                      Expanded(
+                        child:
+                            widget.headerTitle ??
+                            Text(
+                              panel
+                                  ? (widget.panelTitle ??
+                                        channel?.name ??
+                                        'Chat')
+                                  : channel?.name ?? '',
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleSmall,
+                            ),
                       ),
+                      ...widget.headerActions,
                       IconButton(
                         tooltip: 'Pinned messages',
                         onPressed: () => showPinnedMessages(
@@ -455,6 +509,8 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
                           channelId: channelId,
                           spaceId: spaceId,
                           canManage: canManageMessages,
+                          onUserTap: widget.onUserTap,
+                          onUserContextMenu: widget.onUserContextMenu,
                         ),
                         icon: Icon(
                           Icons.push_pin_outlined,
@@ -530,11 +586,15 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
                       // Members only loads the first page; backfill authors
                       // outside it from the on-demand user cache.
                       AccordUser? authorUser;
-                      if (author == null && members != null) {
+                      if (author == null) {
                         authorUser = userCache[message.authorId];
                         if (authorUser == null) {
                           ref
-                              .read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier)
+                              .read(
+                                accordUsersControllerProvider(
+                                  ref.readActiveServerKey() ?? '',
+                                ).notifier,
+                              )
                               .ensure(message.authorId);
                         }
                       }
@@ -583,6 +643,8 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
                         isOwn: isOwn,
                         mentionsMe: mentionsMe,
                         canManageMessages: canManageMessages,
+                        onUserTap: widget.onUserTap,
+                        onUserContextMenu: widget.onUserContextMenu,
                         selecting: _selecting,
                         selected: _selectedMessageIds.contains(message.id),
                         onLongPressSelect: canManageMessages
@@ -612,7 +674,11 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
                       members: members,
                       users: userCache,
                       ensure: ref
-                          .read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier)
+                          .read(
+                            accordUsersControllerProvider(
+                              ref.readActiveServerKey() ?? '',
+                            ).notifier,
+                          )
                           .ensure,
                     ),
               onCancelReply: () => setState(() => _replyTo = null),
@@ -668,20 +734,33 @@ class _TypingIndicator extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = BonfireThemeExtension.of(context);
-    final typing = ref.watch(typingControllerProvider(ref.readActiveServerKey() ?? '', channelId));
+    final typing = ref.watch(
+      typingControllerProvider(ref.readActiveServerKey() ?? '', channelId),
+    );
     final members = spaceId == null
         ? null
-        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId!));
-    final userCache = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
+        : ref.watch(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              spaceId!,
+            ),
+          );
+    final userCache = ref.watch(
+      accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
+    );
 
     String nameFor(String userId) {
       final member = members?[userId];
       if (member != null) return accordMemberName(member, fallback: 'Someone');
       final user = userCache[userId];
       if (user != null) return accordUserName(user, fallback: 'Someone');
-      if (members != null) {
-        ref.read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier).ensure(userId);
-      }
+      ref
+          .read(
+            accordUsersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+            ).notifier,
+          )
+          .ensure(userId);
       return 'Someone';
     }
 

--- a/lib/features/messaging/views/message_pane/message_row.dart
+++ b/lib/features/messaging/views/message_pane/message_row.dart
@@ -19,6 +19,8 @@ class _MessageRow extends ConsumerStatefulWidget {
     this.author,
     this.authorUser,
     this.nameColor,
+    this.onUserTap,
+    this.onUserContextMenu,
   });
 
   final AccordMessage message;
@@ -76,6 +78,12 @@ class _MessageRow extends ConsumerStatefulWidget {
 
   /// The author's highest colored-role color, or null for the default color.
   final Color? nameColor;
+
+  /// Account-level user interactions used by DM panes, where no space member
+  /// popout exists. Space rows continue to use the member popout directly.
+  final ValueChanged<AccordUser>? onUserTap;
+  final void Function(AccordUser user, Offset? globalPosition)?
+  onUserContextMenu;
 
   @override
   ConsumerState<_MessageRow> createState() => _MessageRowState();
@@ -194,7 +202,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     if (client == null || text.trim().isEmpty || _busy) return;
     setState(() => _busy = true);
     final ok = await ref
-        .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId).notifier)
+        .read(
+          accordMessagesControllerProvider(
+            ref.readActiveServerKey() ?? '',
+            widget.channelId,
+          ).notifier,
+        )
         .edit(client, messageId, text);
     if (!mounted) return;
     setState(() => _busy = false);
@@ -203,8 +216,18 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
 
   void _openPopout(String authorId) {
     final spaceId = widget.spaceId;
-    if (spaceId == null) return;
-    showAccordMemberPopout(context, spaceId: spaceId, userId: authorId);
+    if (spaceId != null) {
+      showAccordMemberPopout(context, spaceId: spaceId, userId: authorId);
+      return;
+    }
+    final user = widget.authorUser;
+    if (user != null) widget.onUserTap?.call(user);
+  }
+
+  void _openUserMenu([Offset? position]) {
+    final user = widget.author?.user ?? widget.authorUser;
+    if (user == null) return;
+    widget.onUserContextMenu?.call(user, position);
   }
 
   /// Opens a popup listing the users who added [reaction], lazy-loaded.
@@ -220,15 +243,16 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     );
   }
 
-  void _toggleReaction(
-    String messageId,
-    String emojiName, {
-    String? emojiId,
-  }) {
+  void _toggleReaction(String messageId, String emojiName, {String? emojiId}) {
     final client = _client;
     if (client == null) return;
     ref
-        .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId).notifier)
+        .read(
+          accordMessagesControllerProvider(
+            ref.readActiveServerKey() ?? '',
+            widget.channelId,
+          ).notifier,
+        )
         .toggleReaction(client, messageId, emojiName, emojiId: emojiId);
   }
 
@@ -242,7 +266,10 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     final client = _client;
     if (client == null) return;
     final controller = ref.read(
-      accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId).notifier,
+      accordMessagesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        widget.channelId,
+      ).notifier,
     );
     if (pinned) {
       await controller.unpin(client, messageId);
@@ -277,7 +304,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     if (confirmed != true || !mounted) return;
     setState(() => _busy = true);
     final ok = await ref
-        .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId).notifier)
+        .read(
+          accordMessagesControllerProvider(
+            ref.readActiveServerKey() ?? '',
+            widget.channelId,
+          ).notifier,
+        )
         .delete(client, messageId);
     if (!mounted) return;
     // Row disappears on success; if it failed we re-enable and say so, rather
@@ -312,7 +344,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
       widget.author?.user ?? widget.authorUser,
       message.authorId,
     );
-    final tappable = widget.spaceId != null;
+    final tappable =
+        widget.spaceId != null ||
+        (widget.authorUser != null && widget.onUserTap != null);
+    final userMenuEnabled =
+        widget.onUserContextMenu != null &&
+        (widget.author?.user != null || widget.authorUser != null);
     void openPopout() => _openPopout(message.authorId);
     // Hover actions are mouse-driven and have no affordance on touch, where
     // `Opacity` would still reserve their width and squeeze the message content
@@ -400,6 +437,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
                   _MaybeTappable(
                     enabled: tappable,
                     onTap: openPopout,
+                    onLongPressStart: userMenuEnabled
+                        ? (d) => _openUserMenu(d.globalPosition)
+                        : null,
+                    onSecondaryTapUp: userMenuEnabled
+                        ? (d) => _openUserMenu(d.globalPosition)
+                        : null,
                     child: AccordMemberAvatar(
                       avatarUrl: avatarUrl,
                       initial: _initial,
@@ -423,6 +466,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
                           // timestamp out of a narrow row.
                           ellipsizeName: true,
                           onNameTap: tappable ? openPopout : null,
+                          onNameLongPressStart: userMenuEnabled
+                              ? (d) => _openUserMenu(d.globalPosition)
+                              : null,
+                          onNameSecondaryTapUp: userMenuEnabled
+                              ? (d) => _openUserMenu(d.globalPosition)
+                              : null,
                           pinned: message.pinned,
                           origin: _authorOrigin,
                           time: _time,
@@ -468,6 +517,8 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     spaceId: widget.spaceId,
     root: message,
     canManageMessages: widget.canManageMessages,
+    onUserTap: widget.onUserTap,
+    onUserContextMenu: widget.onUserContextMenu,
   );
 
   void _report(String messageId) {
@@ -522,8 +573,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
             AccordMenuEntry(
               label: message.pinned ? 'Unpin' : 'Pin',
               icon: message.pinned ? Icons.push_pin_outlined : Icons.push_pin,
-              onSelected: () =>
-                  _togglePin(message.id, pinned: message.pinned),
+              onSelected: () => _togglePin(message.id, pinned: message.pinned),
             ),
         ],
       ),
@@ -592,7 +642,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     final spaceId = widget.spaceId;
     final customEmoji = spaceId == null
         ? const <AccordEmoji>[]
-        : ref.watch(accordEmojisControllerProvider(ref.readActiveServerKey() ?? '', spaceId)) ??
+        : ref.watch(
+                accordEmojisControllerProvider(
+                  ref.readActiveServerKey() ?? '',
+                  spaceId,
+                ),
+              ) ??
               const <AccordEmoji>[];
     return Padding(
       padding: const EdgeInsets.only(top: 4),
@@ -649,7 +704,10 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
   ) {
     final theme = Theme.of(context);
     final messages = ref.read(
-      accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId),
+      accordMessagesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        widget.channelId,
+      ),
     );
     final referenced = messages?.firstWhereOrNull(
       (m) => m.id == message.replyTo,
@@ -663,18 +721,27 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
       final member = widget.spaceId == null
           ? null
           : ref.watch(
-              accordMembersControllerProvider(ref.readActiveServerKey() ?? '',
+              accordMembersControllerProvider(
+                ref.readActiveServerKey() ?? '',
                 widget.spaceId!,
               ).select((m) => m?[authorId]),
             );
       final user = ref.watch(
-        accordUsersControllerProvider(ref.readActiveServerKey() ?? '').select((u) => u[authorId]),
+        accordUsersControllerProvider(
+          ref.readActiveServerKey() ?? '',
+        ).select((u) => u[authorId]),
       );
       name = accordAuthorNameOf(
         authorId,
         member: member,
         user: user,
-        ensure: ref.read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier).ensure,
+        ensure: ref
+            .read(
+              accordUsersControllerProvider(
+                ref.readActiveServerKey() ?? '',
+              ).notifier,
+            )
+            .ensure,
       );
       preview = referenced.content.isEmpty
           ? '(attachment)'

--- a/lib/features/messaging/views/message_pane/message_row.dart
+++ b/lib/features/messaging/views/message_pane/message_row.dart
@@ -45,7 +45,8 @@ class _MessageRow extends ConsumerStatefulWidget {
   final VoidCallback onReply;
 
   /// The space this message belongs to, for opening the author's profile
-  /// popout. `null` in contexts without a space (e.g. DMs, not yet supported).
+  /// popout. `null` in contexts without a space (e.g. DMs), which use
+  /// [onUserTap]/[onUserContextMenu] instead.
   final String? spaceId;
 
   /// Whether this message belongs to the current user (gates edit/delete).

--- a/lib/features/messaging/views/message_pane/message_row_actions.dart
+++ b/lib/features/messaging/views/message_pane/message_row_actions.dart
@@ -42,18 +42,27 @@ class _MaybeTappable extends StatelessWidget {
     required this.enabled,
     required this.onTap,
     required this.child,
+    this.onLongPressStart,
+    this.onSecondaryTapUp,
   });
 
   final bool enabled;
   final VoidCallback onTap;
   final Widget child;
+  final GestureLongPressStartCallback? onLongPressStart;
+  final GestureTapUpCallback? onSecondaryTapUp;
 
   @override
   Widget build(BuildContext context) {
     if (!enabled) return child;
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      child: GestureDetector(onTap: onTap, child: child),
+      child: GestureDetector(
+        onTap: onTap,
+        onLongPressStart: onLongPressStart,
+        onSecondaryTapUp: onSecondaryTapUp,
+        child: child,
+      ),
     );
   }
 }

--- a/lib/features/messaging/views/pinned_messages.dart
+++ b/lib/features/messaging/views/pinned_messages.dart
@@ -18,6 +18,8 @@ Future<void> showPinnedMessages(
   required String channelId,
   String? spaceId,
   required bool canManage,
+  ValueChanged<AccordUser>? onUserTap,
+  void Function(AccordUser user, Offset? globalPosition)? onUserContextMenu,
 }) {
   return showDialog<void>(
     context: context,
@@ -25,6 +27,8 @@ Future<void> showPinnedMessages(
       channelId: channelId,
       spaceId: spaceId,
       canManage: canManage,
+      onUserTap: onUserTap,
+      onUserContextMenu: onUserContextMenu,
     ),
   );
 }
@@ -34,11 +38,16 @@ class _PinnedMessagesDialog extends ConsumerStatefulWidget {
     required this.channelId,
     required this.spaceId,
     required this.canManage,
+    required this.onUserTap,
+    required this.onUserContextMenu,
   });
 
   final String channelId;
   final String? spaceId;
   final bool canManage;
+  final ValueChanged<AccordUser>? onUserTap;
+  final void Function(AccordUser user, Offset? globalPosition)?
+  onUserContextMenu;
 
   @override
   ConsumerState<_PinnedMessagesDialog> createState() =>
@@ -55,8 +64,11 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
   }
 
   Future<List<AccordMessage>> _load() async {
-    final client = ref.read(accordAuthProvider
-        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    final client = ref.read(
+      accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.client : null,
+      ),
+    );
     if (client == null) return const [];
     final result = await client.messages.listPins(widget.channelId);
     final data = result.data;
@@ -65,11 +77,19 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
   }
 
   Future<void> _unpin(AccordMessage message) async {
-    final client = ref.read(accordAuthProvider
-        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    final client = ref.read(
+      accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.client : null,
+      ),
+    );
     if (client == null) return;
     await ref
-        .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId).notifier)
+        .read(
+          accordMessagesControllerProvider(
+            ref.readActiveServerKey() ?? '',
+            widget.channelId,
+          ).notifier,
+        )
         .unpin(client, message.id);
     if (mounted) setState(() => _future = _load());
   }
@@ -79,10 +99,22 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
     final colors = BonfireThemeExtension.of(context);
     final members = widget.spaceId == null
         ? null
-        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId!));
-    final users = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
-    final ensureUser =
-        ref.read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier).ensure;
+        : ref.watch(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              widget.spaceId!,
+            ),
+          );
+    final users = ref.watch(
+      accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
+    );
+    final ensureUser = ref
+        .read(
+          accordUsersControllerProvider(
+            ref.readActiveServerKey() ?? '',
+          ).notifier,
+        )
+        .ensure;
     return Dialog(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 460, maxHeight: 560),
@@ -96,8 +128,10 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                 children: [
                   Icon(Icons.push_pin, size: 18, color: colors.dirtyWhite),
                   const SizedBox(width: 8),
-                  Text('Pinned messages',
-                      style: Theme.of(context).textTheme.titleMedium),
+                  Text(
+                    'Pinned messages',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
                   const Spacer(),
                   IconButton(
                     onPressed: () => Navigator.of(context).maybePop(),
@@ -122,8 +156,10 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                     return Padding(
                       padding: const EdgeInsets.all(32),
                       child: Center(
-                        child: Text('No pinned messages',
-                            style: Theme.of(context).textTheme.bodyMedium),
+                        child: Text(
+                          'No pinned messages',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
                       ),
                     );
                   }
@@ -134,18 +170,52 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                     separatorBuilder: (_, _) => const Divider(height: 1),
                     itemBuilder: (context, index) {
                       final message = pins[index];
-                      final name = accordAuthorName(message.authorId,
-                          members: members,
-                          users: users,
-                          ensure: ensureUser);
+                      final name = accordAuthorName(
+                        message.authorId,
+                        members: members,
+                        users: users,
+                        ensure: ensureUser,
+                      );
+                      final author =
+                          members?[message.authorId]?.user ??
+                          users[message.authorId];
+                      Widget authorName = Text(
+                        name,
+                        style: Theme.of(context).textTheme.titleSmall,
+                      );
+                      if (author != null &&
+                          (widget.onUserTap != null ||
+                              widget.onUserContextMenu != null)) {
+                        authorName = MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: widget.onUserTap == null
+                                ? null
+                                : () => widget.onUserTap!(author),
+                            onLongPressStart: widget.onUserContextMenu == null
+                                ? null
+                                : (details) => widget.onUserContextMenu!(
+                                    author,
+                                    details.globalPosition,
+                                  ),
+                            onSecondaryTapUp: widget.onUserContextMenu == null
+                                ? null
+                                : (details) => widget.onUserContextMenu!(
+                                    author,
+                                    details.globalPosition,
+                                  ),
+                            child: authorName,
+                          ),
+                        );
+                      }
                       return ListTile(
                         // Keyed by message id so rows track their message, not
                         // their slot, when the list reloads after an unpin
                         // (see #198). The unpin handler already captures its
                         // message rather than reading it back from the row.
                         key: ValueKey(message.id),
-                        title: Text(name,
-                            style: Theme.of(context).textTheme.titleSmall),
+                        title: authorName,
                         subtitle: Text(
                           message.content.isEmpty
                               ? '(attachment)'
@@ -157,8 +227,10 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                             ? IconButton(
                                 tooltip: 'Unpin',
                                 onPressed: () => _unpin(message),
-                                icon: const Icon(Icons.push_pin_outlined,
-                                    size: 18),
+                                icon: const Icon(
+                                  Icons.push_pin_outlined,
+                                  size: 18,
+                                ),
                               )
                             : null,
                       );

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -40,6 +40,8 @@ Future<ThreadResult?> showAccordThread(
   String? spaceId,
   required AccordMessage root,
   bool canManageMessages = false,
+  ValueChanged<AccordUser>? onUserTap,
+  void Function(AccordUser user, Offset? globalPosition)? onUserContextMenu,
 }) {
   return showDialog<ThreadResult>(
     context: context,
@@ -51,6 +53,8 @@ Future<ThreadResult?> showAccordThread(
           spaceId: spaceId,
           root: root,
           canManageMessages: canManageMessages,
+          onUserTap: onUserTap,
+          onUserContextMenu: onUserContextMenu,
           dialog: true,
           onClose: (result) => Navigator.of(dialogContext).pop(result),
         ),
@@ -90,6 +94,8 @@ class AccordThreadPane extends ConsumerStatefulWidget {
     required this.root,
     required this.canManageMessages,
     required this.onClose,
+    this.onUserTap,
+    this.onUserContextMenu,
     this.dialog = false,
   });
 
@@ -98,6 +104,9 @@ class AccordThreadPane extends ConsumerStatefulWidget {
   final AccordMessage root;
   final bool canManageMessages;
   final void Function(ThreadResult? result) onClose;
+  final ValueChanged<AccordUser>? onUserTap;
+  final void Function(AccordUser user, Offset? globalPosition)?
+  onUserContextMenu;
 
   /// When true, renders with dialog chrome (close icon, shrink-wrapped); when
   /// false, fills the available area with a back arrow.
@@ -143,7 +152,8 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     setState(() => _sending = true);
     final ok = await ref
         .read(
-          threadRepliesControllerProvider(ref.readActiveServerKey() ?? '',
+          threadRepliesControllerProvider(
+            ref.readActiveServerKey() ?? '',
             widget.channelId,
             widget.root.id,
           ).notifier,
@@ -216,7 +226,12 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
         break;
       }
     }
-    final channels = ref.read(accordChannelsControllerProvider(ref.readActiveServerKey() ?? '', spaceId));
+    final channels = ref.read(
+      accordChannelsControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        spaceId,
+      ),
+    );
     AccordChannel? channel;
     for (final c in channels ?? const <AccordChannel>[]) {
       if (c.id == widget.channelId) {
@@ -271,7 +286,11 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     final colors = BonfireThemeExtension.of(context);
     final theme = Theme.of(context);
     final replies = ref.watch(
-      threadRepliesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId, widget.root.id),
+      threadRepliesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        widget.channelId,
+        widget.root.id,
+      ),
     );
     final currentUserId = _currentUserId;
     final dialog = widget.dialog;
@@ -310,6 +329,8 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
             rootId: widget.root.id,
             isOwn: currentUserId != null && _root.authorId == currentUserId,
             canManageMessages: widget.canManageMessages,
+            onUserTap: widget.onUserTap,
+            onUserContextMenu: widget.onUserContextMenu,
             onEdit: _editRoot,
             onDelete: _deleteRoot,
           );
@@ -339,6 +360,8 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
           rootId: widget.root.id,
           isOwn: currentUserId != null && reply.authorId == currentUserId,
           canManageMessages: widget.canManageMessages,
+          onUserTap: widget.onUserTap,
+          onUserContextMenu: widget.onUserContextMenu,
         );
       },
     );
@@ -454,6 +477,8 @@ class _MessageLine extends ConsumerStatefulWidget {
     required this.rootId,
     required this.isOwn,
     required this.canManageMessages,
+    this.onUserTap,
+    this.onUserContextMenu,
     this.onEdit,
     this.onDelete,
   });
@@ -467,6 +492,9 @@ class _MessageLine extends ConsumerStatefulWidget {
   final String rootId;
   final bool isOwn;
   final bool canManageMessages;
+  final ValueChanged<AccordUser>? onUserTap;
+  final void Function(AccordUser user, Offset? globalPosition)?
+  onUserContextMenu;
 
   /// Root-only handlers (the root edits its title and pops on delete).
   final VoidCallback? onEdit;
@@ -489,7 +517,11 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
   AccordClient? get _client => ref.accordClient;
 
   ThreadRepliesController get _replies => ref.read(
-    threadRepliesControllerProvider(ref.readActiveServerKey() ?? '', widget.channelId, widget.rootId).notifier,
+    threadRepliesControllerProvider(
+      ref.readActiveServerKey() ?? '',
+      widget.channelId,
+      widget.rootId,
+    ).notifier,
   );
 
   bool get _canDelete => widget.isOwn || widget.canManageMessages;
@@ -535,8 +567,15 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
     final authorId = message.authorId;
     final member = widget.spaceId == null
         ? null
-        : ref.read(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId!))?[authorId];
-    final user = ref.read(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''))[authorId];
+        : ref.read(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              widget.spaceId!,
+            ),
+          )?[authorId];
+    final user = ref.read(
+      accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
+    )[authorId];
     final name = accordAuthorNameOf(authorId, member: member, user: user);
     final entries = buildMessageActionEntries(
       content: message.content,
@@ -567,14 +606,23 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
     final member = widget.spaceId == null
         ? null
         : ref.watch(
-            accordMembersControllerProvider(ref.readActiveServerKey() ?? '',
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
               widget.spaceId!,
             ).select((m) => m?[authorId]),
           );
     final user = ref.watch(
-      accordUsersControllerProvider(ref.readActiveServerKey() ?? '').select((m) => m[authorId]),
+      accordUsersControllerProvider(
+        ref.readActiveServerKey() ?? '',
+      ).select((m) => m[authorId]),
     );
-    final ensure = ref.read(accordUsersControllerProvider(ref.readActiveServerKey() ?? '').notifier).ensure;
+    final ensure = ref
+        .read(
+          accordUsersControllerProvider(
+            ref.readActiveServerKey() ?? '',
+          ).notifier,
+        )
+        .ensure;
     final cdnUrl = ref.watchCdnUrl();
     final name = accordAuthorNameOf(
       authorId,
@@ -589,6 +637,39 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
     );
     final avatarBg = accordAvatarColor(member?.user ?? user, authorId);
     final initial = accordInitial(name);
+    final author = member?.user ?? user;
+    final userActionsEnabled =
+        author != null &&
+        (widget.onUserTap != null || widget.onUserContextMenu != null);
+    void openUser() {
+      if (author != null) widget.onUserTap?.call(author);
+    }
+
+    void openUserMenu(Offset? position) {
+      if (author != null) widget.onUserContextMenu?.call(author, position);
+    }
+
+    Widget avatar = AccordMemberAvatar(
+      avatarUrl: avatarUrl,
+      initial: initial,
+      backgroundColor: avatarBg,
+      radius: 16,
+    );
+    if (userActionsEnabled) {
+      avatar = MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: widget.onUserTap == null ? null : openUser,
+          onLongPressStart: widget.onUserContextMenu == null
+              ? null
+              : (details) => openUserMenu(details.globalPosition),
+          onSecondaryTapUp: widget.onUserContextMenu == null
+              ? null
+              : (details) => openUserMenu(details.globalPosition),
+          child: avatar,
+        ),
+      );
+    }
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
@@ -604,12 +685,7 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              AccordMemberAvatar(
-                avatarUrl: avatarUrl,
-                initial: initial,
-                backgroundColor: avatarBg,
-                radius: 16,
-              ),
+              avatar,
               const SizedBox(width: 10),
               Expanded(
                 child: Column(
@@ -618,6 +694,17 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
                     MessageAuthorHeader(
                       name: name,
                       ellipsizeName: true,
+                      onNameTap: userActionsEnabled && widget.onUserTap != null
+                          ? openUser
+                          : null,
+                      onNameLongPressStart:
+                          userActionsEnabled && widget.onUserContextMenu != null
+                          ? (details) => openUserMenu(details.globalPosition)
+                          : null,
+                      onNameSecondaryTapUp:
+                          userActionsEnabled && widget.onUserContextMenu != null
+                          ? (details) => openUserMenu(details.globalPosition)
+                          : null,
                       time: _time,
                       smallTime: true,
                       edited: message.editedAt != null,

--- a/lib/features/spaces/views/accord_home_rail_tiles.dart
+++ b/lib/features/spaces/views/accord_home_rail_tiles.dart
@@ -729,6 +729,8 @@ class _RailIconTile extends StatelessWidget {
     required this.onTap,
     this.iconSize,
     this.iconColor,
+    this.hasUnread = false,
+    this.mentionCount = 0,
   });
 
   final String tooltip;
@@ -738,6 +740,8 @@ class _RailIconTile extends StatelessWidget {
 
   /// Icon tint; defaults to the theme's `dirtyWhite`.
   final Color? iconColor;
+  final bool hasUnread;
+  final int mentionCount;
 
   @override
   Widget build(BuildContext context) {
@@ -747,19 +751,45 @@ class _RailIconTile extends StatelessWidget {
         message: tooltip,
         child: GestureDetector(
           onTap: onTap,
-          child: Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              color: colors.darkGray,
-              borderRadius: BorderRadius.circular(24),
-            ),
-            alignment: Alignment.center,
-            child: Icon(
-              icon,
-              size: iconSize,
-              color: iconColor ?? colors.dirtyWhite,
-            ),
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: colors.darkGray,
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  icon,
+                  size: iconSize,
+                  color: iconColor ?? colors.dirtyWhite,
+                ),
+              ),
+              if (mentionCount > 0)
+                Positioned(
+                  right: -4,
+                  top: -2,
+                  child: _MentionBadge(count: mentionCount),
+                )
+              else if (hasUnread)
+                Positioned(
+                  left: -4,
+                  top: 18,
+                  child: Container(
+                    width: 8,
+                    height: 12,
+                    decoration: const BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.horizontal(
+                        right: Radius.circular(4),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
           ),
         ),
       ),
@@ -770,18 +800,46 @@ class _RailIconTile extends StatelessWidget {
 /// The Direct Messages affordance pinned at the top of the rail, styled as a
 /// space-icon tile (Discord-style "home" button) rather than a small footer
 /// icon. Opens the DM/friends modal.
-class _DirectMessagesButton extends StatelessWidget {
+class _DirectMessagesButton extends ConsumerWidget {
   const _DirectMessagesButton({required this.onTap});
 
   final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context) => _RailIconTile(
-    tooltip: 'Direct messages',
-    icon: Icons.chat_bubble_outline,
-    iconSize: 22,
-    onTap: onTap,
-  );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connections = ref.watch(
+      connectionsControllerProvider.select((state) => state.connections),
+    );
+    var hasUnread = false;
+    var mentions = 0;
+    for (final connection in connections) {
+      final snapshot = ref.watch(readStateControllerProvider(connection.key));
+      final levels = ref.watch(
+        settingsControllerProvider.select(
+          (settings) => settings.channelNotificationsFor(connection.key),
+        ),
+      );
+      for (final entry in snapshot.entries.values) {
+        if (entry.spaceId != null ||
+            !UnreadIndicatorGate.countsTowardSpace(
+              spaceMuted: false,
+              channelLevel: levels[entry.channelId],
+            )) {
+          continue;
+        }
+        hasUnread = true;
+        mentions += entry.mentions;
+      }
+    }
+    return _RailIconTile(
+      tooltip: 'Direct messages',
+      icon: Icons.chat_bubble_outline,
+      iconSize: 22,
+      hasUnread: hasUnread,
+      mentionCount: mentions,
+      onTap: onTap,
+    );
+  }
 }
 
 /// The "Add a Server" (+) affordance at the foot of the rail's space list.

--- a/lib/features/user/views/accord_direct_messages.dart
+++ b/lib/features/user/views/accord_direct_messages.dart
@@ -1,18 +1,21 @@
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
-import 'package:bonfire/features/messaging/utils/emoticons.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/messaging/views/message_pane/message_pane.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
+import 'package:bonfire/shared/components/context_menu.dart';
 import 'package:bonfire/shared/components/user_avatar.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/shared/utils/restore_failed_send.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/text_prompt_dialog.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/member/views/remote_origin_badge.dart';
-import 'package:bonfire/features/messaging/views/box/accord_message_content.dart';
+import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/features/voice/controllers/call.dart';
 import 'package:bonfire/features/voice/controllers/missed_calls.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
@@ -20,6 +23,7 @@ import 'package:bonfire/features/voice/views/voice_pip_overlay.dart';
 import 'package:bonfire/features/voice/views/voice_view.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'accord_direct_messages_conversations.dart';
@@ -127,6 +131,204 @@ void _snackDmError(BuildContext context, AccordError? error, String fallback) {
   );
 }
 
+/// Account-level profile used where there is no space/member context. It keeps
+/// DM author and recipient interactions useful without pretending that a DM
+/// user has space roles, nicknames, or moderation controls.
+Future<void> showAccordUserProfile(
+  BuildContext context,
+  AccordUser user, {
+  String? cdnUrl,
+}) {
+  final name = _userName(user);
+  final origin = accordUserOrigin(user);
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 340),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            UserAvatar(
+              name,
+              imageUrl: accordAvatarUrl(user, cdnUrl),
+              radius: 30,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(name, style: Theme.of(context).textTheme.titleMedium),
+                  if (user.username.isNotEmpty) Text('@${user.username}'),
+                  const SizedBox(height: 8),
+                  SelectableText(user.id),
+                  if (origin != null) ...[
+                    const SizedBox(height: 8),
+                    RemoteOriginBadge(domain: origin),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Responsive right-click/long-press menu for users shown in DMs. Relationship
+/// state is fetched when the menu opens so the action is accurate even when the
+/// Friends tab has not been visited this session.
+Future<void> showAccordDmUserContextMenu(
+  BuildContext context,
+  WidgetRef ref,
+  AccordUser user, {
+  Offset? globalPosition,
+  String? currentDmUserId,
+  List<AccordMenuEntry> extraEntries = const [],
+}) async {
+  final client = ref.accordClient;
+  final selfId = ref.readUserId();
+  AccordRelationship? relationship;
+  if (client != null && user.id != selfId) {
+    final result = await client.users.listRelationships();
+    final data = result.data;
+    if (data is List) {
+      for (final item in data.whereType<AccordRelationship>()) {
+        if (item.user?.id == user.id) {
+          relationship = item;
+          break;
+        }
+      }
+    }
+  }
+  if (!context.mounted) return;
+
+  final rel = relationship;
+  final entries = <AccordMenuEntry>[
+    AccordMenuEntry(
+      label: 'View profile',
+      icon: Icons.account_circle_outlined,
+      onSelected: () =>
+          showAccordUserProfile(context, user, cdnUrl: ref.readCdnUrl()),
+    ),
+    if (user.id != selfId && user.id != currentDmUserId)
+      AccordMenuEntry(
+        label: 'Direct message',
+        icon: Icons.chat_bubble_outline,
+        onSelected: () => openAccordDirectMessage(context, ref, user.id),
+      ),
+    if (user.id != selfId) ...[
+      AccordMenuEntry(
+        label: switch (rel?.type) {
+          _Rel.friend => 'Remove friend',
+          _Rel.blocked => 'Unblock',
+          _Rel.pendingIn => 'Accept friend request',
+          _Rel.pendingOut => 'Cancel friend request',
+          _ => 'Add friend',
+        },
+        icon: switch (rel?.type) {
+          _Rel.friend => Icons.person_remove_outlined,
+          _Rel.blocked => Icons.lock_open_outlined,
+          _Rel.pendingIn => Icons.person_add_alt_1,
+          _Rel.pendingOut => Icons.person_remove_outlined,
+          _ => Icons.person_add_outlined,
+        },
+        destructive: rel?.type == _Rel.friend,
+        onSelected: () => _changeDmRelationship(context, ref, user, rel?.type),
+      ),
+      if (rel?.type != _Rel.blocked)
+        AccordMenuEntry(
+          label: 'Block',
+          icon: Icons.block,
+          destructive: true,
+          onSelected: () => _blockDmUser(context, ref, user),
+        ),
+    ],
+    const AccordMenuEntry.divider(),
+    AccordMenuEntry(
+      label: 'Copy user ID',
+      icon: Icons.copy_outlined,
+      onSelected: () => Clipboard.setData(ClipboardData(text: user.id)),
+    ),
+    if (user.username.isNotEmpty)
+      AccordMenuEntry(
+        label: 'Copy username',
+        icon: Icons.alternate_email,
+        onSelected: () => Clipboard.setData(ClipboardData(text: user.username)),
+      ),
+    ...extraEntries,
+  ];
+  await showAccordContextMenu(
+    context,
+    entries: entries,
+    globalPosition: globalPosition,
+    title: _userName(user),
+    titleIcon: Icons.person_outline,
+  );
+}
+
+Future<void> _changeDmRelationship(
+  BuildContext context,
+  WidgetRef ref,
+  AccordUser user,
+  int? currentType,
+) async {
+  final client = ref.accordClient;
+  if (client == null) return;
+  final removing =
+      currentType == _Rel.friend ||
+      currentType == _Rel.blocked ||
+      currentType == _Rel.pendingOut;
+  final result = removing
+      ? await client.users.deleteRelationship(user.id)
+      : await client.users.putRelationship(user.id, {'type': _Rel.friend});
+  if (!context.mounted) return;
+  showInfoSnack(
+    context,
+    result.ok
+        ? switch (currentType) {
+            _Rel.friend => 'Friend removed',
+            _Rel.blocked => 'User unblocked',
+            _Rel.pendingIn => 'Friend request accepted',
+            _Rel.pendingOut => 'Friend request cancelled',
+            _ => 'Friend request sent',
+          }
+        : 'Failed to update relationship',
+  );
+}
+
+Future<void> _blockDmUser(
+  BuildContext context,
+  WidgetRef ref,
+  AccordUser user,
+) async {
+  final confirmed = await showConfirmDialog(
+    context,
+    title: 'Block user',
+    message: 'Blocked users cannot DM you and their messages are hidden.',
+    confirmLabel: 'Block',
+    danger: true,
+  );
+  if (confirmed != true || !context.mounted) return;
+  final result = await ref.accordClient?.users.putRelationship(user.id, {
+    'type': _Rel.blocked,
+  });
+  if (!context.mounted) return;
+  showInfoSnack(
+    context,
+    result?.ok == true ? 'User blocked' : 'Failed to block user',
+  );
+}
+
 class _DirectMessagesDialog extends ConsumerStatefulWidget {
   const _DirectMessagesDialog({this.initialChannel});
 
@@ -159,7 +361,7 @@ class _DirectMessagesDialogState extends ConsumerState<_DirectMessagesDialog>
       backgroundColor: colors.foreground,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: ConstrainedBox(
-        constraints: dialogConstraints(context, maxWidth: 560, maxHeight: 620),
+        constraints: dialogConstraints(context, maxWidth: 900, maxHeight: 720),
         child: openChannel != null
             ? _DmConversation(
                 channel: openChannel,

--- a/lib/features/user/views/accord_direct_messages_conversations.dart
+++ b/lib/features/user/views/accord_direct_messages_conversations.dart
@@ -103,10 +103,18 @@ class _DmListTabState extends ConsumerState<_DmListTab> {
     final client = _client;
     final serverKey = ref.readActiveServerKey();
     if (client == null || serverKey == null) return;
-    final result = await client.channels.delete(channel.id);
+    final selfId = widget.selfId;
+    if (group && selfId == null) return;
+    final result = group
+        ? await client.channels.removeRecipient(channel.id, selfId!)
+        : await client.channels.delete(channel.id);
     if (!mounted || ref.readActiveServerKey() != serverKey) return;
     if (!result.ok) {
-      _snackDmError(context, result.error, 'Failed to close conversation');
+      _snackDmError(
+        context,
+        result.error,
+        group ? 'Failed to leave group' : 'Failed to close conversation',
+      );
       return;
     }
     ref

--- a/lib/features/user/views/accord_direct_messages_conversations.dart
+++ b/lib/features/user/views/accord_direct_messages_conversations.dart
@@ -11,6 +11,8 @@ class _DmListTab extends ConsumerStatefulWidget {
 }
 
 class _DmListTabState extends ConsumerState<_DmListTab> {
+  final _search = TextEditingController();
+
   @override
   void initState() {
     super.initState();
@@ -19,6 +21,12 @@ class _DmListTabState extends ConsumerState<_DmListTab> {
 
   AccordClient? get _client => ref.accordClient;
 
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
   Future<void> _load() async {
     final client = _client;
     final serverKey = ref.readActiveServerKey();
@@ -26,9 +34,28 @@ class _DmListTabState extends ConsumerState<_DmListTab> {
     final result = await client.users.listChannels();
     if (!mounted || ref.readActiveServerKey() != serverKey) return;
     final data = result.data;
-    ref.read(dmChannelsControllerProvider(serverKey).notifier).setChannels(
-          data is List ? data.whereType<AccordChannel>().toList() : const [],
-        );
+    final channels = data is List
+        ? data.whereType<AccordChannel>().toList()
+        : <AccordChannel>[];
+    final controller = ref.read(
+      dmChannelsControllerProvider(serverKey).notifier,
+    );
+    controller.setChannels(channels);
+    await Future.wait([
+      for (final channel in channels)
+        client.messages.list(channel.id, query: {'limit': 1}).then((result) {
+          if (!mounted || ref.readActiveServerKey() != serverKey) return;
+          final messages = result.data;
+          if (result.ok && messages is List) {
+            AccordMessage? latest;
+            for (final message in messages.whereType<AccordMessage>()) {
+              latest = message;
+              break;
+            }
+            if (latest != null) controller.setPreview(channel.id, latest);
+          }
+        }),
+    ]);
   }
 
   Future<void> _createGroup() async {
@@ -61,31 +88,127 @@ class _DmListTabState extends ConsumerState<_DmListTab> {
     await openAccordDirectMessage(context, ref, handle);
   }
 
+  Future<void> _closeConversation(AccordChannel channel) async {
+    final group = _isGroup(channel, widget.selfId);
+    final confirmed = await showConfirmDialog(
+      context,
+      title: group ? 'Leave group' : 'Close direct message',
+      message: group
+          ? 'Leave ${_channelTitle(channel, widget.selfId)}? You can be re-added later.'
+          : 'Remove this conversation from your direct-message list? Its history is retained if you message this user again.',
+      confirmLabel: group ? 'Leave' : 'Close',
+      danger: true,
+    );
+    if (confirmed != true || !mounted) return;
+    final client = _client;
+    final serverKey = ref.readActiveServerKey();
+    if (client == null || serverKey == null) return;
+    final result = await client.channels.delete(channel.id);
+    if (!mounted || ref.readActiveServerKey() != serverKey) return;
+    if (!result.ok) {
+      _snackDmError(context, result.error, 'Failed to close conversation');
+      return;
+    }
+    ref
+        .read(dmChannelsControllerProvider(serverKey).notifier)
+        .remove(channel.id);
+    ref
+        .read(readStateControllerProvider(serverKey).notifier)
+        .markRead(channel.id);
+  }
+
+  void _showConversationMenu(AccordChannel channel, Offset? position) {
+    final group = _isGroup(channel, widget.selfId);
+    final others = _others(channel, widget.selfId);
+    final user = !group && others.isNotEmpty ? others.first : null;
+    final closeEntry = AccordMenuEntry(
+      label: group ? 'Leave group' : 'Close direct message',
+      icon: group ? Icons.logout : Icons.close,
+      destructive: true,
+      onSelected: () => _closeConversation(channel),
+    );
+    if (user != null) {
+      showAccordDmUserContextMenu(
+        context,
+        ref,
+        user,
+        globalPosition: position,
+        currentDmUserId: user.id,
+        extraEntries: [const AccordMenuEntry.divider(), closeEntry],
+      );
+      return;
+    }
+    showAccordContextMenu(
+      context,
+      entries: [closeEntry],
+      globalPosition: position,
+      title: _channelTitle(channel, widget.selfId),
+      titleIcon: Icons.group_outlined,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
-    final channels = ref.watch(dmChannelsControllerProvider(ref.readActiveServerKey() ?? ''));
+    final serverKey = ref.watchActiveServerKey() ?? '';
+    final channels = ref.watch(dmChannelsControllerProvider(serverKey));
+    final previews = ref.read(dmChannelsControllerProvider(serverKey).notifier);
     final cdnUrl = ref.watchCdnUrl();
     final missed = ref.watch(missedCallsControllerProvider);
+    final readState = ref.watch(readStateControllerProvider(serverKey));
+    final channelLevels = ref.watch(
+      settingsControllerProvider.select(
+        (settings) => settings.channelNotificationsFor(serverKey),
+      ),
+    );
+    final query = _search.text.trim().toLowerCase();
+    final filtered = channels
+        ?.where(
+          (channel) =>
+              query.isEmpty ||
+              _channelTitle(
+                channel,
+                widget.selfId,
+              ).toLowerCase().contains(query),
+        )
+        .toList();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
+          child: Column(
             children: [
-              FilledButton.icon(
-                onPressed: _createGroup,
-                icon: const Icon(Icons.group_add, size: 18),
-                label: const Text('New group'),
+              TextField(
+                controller: _search,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  isDense: true,
+                  prefixIcon: Icon(Icons.search, size: 20),
+                  hintText: 'Search conversations',
+                  border: OutlineInputBorder(),
+                ),
               ),
-              OutlinedButton.icon(
-                onPressed: _messageRemoteUser,
-                icon: const Icon(Icons.alternate_email, size: 18),
-                label: const Text('Message remote user'),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: _createGroup,
+                      icon: const Icon(Icons.group_add, size: 18),
+                      label: const Text('New group'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: _messageRemoteUser,
+                      icon: const Icon(Icons.alternate_email, size: 18),
+                      label: const Text('Message remote user'),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),
@@ -93,69 +216,118 @@ class _DmListTabState extends ConsumerState<_DmListTab> {
         Expanded(
           child: channels == null
               ? const LoadingView()
-              : channels.isEmpty
-                  ? Center(
-                      child: Text('No direct messages yet',
-                          style: theme.textTheme.bodyMedium))
-                  : ListView.builder(
-                      padding: const EdgeInsets.all(8),
-                      itemCount: channels.length,
-                      itemBuilder: (context, index) {
-                        final channel = channels[index];
-                        final title = _channelTitle(channel, widget.selfId);
-                        final group = _isGroup(channel, widget.selfId);
-                        final origin =
-                            _dmRemoteOrigin(channel, widget.selfId);
-                        final others = _others(channel, widget.selfId);
-                        final other =
-                            group || others.isEmpty ? null : others.first;
-                        final avatarUrl = other == null
-                            ? null
-                            : accordAvatarUrl(other, cdnUrl);
-                        final missedCall = missed[channel.id];
-                        return ListTile(
-                          leading: group
-                              ? CircleAvatar(
-                                  backgroundColor: colors.darkGray,
-                                  child: Icon(Icons.group,
-                                      size: 18, color: colors.dirtyWhite),
-                                )
-                              : UserAvatar(title,
-                                  imageUrl: avatarUrl, radius: 20),
-                          title: Row(
-                            children: [
-                              Flexible(
-                                child: Text(title,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis),
+              : filtered!.isEmpty
+              ? Center(
+                  child: Text(
+                    query.isEmpty
+                        ? 'No direct messages yet'
+                        : 'No matching conversations',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final channel = filtered[index];
+                    final title = _channelTitle(channel, widget.selfId);
+                    final group = _isGroup(channel, widget.selfId);
+                    final origin = _dmRemoteOrigin(channel, widget.selfId);
+                    final others = _others(channel, widget.selfId);
+                    final other = group || others.isEmpty ? null : others.first;
+                    final avatarUrl = other == null
+                        ? null
+                        : accordAvatarUrl(other, cdnUrl);
+                    final missedCall = missed[channel.id];
+                    final unread = readState.isUnreadVisible(
+                      channel.id,
+                      channelLevels: channelLevels,
+                    );
+                    final mentions = readState.visibleMentionCount(
+                      channel.id,
+                      channelLevels: channelLevels,
+                    );
+                    final preview = previews.previewFor(channel.id);
+                    final tile = ListTile(
+                      tileColor: unread
+                          ? colors.primary.withValues(alpha: 0.08)
+                          : null,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      leading: group
+                          ? CircleAvatar(
+                              backgroundColor: colors.darkGray,
+                              child: Icon(
+                                Icons.group,
+                                size: 18,
+                                color: colors.dirtyWhite,
                               ),
-                              if (origin != null) ...[
-                                const SizedBox(width: 6),
-                                RemoteOriginBadge(domain: origin),
-                              ],
-                            ],
-                          ),
-                          subtitle: missedCall != null
-                              ? _MissedCallLabel(missed: missedCall)
-                              : group
-                                  ? Text(
-                                      '${_others(channel, widget.selfId).length + 1} members',
-                                      style: theme.textTheme.bodySmall)
+                            )
+                          : UserAvatar(title, imageUrl: avatarUrl, radius: 20),
+                      title: Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: unread
+                                  ? const TextStyle(fontWeight: FontWeight.w700)
                                   : null,
-                          trailing: missedCall == null
-                              ? null
-                              : Container(
-                                  width: 10,
-                                  height: 10,
-                                  decoration: BoxDecoration(
-                                    color: colors.red,
-                                    shape: BoxShape.circle,
-                                  ),
-                                ),
-                          onTap: () => widget.onOpen(channel),
-                        );
-                      },
-                    ),
+                            ),
+                          ),
+                          if (origin != null) ...[
+                            const SizedBox(width: 6),
+                            RemoteOriginBadge(domain: origin),
+                          ],
+                        ],
+                      ),
+                      subtitle: missedCall != null
+                          ? _MissedCallLabel(missed: missedCall)
+                          : preview != null
+                          ? Text(
+                              preview,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall,
+                            )
+                          : group
+                          ? Text(
+                              '${_others(channel, widget.selfId).length + 1} members',
+                              style: theme.textTheme.bodySmall,
+                            )
+                          : null,
+                      trailing: mentions > 0
+                          ? Badge(label: Text('$mentions'))
+                          : unread || missedCall != null
+                          ? Container(
+                              width: 10,
+                              height: 10,
+                              decoration: BoxDecoration(
+                                color: missedCall != null
+                                    ? colors.red
+                                    : colors.primary,
+                                shape: BoxShape.circle,
+                              ),
+                            )
+                          : null,
+                      onTap: () => widget.onOpen(channel),
+                    );
+                    return GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onLongPressStart: (details) => _showConversationMenu(
+                        channel,
+                        details.globalPosition,
+                      ),
+                      onSecondaryTapUp: (details) => _showConversationMenu(
+                        channel,
+                        details.globalPosition,
+                      ),
+                      child: tile,
+                    );
+                  },
+                ),
         ),
       ],
     );
@@ -172,19 +344,26 @@ class _MissedCallLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
-    final style = Theme.of(context)
-        .textTheme
-        .bodySmall
-        ?.copyWith(color: colors.red, fontWeight: FontWeight.w600);
+    final style = Theme.of(context).textTheme.bodySmall?.copyWith(
+      color: colors.red,
+      fontWeight: FontWeight.w600,
+    );
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(missed.video ? Icons.missed_video_call : Icons.call_missed,
-            size: 14, color: colors.red),
+        Icon(
+          missed.video ? Icons.missed_video_call : Icons.call_missed,
+          size: 14,
+          color: colors.red,
+        ),
         const SizedBox(width: 4),
         Flexible(
-          child: Text(missed.label,
-              style: style, maxLines: 1, overflow: TextOverflow.ellipsis),
+          child: Text(
+            missed.label,
+            style: style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
       ],
     );
@@ -207,29 +386,41 @@ class _DmConversation extends ConsumerStatefulWidget {
 }
 
 class _DmConversationState extends ConsumerState<_DmConversation> {
-  final _input = TextEditingController();
-  final _inputFocus = FocusNode();
-  List<AccordMessage>? _messages;
   late AccordChannel _channel = widget.channel;
-  bool _sending = false;
+  late final String _serverKey = ref.readActiveServerKey() ?? '';
+  ServerChannelKey? _previousVisibleChannel;
 
   @override
   void initState() {
     super.initState();
-    _load();
+    _previousVisibleChannel = accordVisibleChannel;
     // Opening the conversation is the acknowledgement: drop any missed-call
     // indicator for it. Deferred a frame — `initState` runs during a build, and
     // Riverpod forbids mutating a provider from inside one.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      for (final user in _channel.recipients ?? const <AccordUser>[]) {
+        ref
+            .read(accordUsersControllerProvider(_serverKey).notifier)
+            .upsert(user);
+      }
+      accordVisibleChannel = (serverKey: _serverKey, channelId: _channel.id);
+      markChannelRead(
+        ref,
+        _channel.id,
+        serverKey: _serverKey,
+        fallbackMessageId: _channel.lastMessageId,
+      );
       ref.read(missedCallsControllerProvider.notifier).clear(_channel.id);
     });
   }
 
   @override
   void dispose() {
-    _input.dispose();
-    _inputFocus.dispose();
+    final visible = accordVisibleChannel;
+    if (visible?.serverKey == _serverKey && visible?.channelId == _channel.id) {
+      accordVisibleChannel = _previousVisibleChannel;
+    }
     super.dispose();
   }
 
@@ -240,25 +431,17 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
   bool get _isOwner =>
       _channel.ownerId != null && _channel.ownerId == widget.selfId;
 
-  Future<void> _load() async {
-    final client = _client;
-    if (client == null) return;
-    final result =
-        await client.messages.list(_channel.id, query: {'limit': 50});
-    if (!mounted) return;
-    final data = result.data;
-    setState(() {
-      _messages = data is List
-          ? data.whereType<AccordMessage>().toList().reversed.toList()
-          : <AccordMessage>[];
-    });
-  }
-
   /// Updates the local channel and mirrors it into the shared DM cache so the
   /// list behind this conversation reflects the change too.
   void _setChannel(AccordChannel channel) {
     setState(() => _channel = channel);
-    ref.read(dmChannelsControllerProvider(ref.readActiveServerKey() ?? '').notifier).upsert(channel);
+    ref
+        .read(
+          dmChannelsControllerProvider(
+            ref.readActiveServerKey() ?? '',
+          ).notifier,
+        )
+        .upsert(channel);
   }
 
   /// Refetches the channel so the recipient list reflects add/remove changes.
@@ -271,40 +454,6 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
     if (result.ok && data is AccordChannel) {
       _setChannel(data);
     }
-  }
-
-  Future<void> _send() async {
-    final raw = _input.text.trim();
-    // Same conversion as the main composer — emoticons resolve on send so every
-    // client stores and renders the identical glyph.
-    final text =
-        ref.read(settingsControllerProvider.select((s) => s.convertEmoticons))
-        ? applyEmoticons(raw)
-        : raw;
-    if (text.isEmpty || _sending) return;
-    final client = _client;
-    if (client == null) return;
-    // Clear up front rather than after the round-trip. The field is never
-    // disabled (that would drop focus and the mobile keyboard for the whole
-    // send), so it has to be free for the next message straight away; the text
-    // comes back if the send fails.
-    _input.clear();
-    setState(() => _sending = true);
-    final result =
-        await client.messages.create(_channel.id, {'content': text});
-    if (!mounted) return;
-    final message = result.data;
-    if (result.ok && message is AccordMessage) {
-      setState(() {
-        _sending = false;
-        _messages = [...?_messages, message];
-      });
-      return;
-    }
-    // Hand the message back so it can be retried instead of retyped.
-    setState(() => _sending = false);
-    restoreFailedSend(_input, text);
-    _snack('Failed to send message');
   }
 
   Future<void> _addMember() async {
@@ -334,10 +483,12 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
     final client = _client;
     if (client == null) return;
     final ok = await _confirm(
-        'Remove member', 'Remove ${_userName(user)} from this group?', 'Remove');
+      'Remove member',
+      'Remove ${_userName(user)} from this group?',
+      'Remove',
+    );
     if (ok != true) return;
-    final result =
-        await client.channels.removeRecipient(_channel.id, user.id);
+    final result = await client.channels.removeRecipient(_channel.id, user.id);
     if (!mounted) return;
     if (result.ok) {
       await _refreshChannel();
@@ -356,8 +507,9 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
     if (name == null) return;
     final client = _client;
     if (client == null) return;
-    final result =
-        await client.channels.update(_channel.id, {'name': name.trim()});
+    final result = await client.channels.update(_channel.id, {
+      'name': name.trim(),
+    });
     if (!mounted) return;
     final data = result.data;
     if (result.ok && data is AccordChannel) {
@@ -374,12 +526,21 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
     final client = _client;
     if (client == null || selfId == null) return;
     final ok = await _confirm(
-        'Leave group', 'Leave this group? You can be re-added later.', 'Leave');
+      'Leave group',
+      'Leave this group? You can be re-added later.',
+      'Leave',
+    );
     if (ok != true) return;
     final result = await client.channels.removeRecipient(_channel.id, selfId);
     if (!mounted) return;
     if (result.ok) {
-      ref.read(dmChannelsControllerProvider(ref.readActiveServerKey() ?? '').notifier).remove(_channel.id);
+      ref
+          .read(
+            dmChannelsControllerProvider(
+              ref.readActiveServerKey() ?? '',
+            ).notifier,
+          )
+          .remove(_channel.id);
       widget.onBack();
     } else {
       _snack('Failed to leave group');
@@ -433,169 +594,223 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
     // Keep the open conversation in sync with gateway-driven channel updates
     // (remote rename / recipient add/remove) the DM cache receives.
-    ref.listen<List<AccordChannel>?>(dmChannelsControllerProvider(ref.readActiveServerKey() ?? ''),
-        (previous, next) {
-      if (next == null) return;
-      AccordChannel? updated;
-      for (final c in next) {
-        if (c.id == _channel.id) {
-          updated = c;
-          break;
+    ref.listen<List<AccordChannel>?>(
+      dmChannelsControllerProvider(ref.readActiveServerKey() ?? ''),
+      (previous, next) {
+        if (next == null) return;
+        AccordChannel? updated;
+        for (final c in next) {
+          if (c.id == _channel.id) {
+            updated = c;
+            break;
+          }
         }
-      }
-      if (updated != null && !identical(updated, _channel)) {
-        setState(() => _channel = updated!);
-      }
-    });
-    final messages = _messages;
+        if (updated != null && !identical(updated, _channel)) {
+          setState(() => _channel = updated!);
+        }
+      },
+    );
+    ref.listen<List<AccordMessage>?>(
+      accordMessagesControllerProvider(_serverKey, _channel.id),
+      (previous, next) {
+        if (next == null || next.isEmpty) return;
+        markChannelRead(
+          ref,
+          _channel.id,
+          serverKey: _serverKey,
+          fallbackMessageId: next.last.id,
+        );
+      },
+    );
+    // The home route remains mounted beneath this dialog and may rebuild while
+    // it is open. Reassert the modal conversation as the visible channel so its
+    // incoming messages do not produce unread badges/notifications.
+    accordVisibleChannel = (serverKey: _serverKey, channelId: _channel.id);
     final group = _isGroupChannel;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-          child: Row(
-            children: [
-              IconButton(
-                tooltip: 'Back',
-                onPressed: widget.onBack,
-                icon: Icon(Icons.arrow_back, size: 20, color: colors.dirtyWhite),
-              ),
-              if (group)
-                Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: CircleAvatar(
-                    radius: 14,
-                    backgroundColor: colors.darkGray,
-                    child:
-                        Icon(Icons.group, size: 16, color: colors.dirtyWhite),
-                  ),
-                ),
-              Expanded(
-                child: Row(
-                  children: [
-                    Flexible(
-                      child: Text(_channelTitle(_channel, widget.selfId),
-                          style: theme.textTheme.titleSmall,
-                          overflow: TextOverflow.ellipsis),
-                    ),
-                    if (_dmRemoteOrigin(_channel, widget.selfId) != null) ...[
-                      const SizedBox(width: 6),
-                      RemoteOriginBadge(
-                          domain: _dmRemoteOrigin(_channel, widget.selfId)),
-                    ],
-                  ],
-                ),
-              ),
-              IconButton(
-                tooltip: 'Start voice call',
-                onPressed: () => _startCall(video: false),
-                icon: Icon(Icons.call, size: 20, color: colors.dirtyWhite),
-              ),
-              IconButton(
-                tooltip: 'Start video call',
-                onPressed: () => _startCall(video: true),
-                icon: Icon(Icons.videocam, size: 20, color: colors.dirtyWhite),
-              ),
-              if (group)
-                PopupMenuButton<String>(
-                  tooltip: 'Group options',
-                  icon: Icon(Icons.more_vert, size: 20, color: colors.gray),
-                  onSelected: (value) {
-                    switch (value) {
-                      case 'members':
-                        _showMembers();
-                      case 'add':
-                        _addMember();
-                      case 'rename':
-                        _rename();
-                      case 'leave':
-                        _leave();
-                    }
-                  },
-                  itemBuilder: (context) => [
-                    const PopupMenuItem(
-                        value: 'members', child: Text('View members')),
-                    const PopupMenuItem(
-                        value: 'add', child: Text('Add member')),
-                    const PopupMenuItem(
-                        value: 'rename', child: Text('Rename group')),
-                    PopupMenuItem(
-                      value: 'leave',
-                      child:
-                          Text('Leave group', style: TextStyle(color: colors.red)),
-                    ),
-                  ],
-                ),
-            ],
+    final others = _others(_channel, widget.selfId);
+    final directUser = group || others.isEmpty ? null : others.first;
+    final title = _channelTitle(_channel, widget.selfId);
+    final origin = _dmRemoteOrigin(_channel, widget.selfId);
+    return MessagePane(
+      channel: _channel,
+      channelId: _channel.id,
+      spaceId: null,
+      canManageMessagesOverride: true,
+      headerLeading: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: 'Back',
+            onPressed: widget.onBack,
+            icon: Icon(Icons.arrow_back, size: 20, color: colors.dirtyWhite),
           ),
-        ),
-        const Divider(height: 1),
-        Expanded(
-          child: messages == null
-              ? const LoadingView()
-              : messages.isEmpty
-                  ? Center(
-                      child: Text('No messages yet',
-                          style: theme.textTheme.bodySmall))
-                  : ListView.builder(
-                      padding: const EdgeInsets.all(12),
-                      itemCount: messages.length,
-                      itemBuilder: (context, index) {
-                        final m = messages[index];
-                        return Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 4),
-                          child: AccordMessageContent(content: m.content),
-                        );
-                      },
-                    ),
-        ),
-        const Divider(height: 1),
-        Padding(
-          padding: const EdgeInsets.all(8),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: _input,
-                  focusNode: _inputFocus,
-                  // Never disabled while sending: a disabled TextField gives up
-                  // focus (and the mobile keyboard) for the whole round-trip.
-                  // The send button and the guard in _send() stop double-sends.
-                  minLines: 1,
-                  maxLines: 4,
-                  // A multiline field defaults to TextInputAction.newline, which
-                  // swallows Enter instead of submitting; match the main
-                  // composer so Enter sends.
-                  textInputAction: TextInputAction.send,
-                  decoration: const InputDecoration(
-                    isDense: true,
-                    hintText: 'Message',
-                    border: OutlineInputBorder(),
-                  ),
-                  onSubmitted: (_) {
-                    // EditableText unfocuses on a `send` action just before
-                    // onSubmitted runs; the field is enabled, so asking for
-                    // focus straight back lands in the same frame.
-                    _inputFocus.requestFocus();
-                    _send();
-                  },
+          if (group)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: CircleAvatar(
+                radius: 14,
+                backgroundColor: colors.darkGray,
+                child: Icon(Icons.group, size: 16, color: colors.dirtyWhite),
+              ),
+            )
+          else if (directUser != null)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: _DmUserGesture(
+                user: directUser,
+                onTap: () => _showUserProfile(directUser),
+                onMenu: (position) => _showUserMenu(directUser, position),
+                child: UserAvatar(
+                  title,
+                  imageUrl: accordAvatarUrl(directUser, ref.watchCdnUrl()),
+                  radius: 14,
                 ),
               ),
-              IconButton(
-                onPressed: _sending ? null : _send,
-                icon: Icon(Icons.send, size: 20, color: colors.dirtyWhite),
-              ),
-            ],
-          ),
+            ),
+        ],
+      ),
+      headerTitle: _DmHeaderTitle(
+        title: title,
+        origin: origin,
+        onTap: directUser == null ? null : () => _showUserProfile(directUser),
+        onMenu: directUser == null
+            ? null
+            : (position) => _showUserMenu(directUser, position),
+      ),
+      headerActions: [
+        IconButton(
+          tooltip: 'Start voice call',
+          onPressed: () => _startCall(video: false),
+          icon: Icon(Icons.call, size: 20, color: colors.dirtyWhite),
         ),
+        IconButton(
+          tooltip: 'Start video call',
+          onPressed: () => _startCall(video: true),
+          icon: Icon(Icons.videocam, size: 20, color: colors.dirtyWhite),
+        ),
+        if (group) _groupOptions(colors),
       ],
+      onUserTap: _showUserProfile,
+      onUserContextMenu: _showUserMenu,
     );
   }
+
+  void _showUserProfile(AccordUser user) {
+    showAccordUserProfile(context, user, cdnUrl: ref.readCdnUrl());
+  }
+
+  void _showUserMenu(AccordUser user, [Offset? position]) {
+    final others = _others(_channel, widget.selfId);
+    showAccordDmUserContextMenu(
+      context,
+      ref,
+      user,
+      globalPosition: position,
+      currentDmUserId: others.length == 1 ? others.first.id : null,
+    );
+  }
+
+  Widget _groupOptions(BonfireThemeExtension colors) => PopupMenuButton<String>(
+    tooltip: 'Group options',
+    icon: Icon(Icons.more_vert, size: 20, color: colors.gray),
+    onSelected: (value) {
+      switch (value) {
+        case 'members':
+          _showMembers();
+        case 'add':
+          _addMember();
+        case 'rename':
+          _rename();
+        case 'leave':
+          _leave();
+      }
+    },
+    itemBuilder: (context) => [
+      const PopupMenuItem(value: 'members', child: Text('View members')),
+      const PopupMenuItem(value: 'add', child: Text('Add member')),
+      const PopupMenuItem(value: 'rename', child: Text('Rename group')),
+      PopupMenuItem(
+        value: 'leave',
+        child: Text('Leave group', style: TextStyle(color: colors.red)),
+      ),
+    ],
+  );
+}
+
+class _DmHeaderTitle extends StatelessWidget {
+  const _DmHeaderTitle({
+    required this.title,
+    required this.origin,
+    required this.onTap,
+    required this.onMenu,
+  });
+
+  final String title;
+  final String? origin;
+  final VoidCallback? onTap;
+  final ValueChanged<Offset?>? onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    final row = Row(
+      children: [
+        Flexible(
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.titleSmall,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        if (origin != null) ...[
+          const SizedBox(width: 6),
+          RemoteOriginBadge(domain: origin),
+        ],
+      ],
+    );
+    if (onTap == null && onMenu == null) return row;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        onLongPressStart: onMenu == null
+            ? null
+            : (details) => onMenu!(details.globalPosition),
+        onSecondaryTapUp: onMenu == null
+            ? null
+            : (details) => onMenu!(details.globalPosition),
+        child: row,
+      ),
+    );
+  }
+}
+
+class _DmUserGesture extends StatelessWidget {
+  const _DmUserGesture({
+    required this.user,
+    required this.onTap,
+    required this.onMenu,
+    required this.child,
+  });
+
+  final AccordUser user;
+  final VoidCallback onTap;
+  final ValueChanged<Offset?> onMenu;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => MouseRegion(
+    cursor: SystemMouseCursors.click,
+    child: GestureDetector(
+      onTap: onTap,
+      onLongPressStart: (details) => onMenu(details.globalPosition),
+      onSecondaryTapUp: (details) => onMenu(details.globalPosition),
+      child: child,
+    ),
+  );
 }
 
 /// Prompts for a remote user's qualified handle (`<id>@<domain>`) to start a
@@ -626,7 +841,8 @@ class _RemoteDmDialogState extends State<_RemoteDmDialog> {
     final value = _controller.text.trim();
     if (!isValidRemoteHandle(value)) {
       setState(
-          () => _error = 'Enter a qualified handle, e.g. 123@server.example');
+        () => _error = 'Enter a qualified handle, e.g. 123@server.example',
+      );
       return;
     }
     Navigator.of(context).pop(value);
@@ -665,10 +881,7 @@ class _RemoteDmDialogState extends State<_RemoteDmDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Message'),
-        ),
+        FilledButton(onPressed: _submit, child: const Text('Message')),
       ],
     );
   }

--- a/lib/features/user/views/accord_direct_messages_friends.dart
+++ b/lib/features/user/views/accord_direct_messages_friends.dart
@@ -111,6 +111,7 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
               for (final r in incoming)
                 _FriendRow(
                   name: _userName(r.user),
+                  user: r.user,
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -136,6 +137,7 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
               for (final r in outgoing)
                 _FriendRow(
                   name: _userName(r.user),
+                  user: r.user,
                   trailing: TextButton(
                     onPressed: _busy || r.user == null
                         ? null
@@ -147,6 +149,7 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
               for (final r in friends)
                 _FriendRow(
                   name: _userName(r.user),
+                  user: r.user,
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -175,6 +178,7 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
               for (final r in blocked)
                 _FriendRow(
                   name: _userName(r.user),
+                  user: r.user,
                   trailing: TextButton(
                     onPressed: _busy || r.user == null
                         ? null
@@ -229,19 +233,41 @@ class _SectionLabel extends StatelessWidget {
   }
 }
 
-class _FriendRow extends StatelessWidget {
-  const _FriendRow({required this.name, required this.trailing});
+class _FriendRow extends ConsumerWidget {
+  const _FriendRow({
+    required this.name,
+    required this.user,
+    required this.trailing,
+  });
 
   final String name;
+  final AccordUser? user;
   final Widget trailing;
 
   @override
-  Widget build(BuildContext context) {
-    return ListTile(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tile = ListTile(
       dense: true,
-      leading: UserAvatar(name),
+      leading: UserAvatar(
+        name,
+        imageUrl: accordAvatarUrl(user, ref.watchCdnUrl()),
+      ),
       title: Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
       trailing: trailing,
+    );
+    final target = user;
+    if (target == null) return tile;
+    return _DmUserGesture(
+      user: target,
+      onTap: () =>
+          showAccordUserProfile(context, target, cdnUrl: ref.readCdnUrl()),
+      onMenu: (position) => showAccordDmUserContextMenu(
+        context,
+        ref,
+        target,
+        globalPosition: position,
+      ),
+      child: tile,
     );
   }
 }

--- a/lib/features/user/views/accord_direct_messages_groups.dart
+++ b/lib/features/user/views/accord_direct_messages_groups.dart
@@ -209,7 +209,7 @@ class _PickUserDialogState extends ConsumerState<_PickUserDialog> {
 }
 
 /// Lists the group's participants with an optional remove action (owner only).
-class _GroupMembersDialog extends StatelessWidget {
+class _GroupMembersDialog extends ConsumerWidget {
   const _GroupMembersDialog({
     required this.members,
     required this.canRemove,
@@ -221,7 +221,7 @@ class _GroupMembersDialog extends StatelessWidget {
   final void Function(AccordUser) onRemove;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = BonfireThemeExtension.of(context);
     final theme = Theme.of(context);
     return Dialog(
@@ -251,25 +251,56 @@ class _GroupMembersDialog extends StatelessWidget {
                         shrinkWrap: true,
                         children: [
                           for (final user in members)
-                            ListTile(
-                              dense: true,
-                              leading: UserAvatar(_userName(user)),
-                              title: Text(
-                                _userName(user),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+                            _DmUserGesture(
+                              user: user,
+                              onTap: () => showAccordUserProfile(
+                                context,
+                                user,
+                                cdnUrl: ref.readCdnUrl(),
                               ),
-                              trailing: canRemove
-                                  ? IconButton(
-                                      tooltip: 'Remove',
-                                      onPressed: () => onRemove(user),
-                                      icon: Icon(
-                                        Icons.person_remove,
-                                        size: 20,
-                                        color: colors.red,
-                                      ),
-                                    )
-                                  : null,
+                              onMenu: (position) => showAccordDmUserContextMenu(
+                                context,
+                                ref,
+                                user,
+                                globalPosition: position,
+                                extraEntries: canRemove
+                                    ? [
+                                        const AccordMenuEntry.divider(),
+                                        AccordMenuEntry(
+                                          label: 'Remove from group',
+                                          icon: Icons.person_remove_outlined,
+                                          destructive: true,
+                                          onSelected: () => onRemove(user),
+                                        ),
+                                      ]
+                                    : const [],
+                              ),
+                              child: ListTile(
+                                dense: true,
+                                leading: UserAvatar(
+                                  _userName(user),
+                                  imageUrl: accordAvatarUrl(
+                                    user,
+                                    ref.watchCdnUrl(),
+                                  ),
+                                ),
+                                title: Text(
+                                  _userName(user),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                trailing: canRemove
+                                    ? IconButton(
+                                        tooltip: 'Remove',
+                                        onPressed: () => onRemove(user),
+                                        icon: Icon(
+                                          Icons.person_remove,
+                                          size: 20,
+                                          color: colors.red,
+                                        ),
+                                      )
+                                    : null,
+                              ),
                             ),
                         ],
                       ),

--- a/multi_instance/support/app_instance.dart
+++ b/multi_instance/support/app_instance.dart
@@ -260,6 +260,21 @@ class AppInstance {
         '--- app output ---\n$log',
       );
     }
+    try {
+      await instance.callUntil(
+        'get_current_state',
+        (result) => (result['connected_servers'] as num? ?? 0) > 0,
+        timeout: const Duration(seconds: 30),
+        description: 'a restored server connection',
+      );
+    } on Object catch (error) {
+      final log = instance.log;
+      await instance.dispose();
+      throw AppUnavailable(
+        '$label: MCP started, but the seeded session did not connect: '
+        '$error\n--- app output ---\n$log',
+      );
+    }
     return instance;
   }
 

--- a/test/features/channels/dm_activity_test.dart
+++ b/test/features/channels/dm_activity_test.dart
@@ -1,0 +1,61 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+AccordMessage _message(
+  String id,
+  String channelId,
+  String content, {
+  List<AccordAttachment> attachments = const [],
+}) => AccordMessage(
+  id: id,
+  channelId: channelId,
+  authorId: 'user',
+  content: content,
+  timestamp: '2026-08-24T12:00:00Z',
+  attachments: attachments,
+);
+
+void main() {
+  test('live DM activity updates preview and moves conversation to front', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      dmChannelsControllerProvider('server').notifier,
+    );
+    controller.setChannels([
+      AccordChannel(id: 'a', type: 'dm'),
+      AccordChannel(id: 'b', type: 'dm'),
+    ]);
+
+    controller.applyMessage(_message('m1', 'b', '  hello\nthere  '));
+
+    expect(
+      container
+          .read(dmChannelsControllerProvider('server'))
+          ?.map((channel) => channel.id),
+      ['b', 'a'],
+    );
+    expect(controller.previewFor('b'), 'hello there');
+  });
+
+  test('edit/delete only changes the current last-message preview', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      dmChannelsControllerProvider('server').notifier,
+    );
+    controller.setChannels([AccordChannel(id: 'dm', type: 'dm')]);
+    controller.applyMessage(_message('latest', 'dm', 'before'));
+
+    controller.updateMessagePreview(_message('older', 'dm', 'ignore'));
+    expect(controller.previewFor('dm'), 'before');
+
+    controller.updateMessagePreview(_message('latest', 'dm', 'after'));
+    expect(controller.previewFor('dm'), 'after');
+
+    controller.removeMessagePreview('dm', 'latest');
+    expect(controller.previewFor('dm'), isNull);
+  });
+}

--- a/test/features/user/dm_conversation_search_test.dart
+++ b/test/features/user/dm_conversation_search_test.dart
@@ -1,0 +1,121 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A [DmChannelsController] exposing a fixed conversation list, so the DM
+/// dialog renders without a server.
+class _FakeDmChannels extends DmChannelsController {
+  _FakeDmChannels(this._channels);
+
+  final List<AccordChannel> _channels;
+
+  @override
+  List<AccordChannel>? build(String serverKey) => _channels;
+}
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+AccordChannel _dm(String id, String withName) => AccordChannel(
+  id: id,
+  type: 'dm',
+  recipients: [AccordUser(id: 'u-$id', username: withName)],
+);
+
+void main() {
+  late ProviderContainer container;
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildAppTheme(AppThemePreset.dark),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => showAccordDirectMessages(context),
+                child: const Text('open dms'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open dms'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    container = ProviderContainer(
+      overrides: [
+        settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+        dmChannelsControllerProvider('').overrideWith(
+          () => _FakeDmChannels([_dm('dm1', 'bob'), _dm('dm2', 'carol')]),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  testWidgets('search narrows the conversation list by title', (tester) async {
+    await openDialog(tester);
+    expect(find.text('bob'), findsOneWidget);
+    expect(find.text('carol'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'car');
+    await tester.pump();
+
+    expect(find.text('bob'), findsNothing);
+    expect(find.text('carol'), findsOneWidget);
+  });
+
+  testWidgets('search is case-insensitive and trims whitespace', (
+    tester,
+  ) async {
+    await openDialog(tester);
+
+    await tester.enterText(find.byType(TextField), '  BOB  ');
+    await tester.pump();
+
+    expect(find.text('bob'), findsOneWidget);
+    expect(find.text('carol'), findsNothing);
+  });
+
+  testWidgets('a query matching nothing shows the empty-results message', (
+    tester,
+  ) async {
+    await openDialog(tester);
+
+    await tester.enterText(find.byType(TextField), 'nobody-has-this-name');
+    await tester.pump();
+
+    expect(find.text('bob'), findsNothing);
+    expect(find.text('carol'), findsNothing);
+    expect(find.text('No matching conversations'), findsOneWidget);
+    expect(find.text('No direct messages yet'), findsNothing);
+  });
+
+  testWidgets('clearing the query restores the full list', (tester) async {
+    await openDialog(tester);
+
+    await tester.enterText(find.byType(TextField), 'car');
+    await tester.pump();
+    expect(find.text('bob'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pump();
+
+    expect(find.text('bob'), findsOneWidget);
+    expect(find.text('carol'), findsOneWidget);
+  });
+}

--- a/test/features/user/dm_missed_call_indicator_test.dart
+++ b/test/features/user/dm_missed_call_indicator_test.dart
@@ -2,6 +2,8 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/user/views/accord_direct_messages.dart';
 import 'package:bonfire/features/voice/controllers/missed_calls.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,11 +20,16 @@ class _FakeDmChannels extends DmChannelsController {
   List<AccordChannel>? build(String serverKey) => _channels;
 }
 
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
 AccordChannel _dm(String id, String withName) => AccordChannel(
-      id: id,
-      type: 'dm',
-      recipients: [AccordUser(id: 'u2', username: withName)],
-    );
+  id: id,
+  type: 'dm',
+  recipients: [AccordUser(id: 'u2', username: withName)],
+);
 
 void main() {
   late ProviderContainer container;
@@ -51,8 +58,10 @@ void main() {
   setUp(() {
     container = ProviderContainer(
       overrides: [
-        dmChannelsControllerProvider('')
-            .overrideWith(() => _FakeDmChannels([_dm('dm1', 'bob')])),
+        settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+        dmChannelsControllerProvider(
+          '',
+        ).overrideWith(() => _FakeDmChannels([_dm('dm1', 'bob')])),
       ],
     );
   });
@@ -66,8 +75,9 @@ void main() {
     expect(find.byIcon(Icons.call_missed), findsNothing);
   });
 
-  testWidgets('a missed call labels the conversation in the DM list',
-      (tester) async {
+  testWidgets('a missed call labels the conversation in the DM list', (
+    tester,
+  ) async {
     container
         .read(missedCallsControllerProvider.notifier)
         .record(channelId: 'dm1', callerId: 'u2');
@@ -78,8 +88,9 @@ void main() {
     expect(find.byIcon(Icons.call_missed), findsOneWidget);
   });
 
-  testWidgets('repeat misses show the count, video misses use the video icon',
-      (tester) async {
+  testWidgets('repeat misses show the count, video misses use the video icon', (
+    tester,
+  ) async {
     final missed = container.read(missedCallsControllerProvider.notifier);
     missed.record(channelId: 'dm1', callerId: 'u2', video: true);
     missed.record(channelId: 'dm1', callerId: 'u2', video: true);
@@ -99,9 +110,9 @@ void main() {
     await openDialog(tester);
     expect(find.text('Missed call'), findsOneWidget);
 
-    // Open the conversation, then go back to the list. The conversation shows
-    // an endless loading spinner while its (never-arriving) fetch is in flight,
-    // so settle isn't an option — pump explicit frames instead.
+    // Open the conversation, then go back to the list. There is no client in
+    // this harness, so the shared message pane remains in its loading state;
+    // pump explicit frames rather than waiting for it to settle.
     await tester.tap(find.text('bob'));
     await tester.pump();
     await tester.pump();
@@ -114,9 +125,39 @@ void main() {
     expect(find.text('Missed call'), findsNothing);
   });
 
-  testWidgets('opening a different conversation keeps the indicator',
-      (tester) async {
+  testWidgets('conversation uses the shared channel message controls', (
+    tester,
+  ) async {
+    await openDialog(tester);
+    await tester.tap(find.text('bob'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byTooltip('Pinned messages'), findsOneWidget);
+    expect(find.byTooltip('Attach files'), findsOneWidget);
+    expect(find.byTooltip('Emoji'), findsOneWidget);
+    expect(find.byTooltip('Start voice call'), findsOneWidget);
+    expect(find.byTooltip('Start video call'), findsOneWidget);
+  });
+
+  testWidgets('long-pressing a DM user opens their context menu', (
+    tester,
+  ) async {
+    await openDialog(tester);
+
+    await tester.longPress(find.text('bob'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View profile'), findsOneWidget);
+    expect(find.text('Copy user ID'), findsOneWidget);
+    expect(find.text('Close direct message'), findsOneWidget);
+  });
+
+  testWidgets('opening a different conversation keeps the indicator', (
+    tester,
+  ) async {
     container.updateOverrides([
+      settingsControllerProvider.overrideWith(_FakeSettingsController.new),
       dmChannelsControllerProvider('').overrideWith(
         () => _FakeDmChannels([_dm('dm1', 'bob'), _dm('dm2', 'carol')]),
       ),


### PR DESCRIPTION
## Summary

- replace the bespoke DM timeline and composer with the shared channel message pane while preserving DM calls and group controls
- add responsive user context menus across DM recipients, authors, friends, group members, threads, and pinned messages
- add conversation search, live previews and ordering, read acknowledgements, unread and mention badges, and close or leave actions
- update direct-message documentation and add regression coverage for shared controls, user menus, and activity previews
- repair the existing executable-file allowlist so CI reaches Flutter analysis and tests

## Testing

- `flutter analyze --no-fatal-infos`
- `flutter test` (1,099 tests passed)
- `flutter test test/features/messaging/message_row_target_test.dart test/features/channels/dm_activity_test.dart test/features/channels/dm_create_test.dart test/features/user/dm_missed_call_indicator_test.dart`
- executable-file allowlist verification
- `git diff --check`