### PR TITLE
Open the channel drawer from a swipe anywhere on mobile

### DIFF
--- a/docs/navigation/spaces-and-channels.md
+++ b/docs/navigation/spaces-and-channels.md
@@ -52,3 +52,5 @@ When you open a channel, it appears as a **tab** at the top of the message area.
 ## On Small Screens
 
 On narrow windows or mobile devices, the sidebar becomes a **drawer** that slides in from the left. Tap the hamburger menu button to open it, and tap outside to close it.
+
+You can also swipe it open. On touch devices, swipe right from anywhere over the message area — not just from the screen edge — and the channel drawer opens; swipe left the same way to open the member list. Swipes that start on the tab bar still scroll the tabs, and a swipe that starts at the very left edge drags the drawer along with your finger.

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -48,6 +48,7 @@ import 'package:bonfire/features/events/controllers/connection.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/shared/components/color_swatch_chip.dart';
 import 'package:bonfire/shared/components/context_menu.dart';
+import 'package:bonfire/shared/components/drawer_swipe_area.dart';
 import 'package:bonfire/shared/components/horizontal_wheel_scroll.dart';
 import 'package:bonfire/shared/components/server_unreachable.dart';
 import 'package:bonfire/shared/models/server_entity_key.dart';
@@ -729,43 +730,53 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
               children: [
                 // Inset the mobile chrome below the OS status bar / nav bar.
                 // The pip overlay stays outside so it can use the full screen.
-                SafeArea(
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          OnboardingAnchor(
-                            anchor: OnboardingAnchorId.navMenu,
-                            child: IconButton(
-                              tooltip: 'Channels',
-                              icon: Icon(Icons.menu, color: colors.dirtyWhite),
-                              onPressed: () =>
-                                  _scaffoldKey.currentState?.openDrawer(),
-                            ),
-                          ),
-                          Expanded(child: _TabStrip(onSelect: _selectTab)),
-                          if (hasMembers)
-                            IconButton(
-                              tooltip: 'Members',
-                              icon: Icon(
-                                Icons.people_alt_outlined,
-                                color: colors.dirtyWhite,
+                //
+                // [DrawerSwipeArea] extends swipe-to-open past the edge strip
+                // `drawerEdgeDragWidth` covers, without stealing horizontal
+                // drags from the tab strip or the voice rails (#125).
+                DrawerSwipeArea(
+                  scaffoldKey: _scaffoldKey,
+                  child: SafeArea(
+                    child: Column(
+                      children: [
+                        Row(
+                          children: [
+                            OnboardingAnchor(
+                              anchor: OnboardingAnchorId.navMenu,
+                              child: IconButton(
+                                tooltip: 'Channels',
+                                icon: Icon(
+                                  Icons.menu,
+                                  color: colors.dirtyWhite,
+                                ),
+                                onPressed: () =>
+                                    _scaffoldKey.currentState?.openDrawer(),
                               ),
-                              onPressed: () =>
-                                  _scaffoldKey.currentState?.openEndDrawer(),
                             ),
-                        ],
-                      ),
-                      Expanded(
-                        child: MessagePane(
-                          channel: channels?.firstWhereOrNull(
-                            (c) => c.id == shownChannelId,
-                          ),
-                          channelId: shownChannelId,
-                          spaceId: effectiveSpaceId,
+                            Expanded(child: _TabStrip(onSelect: _selectTab)),
+                            if (hasMembers)
+                              IconButton(
+                                tooltip: 'Members',
+                                icon: Icon(
+                                  Icons.people_alt_outlined,
+                                  color: colors.dirtyWhite,
+                                ),
+                                onPressed: () =>
+                                    _scaffoldKey.currentState?.openEndDrawer(),
+                              ),
+                          ],
                         ),
-                      ),
-                    ],
+                        Expanded(
+                          child: MessagePane(
+                            channel: channels?.firstWhereOrNull(
+                              (c) => c.id == shownChannelId,
+                            ),
+                            channelId: shownChannelId,
+                            spaceId: effectiveSpaceId,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 pip,

--- a/lib/shared/components/drawer_swipe_area.dart
+++ b/lib/shared/components/drawer_swipe_area.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+/// Minimum horizontal travel, in logical pixels, before a body swipe counts as
+/// a drawer gesture. Measured *after* the gesture recognizer's own touch slop,
+/// so the finger has really committed to a direction.
+const double kDrawerSwipeDistance = 40;
+
+/// Minimum horizontal fling speed, in logical pixels/second, that opens a
+/// drawer no matter how short the flick was.
+const double kDrawerSwipeVelocity = 320;
+
+/// What a finished body swipe should do.
+enum DrawerSwipeAction { none, openDrawer, openEndDrawer }
+
+/// Resolves a completed horizontal body swipe into a drawer action.
+///
+/// [distance] and [velocity] are measured towards the [Scaffold.drawer] edge —
+/// positive is "towards the drawer" (rightwards in LTR). A decisive fling wins
+/// over the accumulated distance, so a drag that wanders one way and flicks
+/// back the other opens what the flick pointed at.
+DrawerSwipeAction drawerSwipeAction({
+  required double distance,
+  required double velocity,
+}) {
+  if (velocity.abs() >= kDrawerSwipeVelocity) {
+    return velocity > 0
+        ? DrawerSwipeAction.openDrawer
+        : DrawerSwipeAction.openEndDrawer;
+  }
+  if (distance >= kDrawerSwipeDistance) return DrawerSwipeAction.openDrawer;
+  if (distance <= -kDrawerSwipeDistance) return DrawerSwipeAction.openEndDrawer;
+  return DrawerSwipeAction.none;
+}
+
+/// Opens a [Scaffold]'s drawers from a horizontal swipe started *anywhere* over
+/// [child], not just in the narrow edge strip Flutter listens on by default.
+///
+/// Flutter's own swipe-to-open lives in `DrawerController`, which paints a
+/// translucent drag target `Scaffold.drawerEdgeDragWidth` wide against the
+/// screen edge. That target sits in the `_ScaffoldSlot.drawer` slot, which is
+/// painted after the body and therefore hit-tested *before* it — so simply
+/// widening the strip to the whole screen makes it win the gesture arena
+/// against every horizontal scrollable underneath (the open-tab strip, the
+/// voice participant rails), leaving them dead.
+///
+/// This widget sits inside the body instead, as an ancestor of the content, so
+/// content recognizers join the arena first and claim the drags they care
+/// about. Only a horizontal drag that nothing inside wanted reaches us.
+///
+/// The edge strip is deliberately left in place: there the framework's gesture
+/// wins and drags the drawer under the finger, which is nicer than the snap
+/// this widget can offer from the middle of the screen (`ScaffoldState` exposes
+/// no way to drive the drawer's animation incrementally).
+class DrawerSwipeArea extends StatefulWidget {
+  const DrawerSwipeArea({
+    super.key,
+    required this.scaffoldKey,
+    required this.child,
+  });
+
+  /// Key of the [Scaffold] whose drawers this swipe opens.
+  final GlobalKey<ScaffoldState> scaffoldKey;
+
+  final Widget child;
+
+  @override
+  State<DrawerSwipeArea> createState() => _DrawerSwipeAreaState();
+}
+
+class _DrawerSwipeAreaState extends State<DrawerSwipeArea> {
+  /// Horizontal travel accumulated since the current drag was recognized.
+  double _distance = 0;
+
+  /// Mirrors `DrawerController`'s own check: swipe-to-open is a touch idiom,
+  /// and a mouse drag across a desktop window shouldn't fling a panel open.
+  bool get _swipeEnabled => switch (Theme.of(context).platform) {
+    TargetPlatform.android ||
+    TargetPlatform.iOS ||
+    TargetPlatform.fuchsia => true,
+    TargetPlatform.macOS ||
+    TargetPlatform.linux ||
+    TargetPlatform.windows => false,
+  };
+
+  /// Sign that maps raw dx onto "towards the drawer": the drawer hangs off the
+  /// start edge, which is the right in RTL.
+  double get _towardsDrawer =>
+      Directionality.of(context) == TextDirection.rtl ? -1 : 1;
+
+  void _onEnd(DragEndDetails details) {
+    final scaffold = widget.scaffoldKey.currentState;
+    // An open drawer covers the screen with its own drag target, so this only
+    // fires while both are shut — but a stale key or a mid-animation drag
+    // shouldn't reopen anything.
+    if (scaffold == null || scaffold.isDrawerOpen || scaffold.isEndDrawerOpen) {
+      return;
+    }
+    final action = drawerSwipeAction(
+      distance: _distance * _towardsDrawer,
+      velocity: details.velocity.pixelsPerSecond.dx * _towardsDrawer,
+    );
+    switch (action) {
+      case DrawerSwipeAction.openDrawer:
+        if (scaffold.hasDrawer) scaffold.openDrawer();
+      case DrawerSwipeAction.openEndDrawer:
+        if (scaffold.hasEndDrawer) scaffold.openEndDrawer();
+      case DrawerSwipeAction.none:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_swipeEnabled) return widget.child;
+    return GestureDetector(
+      // Opaque so the gaps between the content's own widgets swipe too;
+      // children are still hit-tested first, so they keep winning the arena.
+      behavior: HitTestBehavior.opaque,
+      excludeFromSemantics: true,
+      onHorizontalDragStart: (_) => _distance = 0,
+      onHorizontalDragUpdate: (details) => _distance += details.delta.dx,
+      onHorizontalDragEnd: _onEnd,
+      child: widget.child,
+    );
+  }
+}

--- a/test/features/spaces/drawer_swipe_area_test.dart
+++ b/test/features/spaces/drawer_swipe_area_test.dart
@@ -1,0 +1,229 @@
+import 'package:bonfire/shared/components/drawer_swipe_area.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Replicates the narrow-layout body of `AccordHomeScreen`: a horizontally
+/// scrollable tab strip above a message area, all inside a [DrawerSwipeArea].
+/// Stripped of Riverpod/network so the gesture wiring can be exercised alone.
+class _MobileHome extends StatelessWidget {
+  const _MobileHome({
+    required this.scaffoldKey,
+    required this.tabScroll,
+    this.hasEndDrawer = true,
+    this.textDirection = TextDirection.ltr,
+  });
+
+  final GlobalKey<ScaffoldState> scaffoldKey;
+  final ScrollController tabScroll;
+  final bool hasEndDrawer;
+  final TextDirection textDirection;
+
+  @override
+  Widget build(BuildContext context) => Directionality(
+    textDirection: textDirection,
+    child: Scaffold(
+      key: scaffoldKey,
+      drawerEdgeDragWidth: 48,
+      drawer: const Drawer(child: Text('channels')),
+      endDrawer: hasEndDrawer ? const Drawer(child: Text('members')) : null,
+      body: DrawerSwipeArea(
+        scaffoldKey: scaffoldKey,
+        child: Column(
+          children: [
+            SizedBox(
+              height: 38,
+              child: ListView(
+                controller: tabScroll,
+                scrollDirection: Axis.horizontal,
+                children: [
+                  for (var i = 0; i < 30; i++)
+                    SizedBox(width: 80, child: Text('tab$i')),
+                ],
+              ),
+            ),
+            const Expanded(child: ColoredBox(color: Colors.black)),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Somewhere in the message area, well clear of both edge drag strips.
+const Offset _midBody = Offset(400, 400);
+
+/// On the tab strip (38 logical pixels tall), clear of the edge strips.
+const Offset _onTabStrip = Offset(400, 19);
+
+void main() {
+  group('drawerSwipeAction', () {
+    test('ignores a drag that never commits to a direction', () {
+      expect(
+        drawerSwipeAction(distance: 12, velocity: 40),
+        DrawerSwipeAction.none,
+      );
+    });
+
+    test('opens the drawer once the drag passes the distance threshold', () {
+      expect(
+        drawerSwipeAction(distance: kDrawerSwipeDistance, velocity: 0),
+        DrawerSwipeAction.openDrawer,
+      );
+    });
+
+    test('opens the end drawer on the mirrored distance', () {
+      expect(
+        drawerSwipeAction(distance: -kDrawerSwipeDistance, velocity: 0),
+        DrawerSwipeAction.openEndDrawer,
+      );
+    });
+
+    test('a short flick still opens on velocity alone', () {
+      expect(
+        drawerSwipeAction(distance: 5, velocity: kDrawerSwipeVelocity),
+        DrawerSwipeAction.openDrawer,
+      );
+      expect(
+        drawerSwipeAction(distance: -5, velocity: -kDrawerSwipeVelocity),
+        DrawerSwipeAction.openEndDrawer,
+      );
+    });
+
+    test('a decisive flick outvotes distance dragged the other way', () {
+      expect(
+        drawerSwipeAction(distance: 200, velocity: -900),
+        DrawerSwipeAction.openEndDrawer,
+      );
+    });
+  });
+
+  group('DrawerSwipeArea', () {
+    late GlobalKey<ScaffoldState> key;
+    late ScrollController tabScroll;
+
+    setUp(() {
+      key = GlobalKey<ScaffoldState>();
+      tabScroll = ScrollController();
+    });
+
+    tearDown(() => tabScroll.dispose());
+
+    Future<void> pumpHome(
+      WidgetTester tester, {
+      bool hasEndDrawer = true,
+      TargetPlatform platform = TargetPlatform.android,
+      TextDirection textDirection = TextDirection.ltr,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: _MobileHome(
+            scaffoldKey: key,
+            tabScroll: tabScroll,
+            hasEndDrawer: hasEndDrawer,
+            textDirection: textDirection,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('a swipe from mid-body opens the channel drawer', (
+      tester,
+    ) async {
+      await pumpHome(tester);
+      expect(key.currentState!.isDrawerOpen, isFalse);
+
+      await tester.dragFrom(_midBody, const Offset(250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isTrue);
+    });
+
+    testWidgets('the edge strip still opens the drawer', (tester) async {
+      await pumpHome(tester);
+
+      await tester.dragFrom(const Offset(10, 400), const Offset(250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isTrue);
+    });
+
+    testWidgets('a swipe back from mid-body opens the member drawer', (
+      tester,
+    ) async {
+      await pumpHome(tester);
+
+      await tester.dragFrom(_midBody, const Offset(-250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isEndDrawerOpen, isTrue);
+    });
+
+    testWidgets('a swipe back does nothing when there is no member drawer', (
+      tester,
+    ) async {
+      await pumpHome(tester, hasEndDrawer: false);
+
+      await tester.dragFrom(_midBody, const Offset(-250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isFalse);
+      expect(key.currentState!.isEndDrawerOpen, isFalse);
+    });
+
+    testWidgets('a twitch below the threshold opens nothing', (tester) async {
+      await pumpHome(tester);
+
+      await tester.dragFrom(_midBody, const Offset(24, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isFalse);
+    });
+
+    testWidgets('a vertical drag opens nothing', (tester) async {
+      await pumpHome(tester);
+
+      await tester.dragFrom(_midBody, const Offset(0, -250));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isFalse);
+      expect(key.currentState!.isEndDrawerOpen, isFalse);
+    });
+
+    testWidgets('the tab strip keeps its own horizontal drag', (tester) async {
+      await pumpHome(tester);
+      tabScroll.jumpTo(400);
+      await tester.pump();
+
+      await tester.dragFrom(_onTabStrip, const Offset(150, 0));
+      await tester.pumpAndSettle();
+
+      expect(tabScroll.offset, lessThan(400));
+      expect(key.currentState!.isDrawerOpen, isFalse);
+    });
+
+    testWidgets('desktop platforms keep the pointer-driven behavior', (
+      tester,
+    ) async {
+      await pumpHome(tester, platform: TargetPlatform.linux);
+
+      await tester.dragFrom(_midBody, const Offset(250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isFalse);
+    });
+
+    testWidgets('right-to-left mirrors which edge each swipe opens', (
+      tester,
+    ) async {
+      await pumpHome(tester, textDirection: TextDirection.rtl);
+
+      // In RTL the channel drawer hangs off the right, so it is the leftward
+      // swipe that pulls it in.
+      await tester.dragFrom(_midBody, const Offset(-250, 0));
+      await tester.pumpAndSettle();
+
+      expect(key.currentState!.isDrawerOpen, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Swipe-to-open only worked from a thin strip at the screen edge. That
strip is Flutter's own gesture: `DrawerController` paints a translucent
drag target `Scaffold.drawerEdgeDragWidth` wide against the edge, and
the narrow layout set that to 48 logical pixels — so a swipe starting
past ~48px never reached the drawer at all.

Widening the strip to the whole screen is not the fix. That target lives
in `_ScaffoldSlot.drawer`, which is painted after the body and therefore
hit-tested before it, so a full-width strip wins the gesture arena
against every horizontal scrollable underneath: the open-tab strip stops
scrolling and the voice participant rails go dead.

Add `DrawerSwipeArea` instead and wrap the narrow body in it. Sitting
inside the body, as an ancestor of the content, it joins the arena after
the content's own recognizers, so inner horizontal drags are claimed
first and only an unclaimed one opens a drawer. A rightward swipe (or
flick) from anywhere over the message area opens the channel drawer; the
mirrored swipe opens the member list, matching the right-edge gesture
that already existed. Directionality is honoured, and the gesture is
limited to touch platforms the way `DrawerController` limits its own.

The 48px edge strip stays: there the framework's gesture drags the
drawer under the finger, which beats the snap this can offer from
mid-screen (`ScaffoldState` exposes no way to drive the animation
incrementally).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CnLkwMF6a7jv6WiyXApJVt