### PR TITLE
docs(readme): refresh against current client state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ No ads. No first-party analytics or tracking. No corporate lock-in. **Your serve
 
 <p align="left">
   <img alt="License: GPLv3" src="https://img.shields.io/badge/license-GPLv3-blue.svg">
+  <a href="https://github.com/DaccordProject/daccord/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/DaccordProject/daccord"></a>
   <img alt="Built with Flutter" src="https://img.shields.io/badge/built%20with-Flutter-027DFD.svg">
   <img alt="Platforms" src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows%20%7C%20macOS%20%7C%20Linux%20%7C%20Web-success.svg">
   <img alt="Status: early development" src="https://img.shields.io/badge/status-early%20development-orange.svg">
 </p>
 
 > ⚠️ **Early development.** Daccord is moving fast and things may change. Expect rough edges — and help us file them down.
+
+📖 **[User documentation](docs/index.md)** · 📥 **[Download](https://github.com/DaccordProject/daccord/releases/latest)** · 🐛 **[Issues](https://github.com/DaccordProject/daccord/issues)**
 
 ---
 
@@ -34,20 +37,55 @@ This client is the front door: one native app for every screen you own.
 
 ## ✨ Features
 
-- 💬 **Real-time messaging** — send, edit, delete, and reply over WebSocket, across channels and DMs. Updates that feel alive.
-- 🌐 **Multi-server** — connect to many Daccord servers at once and switch between them seamlessly. Your work crew and your gaming crew, side by side.
-- 🔗 **Destination-aware app links** — installed clients can open shared server, space, channel, thread, and message destinations after the owning account is ready.
-- 😀 **Emoji** — full unicode support plus custom server emoji, all behind a slick built-in picker.
+**Messaging**
+
+- 💬 **Real-time messaging** — send, edit, delete, and reply over the Accord gateway, with typing indicators and live presence.
+- 🧵 **Threads, forums & pins** — branch a conversation into a thread, run forum-style channels, and pin what matters.
+- 😀 **Reactions & emoji** — full unicode support plus custom server emoji, all behind a slick built-in picker.
+- 📎 **Files & media** — drag and drop attachments, with inline images, video, and audio playback and a full-screen lightbox.
+- 🔍 **Search** — space-scoped message search that jumps you straight to the hit.
+- ✉️ **Direct messages & DM calls** — private conversations, one-to-one and group, with voice and video.
+
+**Voice & video**
+
 - 🎙️ **Voice, video & screen sharing** — crystal-clear calls powered by **LiveKit/WebRTC**, with camera and screen share built right in.
-- 🛡️ **Server admin tools** — manage channels, roles, bans, invites, and custom emoji without ever leaving the app.
+
+**Servers & communities**
+
+- 🌐 **Multi-server** — connect to many Daccord servers at once and switch between them seamlessly. Your work crew and your gaming crew, side by side.
+- 🧭 **Discovery** — browse public spaces from the server directory and join them, even before you've signed in anywhere.
+- 🛡️ **Server admin tools** — manage channels, roles, permissions, bans, invites, and custom emoji without ever leaving the app.
+- 🔗 **Destination-aware app links** — `daccord://` links open the right server, space, channel, thread, or message once the owning account is ready.
+
+**The app itself**
+
+- 🎨 **Themes** — Dark, Light, Nord, Monokai, and Solarized built in, plus fully custom colors you can copy, paste, and share in chat.
+- 👥 **Multiple profiles** — keep separate local profiles on one device and switch between them without signing out.
+- 🔐 **Secure sign-in** — session tokens live in the OS credential vault, with optional TOTP two-factor authentication.
+- ⬆️ **In-app updates** — desktop and sideloaded Android builds check for, download, and install new releases themselves.
 - 📱 **Responsive everywhere** — one UI that flows from phone to desktop, sharp at every size.
-- 🌙 **Dark theme** — easy on the eyes, right out of the box.
 
 ---
 
-## 📦 Platforms
+## 📥 Download
 
-Native apps for every major platform:
+Grab the latest build from the **[Releases page](https://github.com/DaccordProject/daccord/releases/latest)**:
+
+| Platform | File |
+|---|---|
+| Linux (recommended) | `daccord-linux-x86_64.deb` |
+| Linux (portable) | `daccord-linux-x86_64.tgz` |
+| Windows (installer) | `daccord-windows-x86_64-setup.exe` |
+| Windows (portable) | `daccord-windows-x86_64.zip` |
+| macOS | `daccord-macos-universal.dmg` |
+| Android | `daccord-android.apk` |
+| Web | `daccord-web.zip` |
+
+Every release ships a `SHA256SUMS.txt` so you can verify what you downloaded. Step-by-step instructions per platform live in [Installing daccord](docs/getting-started/installation.md).
+
+iOS and the store channels are built and submitted by the release workflow; public store listings aren't live yet, so the downloads above are the way in today.
+
+### Platform support
 
 | Android | iOS | Windows | macOS | Linux | Web |
 |:---:|:---:|:---:|:---:|:---:|:---:|
@@ -62,44 +100,66 @@ All platform targets are present in the repository (`android/`, `ios/`, `windows
 Daccord connects only to **Daccord/Accord servers** — there is no Discord integration of any kind. You don't sign in to a central service; you connect directly to a server.
 
 1. Open the app.
-2. Click the **`+`** in the server bar on the left.
-3. Enter a server address — including your channel and token — like this:
+2. Click the **`+`** at the bottom of the space bar on the left.
+3. Enter the server's address — a hostname is enough:
 
    ```
-   chat.example.com#general?token=your-token
+   chat.example.com
    ```
 
-4. That's it — you're in. 🎉
+   Self-hosting on your own machine or LAN? Include the scheme, e.g. `http://localhost:39099`.
 
-You can add as many servers as you like.
+4. Sign in with your username and password, or switch to **Register** to create an account on that server.
+5. That's it — you're in. 🎉
+
+You can add as many servers as you like; each gets its own icon in the space bar.
+
+The address also accepts extras: a port (`chat.example.com:8443`), a space (`chat.example.com#my-space`), an invite code (`?invite=…`), or a pre-issued token (`?token=…`, which signs you straight in). See [Adding a Server](docs/getting-started/adding-a-server.md) for the full format.
+
+No address at all? Open **Discovery** and browse public spaces from the server directory.
 
 ### Don't have a server yet?
 
 Run your own. **AccordServer** is the open-source, Rust-powered backend that powers every Daccord community — your infrastructure, your rules.
 
-➡️ **[github.com/DaccordProject/accordserver](https://github.com/DaccordProject/accordserver)**
+The easiest route is the **Accord desktop app**: a tray application that bundles the server and a LiveKit voice server, configures itself on first launch, and keeps itself updated — no Docker, no command line. For an always-on public server, deploy `accordserver` with Docker or from source.
+
+➡️ **[github.com/DaccordProject/accordserver](https://github.com/DaccordProject/accordserver)** · [Self-hosting guide](docs/self-hosting/overview.md)
+
+---
+
+## 📚 Documentation
+
+End-user documentation lives in [`docs/`](docs/index.md):
+
+- [Installing daccord](docs/getting-started/installation.md) · [Adding a server](docs/getting-started/adding-a-server.md) · [Creating an account](docs/getting-started/creating-an-account.md)
+- [Spaces and channels](docs/navigation/spaces-and-channels.md) · [Sending messages](docs/messaging/sending-messages.md) · [Voice and video](docs/voice-and-video/voice-channels.md)
+- [Themes and appearance](docs/customization/themes.md) · [Profiles](docs/customization/profiles.md)
+- [Managing your space](docs/administration/managing-your-space.md) · [Moderation](docs/administration/moderation.md) · [Invites](docs/administration/invites.md)
+- [Self-hosting](docs/self-hosting/overview.md) · [Network behavior and privacy](docs/privacy-network.md) · [Troubleshooting](docs/troubleshooting/common-issues.md)
+
+Maintainer-facing notes: [release signing](docs/release-signing.md) and [store deployment](docs/app-store-deploy.md).
 
 ---
 
 ## 🧱 How it's built
 
-Daccord stands on the shoulders of giants. It's a fork of **[Bonfire](https://github.com/OpenBonfire/bonfire)** — a mature, fast, cross-platform Discord client written in Flutter. We reuse Bonfire's polished UI, theming, routing, and caching, and **replace its Discord networking layer entirely** with the **Accord protocol** via **[accordkit-dart](https://github.com/DaccordProject/accordkit-dart)**.
+Daccord stands on the shoulders of giants. It's a fork of **[Bonfire](https://github.com/OpenBonfire/bonfire)** — a mature, fast, cross-platform Discord client written in Flutter. We reuse Bonfire's polished UI, theming, routing, and caching, and **replaced its Discord networking layer entirely** with the **Accord protocol** via **accordkit**.
 
-The result: Bonfire's battle-tested experience pointed at a platform that's actually free and open. The Flutter client is actively working toward feature parity with the Godot client; it has not reached it yet.
+The result: Bonfire's battle-tested experience pointed at a platform that's actually free and open. This client has replaced the original Godot client as the Daccord app — that codebase is frozen on the [`legacy-godot`](https://github.com/DaccordProject/daccord/tree/legacy-godot) branch.
+
+A single gateway dispatcher subscribes to Accord's event streams, updates per-feature caches, and exposes Riverpod providers to the UI.
 
 ### Current limitations
 
 The core messaging, administration, and LiveKit calling paths are implemented, but early-development gaps still affect day-to-day expectations:
 
 - Background push delivery is not implemented; notifications are currently foreground-only ([#81](https://github.com/DaccordProject/daccord/issues/81)).
-- DM calls still lack some mid-call state propagation and picture-in-picture behavior available elsewhere ([#141](https://github.com/DaccordProject/daccord/issues/141)).
-- `@everyone` / `@here` permission checks, autocomplete, and suppression behavior are incomplete ([#213](https://github.com/DaccordProject/daccord/issues/213)–[#216](https://github.com/DaccordProject/daccord/issues/216)).
-- Device-profile storage isolation on Web does not yet match native platforms ([#247](https://github.com/DaccordProject/daccord/issues/247)).
-- Store signing and distribution setup is still being completed for some release targets ([#90](https://github.com/DaccordProject/daccord/issues/90), [#123](https://github.com/DaccordProject/daccord/issues/123)).
+- Attaching MP3 files fails on Windows ([#196](https://github.com/DaccordProject/daccord/issues/196)).
+- Bearer tokens can still be embedded in server URLs instead of exchanged for one-time codes ([#269](https://github.com/DaccordProject/daccord/issues/269)), and self-update integrity verification does not yet fail closed against a signed manifest ([#264](https://github.com/DaccordProject/daccord/issues/264)).
+- Store signing and distribution setup is still being completed for some release targets ([#90](https://github.com/DaccordProject/daccord/issues/90), [#123](https://github.com/DaccordProject/daccord/issues/123)), and the iOS App Store submission is still working through review ([#285](https://github.com/DaccordProject/daccord/issues/285), [#286](https://github.com/DaccordProject/daccord/issues/286)).
 
 See the [open issue tracker](https://github.com/DaccordProject/daccord/issues) for the current backlog rather than treating this list as exhaustive.
-
-A thin repository layer subscribes to Accord gateway streams, updates a local cache, and exposes Riverpod providers to the UI.
 
 ### Tech stack
 
@@ -108,10 +168,11 @@ A thin repository layer subscribes to Accord gateway streams, updates a local ca
 | Language / framework | Dart / Flutter | |
 | State management | [Riverpod 3](https://riverpod.dev/) | `flutter_riverpod` + `riverpod_annotation` codegen (`*.g.dart`) |
 | Routing | [`go_router`](https://pub.dev/packages/go_router) | |
-| Local storage | [`hive_ce`](https://pub.dev/packages/hive_ce) | boxes: `auth`, `last-location`, `added-accounts`, `accord-session`, `accord-settings` |
-| Networking | [`accordkit`](https://github.com/DaccordProject/accordkit-dart) | Accord protocol SDK — REST + gateway WebSocket + models. Vendored in-tree at `packages/accordkit` |
+| Local storage | [`hive_ce`](https://pub.dev/packages/hive_ce) | device boxes `auth`, `last-location`, `added-accounts`, `space-cache`, `window-state`; `accord-session` / `accord-settings` are opened per local profile |
+| Credentials | [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage) | session tokens live in the OS credential vault; Hive keeps only opaque references |
+| Networking | `accordkit` | Accord protocol SDK — REST + gateway WebSocket + models. Vendored in-tree at `packages/accordkit` and maintained here |
 | Voice / video / screen share | [`livekit_client`](https://pub.dev/packages/livekit_client) | local fork at `packages/livekit_client`, over WebRTC |
-| Media | [`media_kit`](https://pub.dev/packages/media_kit) / `cached_network_image` | CDN URLs point at the Accord server |
+| Media | [`media_kit`](https://pub.dev/packages/media_kit) / [`video_player`](https://pub.dev/packages/video_player) / `cached_network_image` | media_kit everywhere except iOS, which uses AVFoundation via `video_player`; CDN URLs point at the Accord server |
 | Markdown | `markdown_viewer` | custom renderer at `packages/markdown_viewer` |
 | Serialization | Hand-written JSON | most model types come from `accordkit` (`Accord*`) |
 
@@ -132,7 +193,16 @@ Accord uses similar-but-distinct vocabulary from Discord:
 
 ## 🛠️ Building from source
 
-You'll need the [Flutter SDK](https://docs.flutter.dev/get-started/install) installed.
+You'll need the [Flutter SDK](https://docs.flutter.dev/get-started/install) installed. The helper scripts in [`scripts/`](scripts/README.md) wrap the common flows and prefer [fvm](https://fvm.app) when it's available:
+
+```bash
+scripts/setup.sh                 # deps + one-shot codegen (also installs Linux desktop build deps)
+scripts/codegen.sh --watch       # keep this open while developing
+scripts/start.sh --flavor github # run on an Android device/emulator
+scripts/start.sh -d chrome       # run in Chrome
+```
+
+Or drive Flutter directly:
 
 ```bash
 flutter pub get
@@ -165,10 +235,25 @@ gradle --project-dir android :livekit_client:testDebugUnitTest \
   --tests io.livekit.plugin.AudioResamplerTest
 ```
 
-CI treats the full vendored-package suites, including all Markdown renderer
-corpus cases, and the Android native seam as merge and release gates.
+CI treats the root analyze/test job, the full vendored-package suites (including
+all Markdown renderer corpus cases), the Android native seam, and the accordkit
+protocol-integration job as merge and release gates. Broader client ↔ server,
+UI end-to-end, multi-instance, and LiveKit SFU scenarios run advisory
+(`continue-on-error`).
 
 ### Release builds
+
+```bash
+scripts/build.sh                 # Web (JavaScript) release -> build/web/
+scripts/build.sh apk             # Android sideload APK (github flavor)
+scripts/build.sh appbundle       # Play Store AAB
+scripts/build.sh linux           # needs libmpv / media_kit deps
+scripts/build.sh windows
+scripts/build.sh macos
+scripts/build.sh ios -- --no-codesign
+```
+
+The equivalent raw Flutter invocations:
 
 ```bash
 flutter build apk     --flavor github --no-tree-shake-icons   # Android sideload APK
@@ -179,6 +264,12 @@ flutter build macos
 flutter build linux                               # needs libmpv / media_kit deps
 flutter build ios     --release --no-tree-shake-icons --no-codesign
 ```
+
+Store builds are compiled with `--dart-define=APP_STORE=true`, which disables the
+in-app self-updater (store guidelines forbid it). Tagging `v<version>` (matching
+`pubspec.yaml`) runs the release workflow: it gates on CI, builds and signs every
+platform, publishes the GitHub Release, and submits the store builds. See
+[store deployment](docs/app-store-deploy.md).
 
 Before a tagged release, maintainers can run the manual **Windows signing smoke
 test** workflow to validate the Certum cloud certificate and Authenticode trust
@@ -195,10 +286,16 @@ Yes — completely free and open source under the GPLv3. Nothing is locked behin
 No. This client talks *only* to Daccord/Accord servers. There is no Discord integration — none of your data goes to Discord, and the app never connects to Discord's services.
 
 **Where is my data stored?**
-Community data is stored on whichever Accord server you connect to — including one you host yourself. Daccord does not proxy that server or voice traffic. The client can still make ancillary requests for discovery, updates, and explicitly approved external media; see [Network behavior and privacy](docs/privacy-network.md).
+Community data is stored on whichever Accord server you connect to — including one you host yourself. Daccord does not proxy that server or voice traffic. Your session tokens are kept in your operating system's credential vault. The client can still make ancillary requests for discovery, updates, and explicitly approved external media; see [Network behavior and privacy](docs/privacy-network.md).
+
+**Do I need one account per server?**
+Yes. Accounts live on the server you register with, so each server you add has its own sign-in. You can be signed in to many at once, and switch local profiles to keep identities separate on a shared device.
 
 **Do I need to run a server to use Daccord?**
-No — you can join any Accord server you have an address and token for. But hosting your own gives you full control. See [Don't have a server yet?](#dont-have-a-server-yet)
+No — you can join any Accord server you have an address for, or find one through Discovery. But hosting your own gives you full control. See [Don't have a server yet?](#dont-have-a-server-yet)
+
+**How do I update?**
+Desktop and sideloaded Android builds check on startup and can install the update for you. Otherwise grab the newest build from [Releases](https://github.com/DaccordProject/daccord/releases/latest).
 
 **Which platforms are supported?**
 Android, iOS, Windows, macOS, Linux, and the Web.
@@ -220,7 +317,7 @@ If you're contributing code, a few house rules keep this a port rather than a re
 
 - Keep changes **minimal and reuse-first** — prefer adapting existing Bonfire widgets, controllers, routing, and theming.
 - Keep new code inside the relevant `lib/features/<feature>/` module and match the surrounding style.
-- Run `dart run build_runner build -d` after touching any `@riverpod`-annotated file.
+- Run `scripts/codegen.sh --check` after touching any `@riverpod`-annotated file.
 - Update contributor and user documentation in the same PR when changing dependencies, generation, build/test commands, CI, supported platforms, or feature behavior. Reviewers should verify those instructions against `pubspec.yaml` and the workflows instead of preserving volatile version or test-count claims.
 - **No Discord.** Don't reintroduce Discord endpoints, branding, or Firebase push. This client talks only to Accord servers.
 - Run `flutter analyze --no-fatal-infos` and `flutter test` before opening a PR.
@@ -244,7 +341,9 @@ Every contribution — however small — goes straight into maintaining and impr
 | Repo | What it is | Language | License |
 |---|---|---|---|
 | **this repo** | Flutter client (what you ship) | Dart / Flutter | GPL-3.0 |
-| [`accordserver`](https://github.com/DaccordProject/accordserver) | Accord server backend | Rust | — |
+| [`accordserver`](https://github.com/DaccordProject/accordserver) | Accord server backend and desktop host app | Rust | — |
+| [`daccord-editor`](https://github.com/DaccordProject/daccord-editor) | Author and test Lua-based activity plugins for your server | — | — |
+| [`legacy-godot`](https://github.com/DaccordProject/daccord/tree/legacy-godot) | The retired Godot client this app replaced | GDScript | MIT |
 
 `accordkit`, `livekit_client`, and `markdown_viewer` are vendored in-tree under `packages/` and maintained in this repository.
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
-# Run the app on the Linux desktop target (debug mode with hot reload).
+# Run the app in debug mode (hot reload). Defaults to the Linux desktop
+# target; pass -d/--device-id to target something else.
 #
 #   scripts/start.sh                 # run on Linux desktop
+#   scripts/start.sh --flavor github # run on an Android device/emulator
+#   scripts/start.sh -d chrome       # run in Chrome
 #   scripts/start.sh --release       # any extra args pass straight to `flutter run`
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 
-warn_if_linux_deps_missing
+# Only default to the Linux desktop device when the caller hasn't already
+# picked one, so `-d chrome` (etc.) isn't clobbered by a second `-d linux`.
+DEVICE_ARGS=()
+has_device=false
+for arg in "$@"; do
+  case "$arg" in
+    -d | --device-id) has_device=true ;;
+  esac
+done
+
+if [ "$has_device" = false ]; then
+  warn_if_linux_deps_missing
+  DEVICE_ARGS=(-d linux)
+fi
 
 log "Fetching package dependencies"
 $FLUTTER pub get
 
-log "Launching app ($FLUTTER run -d linux $*)"
-exec $FLUTTER run -d linux "$@"
+log "Launching app ($FLUTTER run ${DEVICE_ARGS[*]+"${DEVICE_ARGS[*]}"} $*)"
+exec $FLUTTER run ${DEVICE_ARGS[@]+"${DEVICE_ARGS[@]}"} "$@"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,16 +9,23 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 
 # Only default to the Linux desktop device when the caller hasn't already
-# picked one, so `-d chrome` (etc.) isn't clobbered by a second `-d linux`.
+# said where to run, so `-d chrome` (etc.) isn't clobbered by a second
+# `-d linux`.
 DEVICE_ARGS=()
-has_device=false
+has_target=false
 for arg in "$@"; do
   case "$arg" in
-    -d | --device-id) has_device=true ;;
+    # `-d chrome`, `-dchrome`, `--device-id chrome`, `--device-id=chrome`.
+    -d | -d?* | --device-id | --device-id=*) has_target=true ;;
+    # Only Android declares product flavors (android/app/build.gradle), and a
+    # flavor is mandatory there — so `--flavor` means "an Android device", and
+    # forcing `-d linux` alongside it would fail on a target that has no
+    # flavors. Leave the device to `flutter run` to pick or prompt for.
+    --flavor | --flavor=*) has_target=true ;;
   esac
 done
 
-if [ "$has_device" = false ]; then
+if [ "$has_target" = false ]; then
   warn_if_linux_deps_missing
   DEVICE_ARGS=(-d linux)
 fi


### PR DESCRIPTION
The README had drifted from what the app actually does and how it is
installed and built.

- Getting started described a token-in-URL address as the only way in.
  The real flow is a hostname plus username/password sign-in or
  registration, with port/space/invite/token as optional extras, and
  Discovery for finding a public space with no address at all.
- Added a Download section (release assets, checksums, install doc) and a
  Documentation section linking docs/ — neither was referenced at all.
- Features listed only a fraction of what ships: threads, forums, pins,
  search, attachments and inline media, DMs and DM calls, discovery,
  profiles, TOTP, and the self-updater were missing, and "Dark theme"
  predates the five presets plus shareable custom colors.
- Current limitations cited five issues that are now closed (#141,
  #213-216, #247); replaced with the open ones (#81, #196, #264, #269,
  #285, #286) alongside the signing work already listed.
- Tech stack: Hive box list was missing space-cache/window-state and did
  not mention that accord-session/accord-settings are per profile, nor
  that tokens live in the OS credential vault; media row now notes the
  iOS video_player path.
- Build instructions now cover scripts/setup.sh, start.sh and build.sh,
  and the CI paragraph names the protocol-integration gate and the
  advisory jobs.
- The Godot client is frozen on legacy-godot rather than a parity target;
  related repos now list it and daccord-editor.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EXRqGorvy1S34HPnzBxVWb