### PR TITLE
feat(authentication): present the app's terms before signing in or registering

### DIFF
--- a/docs/administration/moderation.md
+++ b/docs/administration/moderation.md
@@ -30,6 +30,34 @@ These actions require the appropriate permissions for your role.
 
 You can unban multiple users at once using bulk selection.
 
+## Reports
+
+Anyone can report a message or an account, and reports are what moderators
+act on.
+
+**Filing a report.** Open a message's actions menu (long-press on touch,
+right-click or the "..." button on desktop) and choose **Report**, or use
+**Report user** on a profile popout or in a direct message's user menu. Pick a
+reason, add optional detail, and submit. Reporting is available everywhere
+messages are -- inside a space and in direct messages alike.
+
+A reported message is hidden from the reporter's own view straight away, on that
+device, whatever the moderators later decide. The report dialog also offers to
+**block** the account; outside a space that option is pre-selected, because a
+direct message has no moderators and blocking is what actually stops the
+contact.
+
+**Where a report goes.** A report filed inside a space goes to that space's
+moderators. A report filed outside a space goes to the server operator, on
+servers that accept account-level reports; where a server does not, the dialog
+says so rather than implying someone will review it, and the block and the local
+hide still apply.
+
+**Reviewing reports.** With the `ban_members` permission, open the reports panel
+to see what has been filed. Each report can be dismissed, resolved, or actioned
+by deleting the reported message, kicking, or banning the account -- resolving a
+report from that panel performs the action and closes it in one step.
+
 ## Deleting Messages
 
 Admins and moderators can delete any message in channels they have permission to moderate. Right-click the message and select **Delete**.

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -234,6 +234,38 @@ Then swap the `mac :appstore` lane's `upload_to_app_store` call back to
 "fastlane/metadata/mac", pkg: pkg)`, and restore the "Generate What's New" step
 in the `mac-appstore` job, and macOS releases the same way iOS does.
 
+## Guideline 1.2: user-generated content
+
+iOS 0.2.16 (build 160, reviewed 2026-08-30) was rejected under App Store
+guideline *1.2 Safety: User-Generated Content*, which requires an app carrying
+user content to present an EULA before a user registers **or** signs in, to let
+users flag objectionable content, and to let them block abusive accounts.
+
+Two of those had gaps, both since fixed:
+
+- **The EULA never appeared.** The terms gate read `tos_enabled` from the
+  server's `GET /settings`, which accordserver serves only to authenticated
+  users — signed out it 401s, so the gate always resolved to "disabled", and it
+  was wired into the Register tab alone. The app now carries terms of its own
+  (`lib/features/authentication/models/app_terms.dart`) behind an unconditional
+  gate ahead of the whole signed-out flow. A server's own ToS still shows
+  alongside it when the server advertises one.
+- **Reporting only existed on space messages.** The action was gated on a
+  non-null space, and a DM pane passes none. Report now sits on every message
+  and on user profiles and DM user menus, filing to the space's moderators
+  where there is a space and to the account-level `/reports` route where there
+  isn't.
+
+Blocking was already in place (member popout, DM relationship actions).
+
+Do not re-gate the terms on a server response: nothing a signed-out client can
+read is guaranteed to be there, and the gate has to hold before any server is
+chosen at all.
+
+Apple also asks for a screen recording of all three precautions, attached under
+**App Review Information → Notes** in App Store Connect, and it is reused by
+later submissions.
+
 ## Guideline 2.5.1: no libmpv in the iOS build
 
 iOS 0.2.6 (build 141, submitted 2026-07-09) was **rejected** under App Store

--- a/docs/getting-started/creating-an-account.md
+++ b/docs/getting-started/creating-an-account.md
@@ -9,6 +9,21 @@ section: getting-started
 
 When you connect to a server for the first time, you'll need to sign in or create a new account.
 
+## Terms of Use
+
+Before the first sign-in or registration on a device, daccord shows its **Terms
+of Use & Community Guidelines** and asks you to agree. They cover what may not
+be posted (there is no tolerance for objectionable content or abusive
+behaviour), and how to report and block. Nothing in the signed-out flow --
+including the server browser -- opens until you accept.
+
+You only see the gate again if the terms change. The full text stays available
+from **Settings → About** at any time, and from the link under the sign-in
+button.
+
+A server may *also* have Terms of Service of its own. When it does, registering
+on that server shows them as a separate checkbox alongside the app's terms.
+
 ## Signing In
 
 If you already have an account on the server:

--- a/docs/messaging/direct-messages.md
+++ b/docs/messaging/direct-messages.md
@@ -45,4 +45,13 @@ Sending messages in a DM uses the same timeline and composer as a channel. Markd
 
 ## User menus
 
-Right-click or long-press a DM recipient, message author, friend, or group member to open their user menu. From there you can view their account profile, start a separate DM, manage the friendship or block state, and copy their user ID or username. Group owners can also remove participants from the group-member menu.
+Right-click or long-press a DM recipient, message author, friend, or group member to open their user menu. From there you can view their account profile, start a separate DM, manage the friendship or block state, report the account, and copy their user ID or username. Group owners can also remove participants from the group-member menu.
+
+## Reporting and blocking
+
+Individual messages in a DM can be reported the same way as anywhere else --
+open the message's actions menu and choose **Report**. Reporting hides the
+message from your view and offers to block the sender, which is pre-selected
+here: a DM has no space moderators, so blocking is what stops the contact. See
+[Moderation](../administration/moderation.md) for what happens to a report after you
+file it.

--- a/lib/features/authentication/models/app_terms.dart
+++ b/lib/features/authentication/models/app_terms.dart
@@ -1,0 +1,110 @@
+/// The client's own terms of use and community guidelines.
+///
+/// Distinct from a *server's* Terms of Service (`tos_gate.dart`), which is
+/// per-instance, optional, and only readable once authenticated — see #289. An
+/// account is always created on somebody else's Accord instance, so the app
+/// needs terms of its own that can be shown before any server is reachable,
+/// and App Store Review Guideline 1.2 requires them to be presented before a
+/// user registers *or* signs in.
+library;
+
+/// Bumped whenever [appTermsBody] changes materially. Acceptance is recorded
+/// against this number, so a bump re-prompts everyone.
+const int appTermsVersion = 1;
+
+const String appTermsTitle = 'Terms of Use & Community Guidelines';
+
+/// One-line summary used next to the acceptance control.
+const String appTermsSummary =
+    'Daccord has a zero-tolerance policy for objectionable content and '
+    'abusive behaviour.';
+
+/// Where a user reports a problem with the app itself (as opposed to content
+/// on a particular server, which goes to that server's moderators).
+const String appTermsContactUrl =
+    'https://github.com/DaccordProject/daccord/issues';
+
+const String appTermsBody = '''
+Last updated: 30 August 2026
+
+1. Accepting these terms
+
+By using Daccord you agree to these Terms of Use and Community Guidelines. If
+you do not agree, do not use the app.
+
+2. What Daccord is
+
+Daccord is a client application. It connects to Accord servers (also called
+instances) that are run by other people and organisations, not by us. Each
+server sets its own rules, keeps its own data, and is moderated by its own
+operators and moderators. When you register an account you are registering with
+that server, and its rules apply to you in addition to these terms.
+
+3. Your content
+
+You keep ownership of what you post. You are responsible for it, and you confirm
+you have the right to post it. Anything you send is transmitted to, and stored
+by, the server you sent it to.
+
+4. Zero tolerance for objectionable content and abusive behaviour
+
+There is no tolerance for objectionable content or for users who behave
+abusively. You must not use Daccord to post, send, or share:
+
+  - sexual content involving minors, or any content that sexualises a minor;
+  - harassment, bullying, stalking, or threats;
+  - hate speech, or attacks on people based on race, ethnicity, national origin,
+    religion, disability, sex, gender identity, sexual orientation, or age;
+  - violent, graphic, or gratuitously shocking material;
+  - content encouraging self-harm or suicide;
+  - terrorist or violent extremist material;
+  - spam, scams, fraud, or malware;
+  - content that is illegal where you are, or where the server you post to is
+    operated.
+
+5. Reporting and blocking
+
+Every message and every account can be reported from inside the app. Use the
+message's Report action, or Report user on an account, to flag anything that
+breaks these guidelines. Reports of content posted in a space go to that space's
+moderators, who are expected to act on them promptly — typically within 24
+hours — by removing content, or by kicking or banning the account responsible.
+
+You can also block any account at any time. Blocking stops that account from
+messaging you and hides its content from you. Blocking is yours alone: it takes
+effect immediately and does not require anyone's approval.
+
+Reporting content does not guarantee a particular outcome, and moderation
+decisions on a server are made by that server's operators.
+
+6. Consequences
+
+Server operators may remove your content, or suspend or terminate your account
+on their server, if you break these guidelines or their own rules. Accounts used
+to post objectionable content or to abuse other users may be removed without
+notice.
+
+7. Privacy
+
+Daccord does not collect analytics, does not show ads, and does not track you.
+What you send goes to the server you chose and nowhere else. Read that server's
+own privacy policy to understand how it handles your data.
+
+8. The software
+
+Daccord is free and open-source software, licensed under the GNU General Public
+License version 3. It is provided "as is", without warranty of any kind, to the
+extent permitted by law. Nothing in these terms limits the rights the GPL grants
+you in the software itself.
+
+9. Changes
+
+These terms may be updated. A material change re-prompts you to accept the new
+version before you continue.
+
+10. Contact
+
+Problems with the app, including anything in these terms, can be raised at
+$appTermsContactUrl. Content posted on a particular
+server is handled by that server's moderators through the in-app report action.
+''';

--- a/lib/features/authentication/utils/terms_acceptance.dart
+++ b/lib/features/authentication/utils/terms_acceptance.dart
@@ -1,0 +1,33 @@
+import 'package:bonfire/features/authentication/models/app_terms.dart';
+import 'package:hive_ce/hive.dart';
+
+/// Device-global record of the user having accepted [appTermsBody].
+///
+/// Stored in the `auth` box rather than a profile box: the terms are the app's,
+/// not an account's, so switching device profiles or signing out must not
+/// re-prompt — while a new terms version must.
+const String _termsBoxName = 'auth';
+const String _termsVersionKey = 'accepted-app-terms-version';
+
+/// Whether the current [appTermsVersion] has been accepted on this device.
+///
+/// False when the box isn't open (very early startup, or a test that skipped
+/// Hive) — failing closed shows the gate rather than silently skipping it.
+bool hasAcceptedAppTerms() {
+  if (!Hive.isBoxOpen(_termsBoxName)) return false;
+  final stored = Hive.box(_termsBoxName).get(_termsVersionKey);
+  final accepted = stored is int ? stored : int.tryParse('$stored');
+  return accepted != null && accepted >= appTermsVersion;
+}
+
+/// Records acceptance of the current [appTermsVersion].
+Future<void> recordAppTermsAcceptance() async {
+  if (!Hive.isBoxOpen(_termsBoxName)) return;
+  await Hive.box(_termsBoxName).put(_termsVersionKey, appTermsVersion);
+}
+
+/// Clears the record, so the gate shows again. Used by tests.
+Future<void> clearAppTermsAcceptance() async {
+  if (!Hive.isBoxOpen(_termsBoxName)) return;
+  await Hive.box(_termsBoxName).delete(_termsVersionKey);
+}

--- a/lib/features/authentication/views/accord_login.dart
+++ b/lib/features/authentication/views/accord_login.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
+
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/authentication/utils/credential_validation.dart';
+import 'package:bonfire/features/authentication/utils/terms_acceptance.dart';
 import 'package:bonfire/features/authentication/utils/tos_gate.dart';
 import 'package:bonfire/features/authentication/views/auth_form.dart';
 import 'package:bonfire/features/authentication/views/password_reset_form.dart';
+import 'package:bonfire/features/authentication/views/terms_gate.dart';
 import 'package:bonfire/features/authentication/views/welcome_view.dart';
 import 'package:bonfire/features/profiles/services/profile_store.dart';
 import 'package:bonfire/features/server/models/accord_server.dart';
@@ -78,6 +82,12 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
   /// Whether any saved accounts exist, gating the "switch account" link.
   bool _hasAccounts = false;
 
+  /// Whether the app's own terms have been accepted on this device. Until they
+  /// are, the gate replaces the whole signed-out flow — App Review 1.2 wants
+  /// the EULA before registering *or* signing in, so it can't live inside the
+  /// register tab (#289).
+  bool _termsAccepted = true;
+
   // Terms-of-Service config, fetched per server when the Register tab is shown.
   bool _tosEnabled = false;
   bool _tosAccepted = false;
@@ -92,6 +102,7 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
   @override
   void initState() {
     super.initState();
+    _termsAccepted = hasAcceptedAppTerms();
     final lastServer = ProfileStore.sessionBox.get('last-server');
     if (lastServer is String) _serverController.text = lastServer;
 
@@ -167,6 +178,14 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
   }
 
   Future<void> _openTos() => openTos(context, url: _tosUrl, text: _tosText);
+
+  /// Accepts the app's terms: the gate lifts immediately and the record is
+  /// written behind it. A failed write only means the gate shows again next
+  /// launch, which is the right way for this to fail.
+  void _acceptAppTerms() {
+    setState(() => _termsAccepted = true);
+    unawaited(recordAppTermsAcceptance());
+  }
 
   /// Discovery (the embedded browser while signed out) needs auth against
   /// `serverUrl` before joining `spaceId`: switch to the credentials form,
@@ -310,6 +329,16 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
       );
     }
 
+    // Nothing in the signed-out flow — not the welcome screen, not the server
+    // browser, and above all not the credentials form — is reachable before the
+    // terms are accepted.
+    if (!_termsAccepted) {
+      return _centered(
+        TermsGateView(onAccept: _acceptAppTerms),
+        maxWidth: 560,
+      );
+    }
+
     // Signed out: walk welcome → browse → credentials. Intercept system back to
     // step through the sub-flow rather than leaving the screen, except at the
     // flow's entry view.
@@ -347,6 +376,7 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
           onGeneratePassword: _generatePassword,
           onTosChanged: (v) => setState(() => _tosAccepted = v),
           onTosLinkTap: _openTos,
+          onAppTermsTap: () => showAppTermsDialog(context),
           onDiscover: () => setState(() => _view = _LoggedOutView.browse),
           onSubmit: _submit,
           error:
@@ -440,6 +470,7 @@ class _AuthForm extends StatelessWidget {
     required this.onGeneratePassword,
     required this.onTosChanged,
     required this.onTosLinkTap,
+    required this.onAppTermsTap,
     required this.onDiscover,
     required this.onSubmit,
     this.onBack,
@@ -460,6 +491,9 @@ class _AuthForm extends StatelessWidget {
   final VoidCallback onGeneratePassword;
   final ValueChanged<bool> onTosChanged;
   final VoidCallback onTosLinkTap;
+
+  /// Opens the app's own terms, linked under the submit button in both modes.
+  final VoidCallback onAppTermsTap;
   final VoidCallback onDiscover;
   final VoidCallback onSubmit;
   final String? error;
@@ -525,6 +559,8 @@ class _AuthForm extends StatelessWidget {
           label: isRegister ? 'Register' : 'Log In',
           onPressed: onSubmit,
         ),
+        const SizedBox(height: 12),
+        AppTermsNotice(onTap: onAppTermsTap),
         const SizedBox(height: 20),
         Row(
           children: [

--- a/lib/features/authentication/views/terms_gate.dart
+++ b/lib/features/authentication/views/terms_gate.dart
@@ -1,0 +1,188 @@
+import 'package:bonfire/features/authentication/models/app_terms.dart';
+import 'package:bonfire/shared/utils/responsive_dialog.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// The app's own terms gate, shown before the signed-out flow can be used.
+///
+/// App Store Review Guideline 1.2 requires an EULA to be presented *before* a
+/// user registers or signs in; a server's own Terms of Service can't satisfy
+/// that (it is optional, per-instance, and only readable once authenticated —
+/// see #289), so this gate is unconditional and lives ahead of the credentials
+/// form rather than inside it.
+class TermsGateView extends StatelessWidget {
+  const TermsGateView({super.key, required this.onAccept});
+
+  /// Called once the user agrees. The caller records acceptance and moves on.
+  final VoidCallback onAccept;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: Image.asset('assets/images/icon.png', width: 64, height: 64),
+        ),
+        const SizedBox(height: 14),
+        Text(
+          appTermsTitle,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          appTermsSummary,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(color: colors.gray),
+        ),
+        const SizedBox(height: 16),
+        const AppTermsBody(),
+        const SizedBox(height: 16),
+        SizedBox(
+          height: 50,
+          child: ElevatedButton(
+            onPressed: onAccept,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colors.primary,
+              foregroundColor: Colors.white,
+              textStyle: theme.textTheme.titleSmall,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            child: const Text('Agree and continue'),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'You must accept these terms to create an account or sign in.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+        ),
+      ],
+    );
+  }
+}
+
+/// The scrollable terms text, sized to leave the accept control on screen.
+///
+/// Bounded on purpose: the gate is hosted inside the login screen's scroll
+/// view, so an unbounded text block would push the button out of reach on a
+/// phone instead of scrolling within itself.
+class AppTermsBody extends StatelessWidget {
+  const AppTermsBody({super.key, this.maxHeight});
+
+  final double? maxHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    final height =
+        maxHeight ??
+        (MediaQuery.sizeOf(context).height * 0.45).clamp(180.0, 460.0);
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: colors.foreground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.darkGray),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Scrollbar(
+        child: SingleChildScrollView(
+          primary: false,
+          child: SelectableText(
+            appTermsBody.trim(),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colors.dirtyWhite,
+              height: 1.45,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The always-visible "by continuing you agree" line under the auth form's
+/// submit button. Shown in both Sign in and Register modes: the gate is what
+/// actually blocks the flow, but Apple's reviewer (and the user) should be able
+/// to reach the terms from the form itself at any time.
+class AppTermsNotice extends StatelessWidget {
+  const AppTermsNotice({super.key, required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    // Wrap, not Row: the title is long enough to overflow a phone-width form
+    // beside the lead-in, and it should fall onto its own line instead.
+    return Wrap(
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        Text(
+          'By continuing you agree to the',
+          style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+        ),
+        TextButton(
+          onPressed: onTap,
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            minimumSize: const Size(0, 32),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: Text(
+            appTermsTitle,
+            style: theme.textTheme.bodySmall?.copyWith(color: colors.primary),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shows the terms as a dialog, for the "Terms of Use" links on the auth form
+/// and in settings once they have already been accepted.
+Future<void> showAppTermsDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) => Dialog(
+      child: ConstrainedBox(
+        constraints: dialogConstraints(context, maxWidth: 560),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                appTermsTitle,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              Flexible(child: const AppTermsBody(maxHeight: 420)),
+              const SizedBox(height: 16),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Close'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/features/member/views/accord_member_popout.dart
+++ b/lib/features/member/views/accord_member_popout.dart
@@ -13,6 +13,7 @@ import 'package:bonfire/features/member/views/remote_origin_badge.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/features/user/views/accord_direct_messages.dart';
+import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -116,6 +117,19 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
       onSuccess: () => ref
           .read(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId).notifier)
           .removeMember(widget.userId),
+    );
+  }
+
+  /// Reports this user to the space's moderators, with the option to block
+  /// them at the same time (App Review 1.2 — see #290).
+  void _report() {
+    showReportDialog(
+      context,
+      spaceId: widget.spaceId,
+      targetType: 'user',
+      targetId: widget.userId,
+      reportedUserId: widget.userId,
+      reportedName: _displayName,
     );
   }
 
@@ -466,6 +480,15 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
                     ),
                     icon: const Icon(Icons.chat_bubble_outline, size: 18),
                     label: const Text('Direct Message'),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: _busy ? null : _report,
+                    style: TextButton.styleFrom(foregroundColor: colors.red),
+                    icon: const Icon(Icons.flag_outlined, size: 18),
+                    label: const Text('Report user'),
                   ),
                 ),
                 Align(

--- a/lib/features/messaging/controllers/hidden_messages.dart
+++ b/lib/features/messaging/controllers/hidden_messages.dart
@@ -1,0 +1,55 @@
+import 'package:bonfire/features/profiles/services/profile_store.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'hidden_messages.g.dart';
+
+/// Key under which the hidden set is persisted in the active profile's settings
+/// box. Deliberately not part of [AccordSettings]: this is a moderation record
+/// rather than a preference, and it must survive even if settings are reset.
+const String hiddenMessagesKey = 'reported-hidden-message-ids';
+
+/// Messages the user has reported and therefore no longer wants to see.
+///
+/// Reporting content in a space hands it to that space's moderators, but
+/// nothing about their decision is instant — and a direct message has no
+/// moderator at all. Either way the reporter should stop seeing what they just
+/// flagged, so the pane filters these out locally, on this device, for good
+/// (App Review 1.2, #290).
+@Riverpod(keepAlive: true)
+class HiddenMessagesController extends _$HiddenMessagesController {
+  /// The settings box, or null when storage isn't up (widget tests that skip
+  /// Hive, and the window before bootstrap finishes). Reading it defensively
+  /// keeps a hidden-message lookup from breaking every pane that watches it.
+  Box? get _box => Hive.isBoxOpen(ProfileStore.activeSettingsBoxName)
+      ? ProfileStore.settingsBox
+      : null;
+
+  @override
+  Set<String> build() {
+    final stored = _box?.get(hiddenMessagesKey);
+    if (stored is! List) return const {};
+    return {
+      for (final id in stored)
+        if (id is String && id.isNotEmpty) id,
+    };
+  }
+
+  /// Hides [messageId] and persists the change. No-op if already hidden.
+  Future<void> hide(String messageId) async {
+    if (messageId.isEmpty || state.contains(messageId)) return;
+    state = {...state, messageId};
+    await _persist();
+  }
+
+  /// Restores [messageId]. Nothing in the UI calls this yet — it exists so a
+  /// mistaken report is recoverable rather than permanent.
+  Future<void> unhide(String messageId) async {
+    if (!state.contains(messageId)) return;
+    state = {...state}..remove(messageId);
+    await _persist();
+  }
+
+  Future<void> _persist() async =>
+      await _box?.put(hiddenMessagesKey, state.toList());
+}

--- a/lib/features/messaging/controllers/hidden_messages.g.dart
+++ b/lib/features/messaging/controllers/hidden_messages.g.dart
@@ -1,0 +1,93 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'hidden_messages.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Messages the user has reported and therefore no longer wants to see.
+///
+/// Reporting content in a space hands it to that space's moderators, but
+/// nothing about their decision is instant — and a direct message has no
+/// moderator at all. Either way the reporter should stop seeing what they just
+/// flagged, so the pane filters these out locally, on this device, for good
+/// (App Review 1.2, #290).
+
+@ProviderFor(HiddenMessagesController)
+const hiddenMessagesControllerProvider = HiddenMessagesControllerProvider._();
+
+/// Messages the user has reported and therefore no longer wants to see.
+///
+/// Reporting content in a space hands it to that space's moderators, but
+/// nothing about their decision is instant — and a direct message has no
+/// moderator at all. Either way the reporter should stop seeing what they just
+/// flagged, so the pane filters these out locally, on this device, for good
+/// (App Review 1.2, #290).
+final class HiddenMessagesControllerProvider
+    extends $NotifierProvider<HiddenMessagesController, Set<String>> {
+  /// Messages the user has reported and therefore no longer wants to see.
+  ///
+  /// Reporting content in a space hands it to that space's moderators, but
+  /// nothing about their decision is instant — and a direct message has no
+  /// moderator at all. Either way the reporter should stop seeing what they just
+  /// flagged, so the pane filters these out locally, on this device, for good
+  /// (App Review 1.2, #290).
+  const HiddenMessagesControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'hiddenMessagesControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$hiddenMessagesControllerHash();
+
+  @$internal
+  @override
+  HiddenMessagesController create() => HiddenMessagesController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
+  }
+}
+
+String _$hiddenMessagesControllerHash() =>
+    r'5677ed030d1d42ca7e891d72706e7c0989d3873b';
+
+/// Messages the user has reported and therefore no longer wants to see.
+///
+/// Reporting content in a space hands it to that space's moderators, but
+/// nothing about their decision is instant — and a direct message has no
+/// moderator at all. Either way the reporter should stop seeing what they just
+/// flagged, so the pane filters these out locally, on this device, for good
+/// (App Review 1.2, #290).
+
+abstract class _$HiddenMessagesController extends $Notifier<Set<String>> {
+  Set<String> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<Set<String>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Set<String>, Set<String>>,
+              Set<String>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -19,6 +19,7 @@ import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:bonfire/features/member/views/accord_member_popout.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
 import 'package:bonfire/features/messaging/controllers/typing.dart';
 import 'package:bonfire/features/messaging/utils/attachment_limits.dart';
 import 'package:bonfire/features/messaging/utils/attachment_types.dart';
@@ -293,12 +294,18 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
       );
     }
 
-    final messages = ref.watch(
+    final loadedMessages = ref.watch(
       accordMessagesControllerProvider(
         ref.readActiveServerKey() ?? '',
         channelId,
       ),
     );
+    // Messages the user reported are dropped from their own view for good —
+    // moderation elsewhere is neither instant nor guaranteed (#290).
+    final hidden = ref.watch(hiddenMessagesControllerProvider);
+    final messages = loadedMessages == null || hidden.isEmpty
+        ? loadedMessages
+        : loadedMessages.where((m) => !hidden.contains(m.id)).toList();
     final members = spaceId == null
         ? null
         : ref.watch(

--- a/lib/features/messaging/views/message_pane/message_row.dart
+++ b/lib/features/messaging/views/message_pane/message_row.dart
@@ -370,12 +370,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
             canEdit: widget.isOwn,
             canDelete: widget.isOwn || widget.canManageMessages,
             canPin: widget.canManageMessages,
-            canReport: !widget.isOwn && widget.spaceId != null,
+            canReport: !widget.isOwn,
             pinned: message.pinned,
             onEdit: () => _startEdit(message),
             onDelete: () => _delete(message.id),
             onTogglePin: () => _togglePin(message.id, pinned: message.pinned),
-            onReport: () => _report(message.id),
+            onReport: () => _report(message),
             onMenuStateChanged: _menuStateChanged,
           );
     return MouseRegion(
@@ -522,15 +522,18 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     onUserContextMenu: widget.onUserContextMenu,
   );
 
-  void _report(String messageId) {
-    final spaceId = widget.spaceId;
-    if (spaceId == null) return;
+  /// Reports [message]. Available in DMs too, where [_MessageRow.spaceId] is
+  /// null: the dialog then files an account-level report and offers to block
+  /// the author, rather than the action disappearing (#290).
+  void _report(AccordMessage message) {
     showReportDialog(
       context,
-      spaceId: spaceId,
+      spaceId: widget.spaceId,
       targetType: 'message',
-      targetId: messageId,
+      targetId: message.id,
       channelId: widget.channelId,
+      reportedUserId: message.authorId.isEmpty ? null : message.authorId,
+      reportedName: _authorName,
     );
   }
 
@@ -544,7 +547,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
   void _showActionsMenu(AccordMessage message, [Offset? position]) {
     if (_editing) return;
     final canDelete = widget.isOwn || widget.canManageMessages;
-    final canReport = !widget.isOwn && widget.spaceId != null;
+    final canReport = !widget.isOwn;
     final entries = <AccordMenuEntry>[
       AccordMenuEntry(
         label: 'Add reaction',
@@ -582,7 +585,7 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
         AccordMenuEntry(
           label: 'Report',
           icon: Icons.flag_outlined,
-          onSelected: () => _report(message.id),
+          onSelected: () => _report(message),
         ),
       if (widget.onLongPressSelect != null) ...[
         const AccordMenuEntry.divider(),

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -17,6 +17,8 @@ import 'package:bonfire/features/updates/views/updates_page.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/user/views/accord_account_settings.dart';
 import 'package:bonfire/features/user/views/accord_profile_edit.dart';
+import 'package:bonfire/features/authentication/models/app_terms.dart';
+import 'package:bonfire/features/authentication/views/terms_gate.dart';
 import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
@@ -758,6 +760,15 @@ class _AboutSection extends StatelessWidget {
             'A native multi-platform Daccord client (GPLv3).',
           ),
           trailing: Text('v$kAppVersion'),
+        ),
+        ListTile(
+          leading: const Icon(Icons.gavel_outlined),
+          title: const Text(appTermsTitle),
+          subtitle: const Text(
+            'The terms you accepted, including what is not allowed and how to '
+            'report it.',
+          ),
+          onTap: () => showAppTermsDialog(context),
         ),
       ],
     );

--- a/lib/features/spaces/views/accord_reports.dart
+++ b/lib/features/spaces/views/accord_reports.dart
@@ -10,18 +10,29 @@ import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Opens a dialog to report [targetType]/[targetId] (e.g. a message or member)
-/// to the space's moderators.
+/// Opens a dialog to report [targetType]/[targetId] — a message or a user.
+///
+/// [spaceId] is the space whose moderators receive the report. It is null for
+/// anything outside a space (a direct message, or a user reported from an
+/// account-level surface); that report goes to the server's account-level
+/// `/reports` route where one exists, and either way the reporter can block the
+/// account and stops seeing the content they flagged. See #290.
+///
+/// [reportedUserId] enables the "block" option and, for a message, names the
+/// account behind it; [reportedName] is only used to label that option.
 Future<void> showReportDialog(
   BuildContext context, {
-  required String spaceId,
+  String? spaceId,
   required String targetType,
   required String targetId,
   String? channelId,
+  String? reportedUserId,
+  String? reportedName,
 }) {
   return showDialog<void>(
     context: context,
@@ -30,6 +41,8 @@ Future<void> showReportDialog(
       targetType: targetType,
       targetId: targetId,
       channelId: channelId,
+      reportedUserId: reportedUserId,
+      reportedName: reportedName,
     ),
   );
 }
@@ -40,12 +53,16 @@ class _ReportDialog extends ConsumerStatefulWidget {
     required this.targetType,
     required this.targetId,
     this.channelId,
+    this.reportedUserId,
+    this.reportedName,
   });
 
-  final String spaceId;
+  final String? spaceId;
   final String targetType;
   final String targetId;
   final String? channelId;
+  final String? reportedUserId;
+  final String? reportedName;
 
   @override
   ConsumerState<_ReportDialog> createState() => _ReportDialogState();
@@ -64,6 +81,17 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
   bool _busy = false;
   String? _error;
   bool _done = false;
+
+  /// Whether to block the reported account as part of submitting. Defaulted on
+  /// outside a space: there are no moderators to act on a direct message, so
+  /// blocking is what actually stops the abuse.
+  late bool _block = widget.spaceId == null;
+
+  /// Whether the server accepted the report (false when it only takes
+  /// space-scoped reports), and whether the block went through — the two
+  /// together decide what the confirmation claims happened.
+  bool _delivered = false;
+  bool _blocked = false;
 
   @override
   void initState() {
@@ -125,23 +153,100 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
       _busy = true;
       _error = null;
     });
-    final result = await client.reports.create(widget.spaceId, {
+
+    final payload = <String, dynamic>{
       'target_type': widget.targetType,
       'target_id': widget.targetId,
       'category': category,
       if (widget.channelId != null) 'channel_id': widget.channelId,
+      if (widget.reportedUserId != null)
+        'reported_user_id': widget.reportedUserId,
       if (_description.text.trim().isNotEmpty)
         'description': _description.text.trim(),
-    });
+    };
+
+    final spaceId = widget.spaceId;
+    var delivered = false;
+    if (spaceId != null) {
+      final result = await client.reports.create(spaceId, payload);
+      if (!mounted) return;
+      if (!result.ok) {
+        setState(() {
+          _busy = false;
+          _error = result.errorOr('Failed to submit report');
+        });
+        return;
+      }
+      delivered = true;
+    } else {
+      final result = await client.reports.createDirect(payload);
+      if (!mounted) return;
+      // A server without the account-level route isn't a failed report: the
+      // block and the local hide below are still the outcome the user asked
+      // for. Any other error is a real failure and stops here.
+      if (!result.ok && !ReportsApi.reportRouteMissing(result)) {
+        setState(() {
+          _busy = false;
+          _error = result.errorOr('Failed to submit report');
+        });
+        return;
+      }
+      delivered = result.ok;
+    }
+
+    // Hidden before the block is attempted: the user reported this content, so
+    // it goes out of their view whether or not the block that follows works.
+    if (widget.targetType == 'message') {
+      await ref
+          .read(hiddenMessagesControllerProvider.notifier)
+          .hide(widget.targetId);
+    }
+
+    var blocked = false;
+    final reportedUserId = widget.reportedUserId;
+    if (_block && reportedUserId != null) {
+      final result = await client.users.putRelationship(reportedUserId, {
+        'type': 2,
+      });
+      if (!mounted) return;
+      blocked = result.ok;
+      if (!result.ok) {
+        setState(() {
+          _busy = false;
+          _error = result.errorOr('Reported, but blocking the account failed');
+        });
+        return;
+      }
+    }
+
     if (!mounted) return;
     setState(() {
       _busy = false;
-      if (result.ok) {
-        _done = true;
-      } else {
-        _error = result.errorOr('Failed to submit report');
-      }
+      _delivered = delivered;
+      _blocked = blocked;
+      _done = true;
     });
+  }
+
+  /// Everything the submission actually did. Empty when it did nothing, which
+  /// the confirmation says outright rather than implying a report was filed.
+  List<String> get _outcomes => [
+    if (_delivered) 'Moderators will review it shortly.',
+    if (widget.targetType == 'message') 'The message is now hidden for you.',
+    if (_blocked) 'The account is blocked and can no longer message you.',
+  ];
+
+  String get _outcomeTitle {
+    if (_delivered) return 'Report submitted';
+    if (_outcomes.isNotEmpty) return 'Done';
+    return 'Report not sent';
+  }
+
+  String get _outcomeBody {
+    final outcomes = _outcomes;
+    if (outcomes.isNotEmpty) return outcomes.join(' ');
+    return 'This server only accepts reports inside a space, so nothing was '
+        'sent. You can still block the account to stop it contacting you.';
   }
 
   @override
@@ -157,15 +262,19 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
               ? Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(Icons.check_circle, color: colors.green, size: 40),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Report submitted',
-                      style: theme.textTheme.titleMedium,
+                    Icon(
+                      _outcomes.isEmpty
+                          ? Icons.info_outline
+                          : Icons.check_circle,
+                      color: _outcomes.isEmpty ? colors.gray : colors.green,
+                      size: 40,
                     ),
+                    const SizedBox(height: 12),
+                    Text(_outcomeTitle, style: theme.textTheme.titleMedium),
                     const SizedBox(height: 8),
                     Text(
-                      'Moderators will review it shortly.',
+                      _outcomeBody,
+                      textAlign: TextAlign.center,
                       style: theme.textTheme.bodySmall!.copyWith(
                         color: colors.gray,
                       ),
@@ -185,8 +294,20 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     Text(
-                      'Report ${widget.targetType}',
+                      widget.targetType == 'user'
+                          ? 'Report ${widget.reportedName ?? 'user'}'
+                          : 'Report message',
                       style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      widget.spaceId != null
+                          ? 'Reports go to this space\'s moderators.'
+                          : 'Reports outside a space go to the server '
+                                'operator. Blocking takes effect immediately.',
+                      style: theme.textTheme.bodySmall!.copyWith(
+                        color: colors.gray,
+                      ),
                     ),
                     const SizedBox(height: 16),
                     DropdownButtonFormField<String>(
@@ -221,6 +342,29 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
                         border: OutlineInputBorder(),
                       ),
                     ),
+                    if (widget.reportedUserId != null) ...[
+                      const SizedBox(height: 4),
+                      CheckboxListTile(
+                        value: _block,
+                        onChanged: _busy
+                            ? null
+                            : (v) => setState(() => _block = v ?? false),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        contentPadding: EdgeInsets.zero,
+                        dense: true,
+                        title: Text(
+                          'Also block ${widget.reportedName ?? 'this account'}',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          'They can no longer message you, and their content '
+                          'is hidden.',
+                          style: theme.textTheme.bodySmall!.copyWith(
+                            color: colors.gray,
+                          ),
+                        ),
+                      ),
+                    ],
                     if (_error != null) ...[
                       const SizedBox(height: 12),
                       InlineError(_error!, centered: false),

--- a/lib/features/user/views/accord_direct_messages.dart
+++ b/lib/features/user/views/accord_direct_messages.dart
@@ -21,6 +21,7 @@ import 'package:bonfire/features/voice/controllers/missed_calls.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/views/voice_pip_overlay.dart';
 import 'package:bonfire/features/voice/views/voice_view.dart';
+import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -244,6 +245,18 @@ Future<void> showAccordDmUserContextMenu(
         },
         destructive: rel?.type == _Rel.friend,
         onSelected: () => _changeDmRelationship(context, ref, user, rel?.type),
+      ),
+      AccordMenuEntry(
+        label: 'Report user',
+        icon: Icons.flag_outlined,
+        destructive: true,
+        onSelected: () => showReportDialog(
+          context,
+          targetType: 'user',
+          targetId: user.id,
+          reportedUserId: user.id,
+          reportedName: _userName(user),
+        ),
       ),
       if (rel?.type != _Rel.blocked)
         AccordMenuEntry(

--- a/packages/accordkit/lib/src/rest/endpoints/reports_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/reports_api.dart
@@ -20,6 +20,28 @@ class ReportsApi extends EndpointBase {
         .then((r) => r.deserialize(AccordReport.fromJson));
   }
 
+  /// Creates a report that isn't scoped to a space — a direct message, or a
+  /// user reported from outside any space — by posting to the account-level
+  /// `/reports` collection. [data] takes the same shape as [create].
+  ///
+  /// Not every server implements this route: an instance that predates it
+  /// answers `404`/`405`, which callers should treat as "this server takes
+  /// space reports only" rather than as a failed report. [reportRouteMissing]
+  /// recognises those statuses.
+  Future<RestResult> createDirect(Map<String, dynamic> data) {
+    return rest
+        .makeRequest('POST', '/reports', body: data)
+        .then((r) => r.deserialize(AccordReport.fromJson));
+  }
+
+  /// Whether [result] failed because the server has no such report route,
+  /// rather than because the report itself was rejected.
+  static bool reportRouteMissing(RestResult result) =>
+      !result.ok &&
+      (result.statusCode == 404 ||
+          result.statusCode == 405 ||
+          result.statusCode == 501);
+
   /// Lists reports. Supports `status`/`limit`/`before`.
   Future<RestResult> list(String spaceId,
       {Map<String, dynamic> query = const {}}) {

--- a/packages/accordkit/test/endpoints_test.dart
+++ b/packages/accordkit/test/endpoints_test.dart
@@ -409,6 +409,70 @@ void main() {
       expect(log.last.method, 'PATCH');
       expect(log.last.jsonBody!['action_taken'], 'none');
     });
+
+    test('createDirect posts to the account-level route', () async {
+      rest = mockRest(
+        log: log,
+        responder: (_) => jsonData({
+          'id': '11',
+          'target_type': 'message',
+          'target_id': '20',
+        }),
+      );
+
+      final result = await ReportsApi(rest).createDirect({
+        'target_type': 'message',
+        'target_id': '20',
+        'category': 'spam',
+      });
+
+      expect(req.method, 'POST');
+      expect(req.url.path, '/api/v1/reports');
+      expect(req.jsonBody, {
+        'target_type': 'message',
+        'target_id': '20',
+        'category': 'spam',
+      });
+      expect(result.data, isA<AccordReport>());
+    });
+
+    test('reportRouteMissing recognises 404/405/501 failures only', () async {
+      rest = mockRest(
+        log: log,
+        responder: (_) => jsonError('NOT_FOUND', 'no such route', status: 404),
+      );
+      final notFound = await ReportsApi(rest).createDirect({});
+      expect(ReportsApi.reportRouteMissing(notFound), isTrue);
+
+      rest = mockRest(
+        log: log,
+        responder: (_) =>
+            jsonError('METHOD_NOT_ALLOWED', 'nope', status: 405),
+      );
+      final methodNotAllowed = await ReportsApi(rest).createDirect({});
+      expect(ReportsApi.reportRouteMissing(methodNotAllowed), isTrue);
+
+      rest = mockRest(
+        log: log,
+        responder: (_) => jsonError('NOT_IMPLEMENTED', 'nope', status: 501),
+      );
+      final notImplemented = await ReportsApi(rest).createDirect({});
+      expect(ReportsApi.reportRouteMissing(notImplemented), isTrue);
+
+      rest = mockRest(
+        log: log,
+        responder: (_) => jsonError('BAD_REQUEST', 'invalid', status: 400),
+      );
+      final badRequest = await ReportsApi(rest).createDirect({});
+      expect(ReportsApi.reportRouteMissing(badRequest), isFalse);
+
+      rest = mockRest(
+        log: log,
+        responder: (_) => jsonData({'id': '12'}),
+      );
+      final ok = await ReportsApi(rest).createDirect({});
+      expect(ReportsApi.reportRouteMissing(ok), isFalse);
+    });
   });
 
   group('FederationApi', () {

--- a/test/features/authentication/terms_gate_test.dart
+++ b/test/features/authentication/terms_gate_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/models/app_terms.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/authentication/utils/terms_acceptance.dart';
+import 'package:bonfire/features/authentication/views/accord_login.dart';
+import 'package:bonfire/features/authentication/views/terms_gate.dart';
+import 'package:bonfire/features/authentication/views/welcome_view.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+/// The app's own terms gate (#289).
+///
+/// A server's Terms of Service can't satisfy App Review 1.2: it is optional per
+/// instance and `GET /settings` is authenticated-only, so a signed-out user
+/// never sees one. These tests pin the replacement — terms shown before *any*
+/// signed-out surface, acceptance remembered, and a version bump re-prompting.
+
+class _LoggedOutAuth extends AccordAuth {
+  @override
+  AccordAuthState build() => AccordAuthLoggedOut();
+
+  @override
+  Future<List<AccordSession>> listAccounts() async => const [];
+
+  @override
+  Future<AccordAuthState> restoreSession() async => state;
+}
+
+Widget _loginApp() => ProviderScope(
+  overrides: [accordAuthProvider.overrideWith(_LoggedOutAuth.new)],
+  child: MaterialApp(
+    theme: buildAppTheme(AppThemePreset.dark),
+    home: const Scaffold(body: AccordLoginScreen()),
+  ),
+);
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync('terms-gate-test');
+    Hive.init(tempDir.path);
+    await Hive.openBox('auth');
+    await Hive.openBox('accord-session');
+    await Hive.openBox('accord-settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('auth');
+    await Hive.deleteBoxFromDisk('accord-session');
+    await Hive.deleteBoxFromDisk('accord-settings');
+    await Hive.close();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  test('acceptance is remembered, and a new version asks again', () async {
+    expect(hasAcceptedAppTerms(), isFalse);
+
+    await recordAppTermsAcceptance();
+    expect(hasAcceptedAppTerms(), isTrue);
+
+    // A terms revision bumps the version; the stored older acceptance no
+    // longer covers it.
+    await Hive.box(
+      'auth',
+    ).put('accepted-app-terms-version', appTermsVersion - 1);
+    expect(hasAcceptedAppTerms(), isFalse);
+
+    await clearAppTermsAcceptance();
+    expect(hasAcceptedAppTerms(), isFalse);
+  });
+
+  testWidgets('the gate replaces every signed-out surface until accepted', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(_loginApp());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(TermsGateView), findsOneWidget);
+    expect(find.text(appTermsTitle), findsOneWidget);
+    expect(find.textContaining('Zero tolerance'), findsOneWidget);
+    // The welcome screen — and with it the server browser and the credentials
+    // form behind it — stays out of reach.
+    expect(find.byType(WelcomeView), findsNothing);
+  });
+
+  testWidgets('agreeing is what lifts the gate', (tester) async {
+    // The gate on its own: the login screen's handler records acceptance
+    // through Hive, whose real IO never lands on a widget test's fake clock.
+    var accepted = false;
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TermsGateView(onAccept: () => accepted = true),
+          ),
+        ),
+      ),
+    );
+
+    final agree = find.widgetWithText(ElevatedButton, 'Agree and continue');
+    await tester.ensureVisible(agree);
+    await tester.tap(agree);
+    await tester.pump();
+
+    expect(accepted, isTrue);
+  });
+
+  testWidgets('an accepted device goes straight to the signed-out flow', (
+    tester,
+  ) async {
+    // Hive writes are real IO: inside a widget test they only run under
+    // runAsync, not on the fake clock pumps drive.
+    await tester.runAsync(recordAppTermsAcceptance);
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_loginApp());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(TermsGateView), findsNothing);
+    expect(find.byType(WelcomeView), findsOneWidget);
+  });
+
+  testWidgets('the terms stay reachable from the credentials form', (
+    tester,
+  ) async {
+    await tester.runAsync(recordAppTermsAcceptance);
+    await tester.binding.setSurfaceSize(const Size(500, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [accordAuthProvider.overrideWith(_LoggedOutAuth.new)],
+        child: MaterialApp(
+          theme: buildAppTheme(AppThemePreset.dark),
+          home: const Scaffold(
+            body: AccordLoginScreen(startOnCredentials: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final link = find.widgetWithText(TextButton, appTermsTitle);
+    expect(link, findsOneWidget);
+    await tester.ensureVisible(link);
+    await tester.tap(link);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppTermsBody), findsOneWidget);
+  });
+}

--- a/test/features/messaging/dm_report_action_test.dart
+++ b/test/features/messaging/dm_report_action_test.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/messaging/views/message_pane/message_pane.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Reporting outside a space (#290).
+///
+/// A direct-message pane has no space, and the Report action used to be gated
+/// on one — so the reviewer looking for a way to flag content in a DM found
+/// none. These tests hold the action in place there, and hold the flip side:
+/// once reported, the message is gone from the reporter's own view.
+
+const _channelId = 'c1';
+const _selfId = 'u1';
+const _themId = 'u2';
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+class _FakeHiddenMessages extends HiddenMessagesController {
+  _FakeHiddenMessages(this.initial);
+
+  final Set<String> initial;
+
+  @override
+  Set<String> build() => initial;
+}
+
+Map<String, String> _msgJson(String id, String content, String authorId) => {
+  'id': id,
+  'channel_id': _channelId,
+  'author_id': authorId,
+  'content': content,
+  'timestamp': '2026-01-01T10:00:00Z',
+};
+
+class _Harness {
+  _Harness({Set<String> hidden = const {}}) {
+    final responder = MockClient((request) async {
+      requests.add('${request.method} ${request.url.path}');
+      if (request.method == 'GET' &&
+          request.url.path.endsWith('/channels/$_channelId/messages')) {
+        return http.Response(
+          jsonEncode([
+            _msgJson('m2', 'from them', _themId),
+            _msgJson('m1', 'from me', _selfId),
+          ]),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      if (request.url.path.endsWith('/reports/categories')) {
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {'value': 'harassment', 'label': 'Harassment or bullying'},
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      return http.Response(
+        '[]',
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+    final server = AccordServer.fromBaseUrl('https://accord.example.test');
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: server.baseUrl,
+      gatewayUrl: server.gatewayUrl,
+      cdnUrl: server.cdnUrl,
+      httpClient: responder,
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(
+          AccordAuthLoggedIn(
+            client: client,
+            session: AccordSession(
+              server: server,
+              token: 'test-token',
+              userId: _selfId,
+              username: 'self',
+            ),
+          ),
+        ),
+        settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+        // Hive isn't open in a widget test; seed the set directly.
+        hiddenMessagesControllerProvider.overrideWith(
+          () => _FakeHiddenMessages(hidden),
+        ),
+      ],
+    );
+  }
+
+  final List<String> requests = [];
+  late final AccordClient client;
+  late final ProviderContainer container;
+
+  /// A DM pane: no space, so nothing here can fall back to space moderation.
+  Widget get app => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: const Scaffold(
+        body: MessagePane(channel: null, channelId: _channelId, spaceId: null),
+      ),
+    ),
+  );
+
+  void dispose() => client.dispose();
+}
+
+Finder _body(String text) => find.text(text, findRichText: true);
+
+Future<void> _tick(WidgetTester tester, {int frames = 12}) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  testWidgets('a direct message from someone else can be reported', (
+    tester,
+  ) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await _tick(tester);
+
+    expect(_body('from them'), findsOneWidget);
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const ValueKey('m2')),
+        matching: find.byTooltip('Message actions'),
+      ),
+    );
+    await _tick(tester);
+    expect(find.widgetWithText(PopupMenuItem<String>, 'Report'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(PopupMenuItem<String>, 'Report'));
+    await _tick(tester);
+
+    expect(find.text('Report message'), findsOneWidget);
+    // No space means no moderators to promise, and blocking is pre-selected.
+    expect(find.textContaining('go to the server operator'), findsOneWidget);
+    final block = tester.widget<CheckboxListTile>(
+      find.byType(CheckboxListTile),
+    );
+    expect(block.value, isTrue);
+  });
+
+  testWidgets('the user\'s own message offers no report action', (
+    tester,
+  ) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await _tick(tester);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const ValueKey('m1')),
+        matching: find.byTooltip('Message actions'),
+      ),
+    );
+    await _tick(tester);
+    expect(find.widgetWithText(PopupMenuItem<String>, 'Report'), findsNothing);
+  });
+
+  testWidgets('a reported message is gone from the reporter\'s view', (
+    tester,
+  ) async {
+    final harness = _Harness(hidden: {'m2'});
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await _tick(tester);
+
+    expect(_body('from me'), findsOneWidget);
+    expect(_body('from them'), findsNothing);
+  });
+}

--- a/test/features/spaces/report_dialog_test.dart
+++ b/test/features/spaces/report_dialog_test.dart
@@ -1,0 +1,187 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/spaces/views/accord_reports.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// The report dialog's two destinations (#290).
+///
+/// A report filed inside a space goes to that space's moderators. Everything
+/// else — a direct message, a user reported from an account-level surface — has
+/// no space to file against, so it goes to the account-level `/reports` route,
+/// and on a server that doesn't serve one the dialog must still do what it
+/// promises (block, hide) and must not claim a moderator will look at it.
+
+const _selfId = 'u1';
+const _themId = 'u2';
+
+class _Harness {
+  _Harness({this.directReportStatus = 200}) {
+    final responder = MockClient((request) async {
+      final path = request.url.path;
+      requests.add('${request.method} $path');
+      if (path.endsWith('/reports/categories')) {
+        return _json({
+          'data': [
+            {'value': 'harassment', 'label': 'Harassment or bullying'},
+            {'value': 'spam', 'label': 'Spam'},
+          ],
+        });
+      }
+      if (path.endsWith('/reports')) {
+        final direct = !path.contains('/spaces/');
+        if (direct && directReportStatus != 200) {
+          return http.Response(
+            jsonEncode({'message': 'not found'}),
+            directReportStatus,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return _json({
+          'data': {'id': 'r1', 'status': 'pending'},
+        });
+      }
+      if (path.contains('/relationships/')) {
+        return _json({'data': {}});
+      }
+      return _json({'data': []});
+    });
+    final server = AccordServer.fromBaseUrl('https://accord.example.test');
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: server.baseUrl,
+      gatewayUrl: server.gatewayUrl,
+      cdnUrl: server.cdnUrl,
+      httpClient: responder,
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(
+          AccordAuthLoggedIn(
+            client: client,
+            session: AccordSession(
+              server: server,
+              token: 'test-token',
+              userId: _selfId,
+              username: 'self',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static http.Response _json(Object body) => http.Response(
+    jsonEncode(body),
+    200,
+    headers: {'content-type': 'application/json'},
+  );
+
+  /// Status the account-level `POST /reports` answers with. 404 stands for a
+  /// server that only implements space-scoped reports.
+  final int directReportStatus;
+  final List<String> requests = [];
+  late final AccordClient client;
+  late final ProviderContainer container;
+
+  Widget app({String? spaceId}) => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showReportDialog(
+              context,
+              spaceId: spaceId,
+              targetType: 'message',
+              targetId: 'm1',
+              channelId: 'c1',
+              reportedUserId: _themId,
+              reportedName: 'them',
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  void dispose() => container.dispose();
+}
+
+Future<void> _openAndSubmit(WidgetTester tester) async {
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byType(DropdownButtonFormField<String>));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Harassment or bullying').last);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Submit report'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a report inside a space goes to that space\'s moderators', (
+    tester,
+  ) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app(spaceId: 's1'));
+    await _openAndSubmit(tester);
+
+    expect(harness.requests, contains('POST /api/v1/spaces/s1/reports'));
+    expect(find.text('Report submitted'), findsOneWidget);
+    expect(find.textContaining('Moderators will review it'), findsOneWidget);
+    // Blocking is opt-in where moderators exist, so nothing was blocked.
+    expect(
+      harness.requests.any((r) => r.startsWith('PUT /api/v1/users')),
+      isFalse,
+    );
+  });
+
+  testWidgets('a report with no space is filed account-level', (tester) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app());
+    await _openAndSubmit(tester);
+
+    expect(harness.requests, contains('POST /api/v1/reports'));
+    expect(find.text('Report submitted'), findsOneWidget);
+    expect(find.textContaining('Moderators will review it'), findsOneWidget);
+    // Outside a space the block is pre-checked, so it also ran.
+    expect(
+      harness.requests.any((r) => r.contains('/users/@me/relationships/u2')),
+      isTrue,
+    );
+  });
+
+  testWidgets('a server without account-level reports still blocks and hides', (
+    tester,
+  ) async {
+    final harness = _Harness(directReportStatus: 404);
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app());
+    await _openAndSubmit(tester);
+
+    expect(find.text('Report submitted'), findsNothing);
+    expect(find.textContaining('Moderators will review it'), findsNothing);
+    expect(find.textContaining('is now hidden for you'), findsOneWidget);
+    expect(find.textContaining('account is blocked'), findsOneWidget);
+    expect(
+      harness.container.read(hiddenMessagesControllerProvider),
+      contains('m1'),
+    );
+  });
+}


### PR DESCRIPTION
App Review rejected 0.2.16 under guideline 1.2 because no EULA is shown
before a user registers or logs in. The terms gate we had could not show
one: it read `tos_enabled` from the server's `GET /settings`, which
accordserver serves to authenticated users only, so a signed-out fetch
401s and the gate always resolved to "disabled" — and it was wired into
the Register tab alone, leaving sign-in with no terms at all.

Carry terms of our own instead. `app_terms.dart` holds the document
(what may not be posted, how to report and block, the GPL and warranty
note); acceptance is recorded per terms version in the device-global
`auth` box, so a revision re-prompts and a profile switch does not. The
gate replaces the whole signed-out flow — welcome, server browser and
credentials form alike — until it is accepted, and the text stays
reachable afterwards from the auth form and Settings → About.

A server's own ToS checkbox is unchanged and still shows alongside this
when the server advertises one.

Refs #289

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GVXDeSVn9njx9vcDv1JWfD