### PR TITLE
fix(messaging): close the remaining gaps in reporting and blocking

### DIFF
--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -252,11 +252,19 @@ Two of those had gaps, both since fixed:
   alongside it when the server advertises one.
 - **Reporting only existed on space messages.** The action was gated on a
   non-null space, and a DM pane passes none. Report now sits on every message
-  and on user profiles and DM user menus, filing to the space's moderators
-  where there is a space and to the account-level `/reports` route where there
-  isn't.
+  surface — the pane, thread replies and the pinned list — and on user profiles
+  and DM user menus, filing to the space's moderators where there is a space and
+  to the account-level `/reports` route where there isn't. When neither route
+  took the report the confirmation says so instead of promising a review.
 
-Blocking was already in place (member popout, DM relationship actions).
+Blocking was already in place (member popout, DM relationship actions) and is
+now reachable from the two places a reviewer actually lands: the account-level
+profile a DM user tap opens, and a visible overflow button in the 1:1 DM header
+(the menu behind it was long-press/right-click only). A blocked account's
+messages are filtered out of every message surface — see `MessageVisibility`
+(`lib/features/messaging/utils/message_visibility.dart`) over
+`BlockedUsersController` — so the promise the block makes is one the client
+keeps rather than one only the server could.
 
 Do not re-gate the terms on a server response: nothing a signed-out client can
 read is guaranteed to be there, and the gate has to hold before any server is

--- a/lib/features/events/services/accord_event_handler.dart
+++ b/lib/features/events/services/accord_event_handler.dart
@@ -21,6 +21,7 @@ import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/server/utils/space_cache.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
 import 'package:bonfire/features/voice/controllers/call.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/controllers/voice_states.dart';
@@ -105,6 +106,14 @@ VoidCallback handleAccordEvents(
         serverKey: serverKey,
         homeDomain: selfDomain,
       );
+      // Blocked accounts drive the message filter that makes "their messages
+      // are hidden" true (#290), and READY doesn't carry relationships — so
+      // this connection's set is fetched here, for background connections too.
+      unawaited(
+        ref
+            .read(blockedUsersControllerProvider(serverKey).notifier)
+            .refresh(client),
+      );
       if (isActive()) {
         _seedVoiceStates(ref, data, serverKey: serverKey);
       }
@@ -178,6 +187,23 @@ VoidCallback handleAccordEvents(
           .upsert(presence, homeDomain: selfDomain);
     }),
   );
+
+  // ── Blocked accounts (message filter) ────────────────────────────────────
+  // A block made on another device has to reach this one, or the account it
+  // silenced keeps appearing here. The relationship events carry no reliable
+  // "which user" for a removal, so each one re-reads the authoritative list —
+  // they are rare enough that the extra request doesn't matter.
+  void refreshBlocked() {
+    unawaited(
+      ref
+          .read(blockedUsersControllerProvider(serverKey).notifier)
+          .refresh(client),
+    );
+  }
+
+  subs.add(client.onRelationshipAdd.listen((_) => refreshBlocked()));
+  subs.add(client.onRelationshipUpdate.listen((_) => refreshBlocked()));
+  subs.add(client.onRelationshipRemove.listen((_) => refreshBlocked()));
 
   // ── User cache (profile changes) ─────────────────────────────────────────
   // `user.update` carries a user's new avatar / display name / username, for

--- a/lib/features/member/views/accord_member_popout.dart
+++ b/lib/features/member/views/accord_member_popout.dart
@@ -12,6 +12,7 @@ import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:bonfire/features/member/views/remote_origin_badge.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
 import 'package:bonfire/features/user/views/accord_direct_messages.dart';
 import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/theme/theme.dart';
@@ -145,9 +146,14 @@ class _MemberPopoutState extends ConsumerState<_MemberPopout> {
     );
     if (confirmed != true) return;
     _run(
-      (c) => c.users.putRelationship(widget.userId, {'type': 2}),
+      (c) => c.users.putRelationship(widget.userId, {
+        'type': accordBlockedRelationship,
+      }),
       failure: 'Failed to block user',
       closeOnSuccess: true,
+      // Applies the "their messages are hidden" half of the promise right away
+      // rather than at the next relationship fetch (#290).
+      onSuccess: () => ref.blockedUsers.block(widget.userId),
     );
   }
 

--- a/lib/features/messaging/utils/message_visibility.dart
+++ b/lib/features/messaging/utils/message_visibility.dart
@@ -1,0 +1,54 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// What a message surface must keep out of the user's view: the messages they
+/// reported, and everything written by an account they blocked (#290).
+///
+/// Every surface that lists messages — the pane, the thread view, the pinned
+/// list — filters through this, so a report or a block applies everywhere
+/// instead of only where it was made.
+class MessageVisibility {
+  const MessageVisibility({
+    required this.hiddenMessageIds,
+    required this.blockedAuthorIds,
+  });
+
+  /// Nothing filtered — for surfaces built without a provider scope.
+  static const none = MessageVisibility(
+    hiddenMessageIds: {},
+    blockedAuthorIds: {},
+  );
+
+  final Set<String> hiddenMessageIds;
+  final Set<String> blockedAuthorIds;
+
+  bool get filtersNothing =>
+      hiddenMessageIds.isEmpty && blockedAuthorIds.isEmpty;
+
+  /// Whether [message] should still be shown.
+  bool shows(AccordMessage message) =>
+      !hiddenMessageIds.contains(message.id) &&
+      !blockedAuthorIds.contains(message.authorId);
+
+  /// [messages] without the hidden/blocked ones. Returns the same list when
+  /// there is nothing to filter, so an untouched pane doesn't copy its list on
+  /// every build.
+  List<AccordMessage> filter(List<AccordMessage> messages) =>
+      filtersNothing ? messages : messages.where(shows).toList();
+}
+
+/// Watches the hidden-message and blocked-account sets for the active
+/// connection. Call from `build` — the result can then be applied inside nested
+/// builders (a `FutureBuilder`, a list item builder) where watching is not
+/// allowed.
+extension MessageVisibilityRef on WidgetRef {
+  MessageVisibility watchMessageVisibility() => MessageVisibility(
+    hiddenMessageIds: watch(hiddenMessagesControllerProvider),
+    blockedAuthorIds: watch(
+      blockedUsersControllerProvider(readActiveServerKey() ?? ''),
+    ),
+  );
+}

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -19,7 +19,7 @@ import 'package:bonfire/features/member/views/accord_member_avatar.dart';
 import 'package:bonfire/features/member/views/accord_member_popout.dart';
 import 'package:bonfire/features/messaging/controllers/accord_emojis.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
-import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/messaging/utils/message_visibility.dart';
 import 'package:bonfire/features/messaging/controllers/typing.dart';
 import 'package:bonfire/features/messaging/utils/attachment_limits.dart';
 import 'package:bonfire/features/messaging/utils/attachment_types.dart';
@@ -300,12 +300,13 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
         channelId,
       ),
     );
-    // Messages the user reported are dropped from their own view for good —
-    // moderation elsewhere is neither instant nor guaranteed (#290).
-    final hidden = ref.watch(hiddenMessagesControllerProvider);
-    final messages = loadedMessages == null || hidden.isEmpty
+    // Messages the user reported, and everything from an account they blocked,
+    // are dropped from their own view — moderation elsewhere is neither instant
+    // nor guaranteed (#290).
+    final visibility = ref.watchMessageVisibility();
+    final messages = loadedMessages == null
         ? loadedMessages
-        : loadedMessages.where((m) => !hidden.contains(m.id)).toList();
+        : visibility.filter(loadedMessages);
     final members = spaceId == null
         ? null
         : ref.watch(

--- a/lib/features/messaging/views/pinned_messages.dart
+++ b/lib/features/messaging/views/pinned_messages.dart
@@ -6,6 +6,8 @@ import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/messaging/utils/message_visibility.dart';
+import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
@@ -94,9 +96,52 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
     if (mounted) setState(() => _future = _load());
   }
 
+  /// Reports a pinned message. The pinned list shows other people's content
+  /// like any other message surface, so it offers the same action (#290).
+  void _report(AccordMessage message, String authorName) {
+    showReportDialog(
+      context,
+      spaceId: widget.spaceId,
+      targetType: 'message',
+      targetId: message.id,
+      channelId: widget.channelId,
+      reportedUserId: message.authorId.isEmpty ? null : message.authorId,
+      reportedName: authorName,
+    );
+  }
+
+  /// A pinned row's trailing actions: Report for anyone else's message, Unpin
+  /// where the user may manage them. Null when there is neither.
+  Widget? _rowActions(
+    AccordMessage message,
+    String authorName, {
+    required String? currentUserId,
+  }) {
+    final actions = <Widget>[
+      if (message.authorId != currentUserId)
+        IconButton(
+          tooltip: 'Report',
+          onPressed: () => _report(message, authorName),
+          icon: const Icon(Icons.flag_outlined, size: 18),
+        ),
+      if (widget.canManage)
+        IconButton(
+          tooltip: 'Unpin',
+          onPressed: () => _unpin(message),
+          icon: const Icon(Icons.push_pin_outlined, size: 18),
+        ),
+    ];
+    if (actions.isEmpty) return null;
+    return Row(mainAxisSize: MainAxisSize.min, children: actions);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
+    // Watched here rather than inside the FutureBuilder, which builds outside
+    // this widget's build phase.
+    final visibility = ref.watchMessageVisibility();
+    final currentUserId = ref.watchUserId();
     final members = widget.spaceId == null
         ? null
         : ref.watch(
@@ -151,7 +196,9 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                       child: LoadingView(),
                     );
                   }
-                  final pins = snapshot.data ?? const <AccordMessage>[];
+                  final pins = visibility.filter(
+                    snapshot.data ?? const <AccordMessage>[],
+                  );
                   if (pins.isEmpty) {
                     return Padding(
                       padding: const EdgeInsets.all(32),
@@ -223,16 +270,11 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                           maxLines: 3,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        trailing: widget.canManage
-                            ? IconButton(
-                                tooltip: 'Unpin',
-                                onPressed: () => _unpin(message),
-                                icon: const Icon(
-                                  Icons.push_pin_outlined,
-                                  size: 18,
-                                ),
-                              )
-                            : null,
+                        trailing: _rowActions(
+                          message,
+                          name,
+                          currentUserId: currentUserId,
+                        ),
                       );
                     },
                   );

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -14,6 +14,8 @@ import 'package:bonfire/features/messaging/controllers/thread_replies.dart';
 import 'package:bonfire/features/messaging/views/box/accord_message_content.dart';
 import 'package:bonfire/features/messaging/views/message_author_header.dart';
 import 'package:bonfire/features/messaging/views/post_composer_dialog.dart';
+import 'package:bonfire/features/messaging/utils/message_visibility.dart';
+import 'package:bonfire/features/spaces/views/accord_reports.dart';
 import 'package:bonfire/features/spaces/utils/message_time.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/shared/components/context_menu.dart';
@@ -285,13 +287,19 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
     final theme = Theme.of(context);
-    final replies = ref.watch(
+    final loadedReplies = ref.watch(
       threadRepliesControllerProvider(
         ref.readActiveServerKey() ?? '',
         widget.channelId,
         widget.root.id,
       ),
     );
+    // Reported replies and blocked authors are filtered here as they are in the
+    // message pane — a hide made in one surface applies in all of them (#290).
+    final visibility = ref.watchMessageVisibility();
+    final replies = loadedReplies == null
+        ? null
+        : visibility.filter(loadedReplies);
     final currentUserId = _currentUserId;
     final dialog = widget.dialog;
     // Index 0 is the root post, 1 the divider, 2 the loading/empty placeholder
@@ -577,13 +585,31 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
       accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
     )[authorId];
     final name = accordAuthorNameOf(authorId, member: member, user: user);
-    final entries = buildMessageActionEntries(
-      content: message.content,
-      canEdit: widget.isOwn,
-      canDelete: _canDelete,
-      onEdit: () => _edit(message),
-      onDelete: () => _delete(message.id),
-    );
+    final entries = [
+      ...buildMessageActionEntries(
+        content: message.content,
+        canEdit: widget.isOwn,
+        canDelete: _canDelete,
+        onEdit: () => _edit(message),
+        onDelete: () => _delete(message.id),
+      ),
+      // A reply is a message like any other: it can be flagged here too, so no
+      // message surface is left without the action (#290).
+      if (!widget.isOwn)
+        AccordMenuEntry(
+          label: 'Report',
+          icon: Icons.flag_outlined,
+          onSelected: () => showReportDialog(
+            context,
+            spaceId: widget.spaceId,
+            targetType: 'message',
+            targetId: message.id,
+            channelId: widget.channelId,
+            reportedUserId: authorId.isEmpty ? null : authorId,
+            reportedName: name,
+          ),
+        ),
+    ];
     if (entries.isEmpty) return;
     showAccordContextMenu(
       context,
@@ -718,7 +744,9 @@ class _MessageLineState extends ConsumerState<_MessageLine> {
                   ],
                 ),
               ),
-              if (_canDelete)
+              // Shown for someone else's reply too — that menu now carries the
+              // Report action, which must not be long-press-only (#290).
+              if (_canDelete || !widget.isOwn)
                 Opacity(
                   opacity: _hovered ? 1 : 0,
                   child: IconButton(

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -123,6 +123,7 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
   final FocusNode _inputFocus = FocusNode();
   late AccordMessage _root = widget.root;
   bool _sending = false;
+  bool _closedForHiddenRoot = false;
 
   @override
   void dispose() {
@@ -300,6 +301,16 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     final replies = loadedReplies == null
         ? null
         : visibility.filter(loadedReplies);
+    // The root isn't in [replies] to filter, but the same promise applies to
+    // it: if reporting it (or blocking its author) just hid it, follow the
+    // pane's behavior and close rather than leave it the one message the
+    // filter didn't reach (#290).
+    if (!visibility.shows(_root) && !_closedForHiddenRoot) {
+      _closedForHiddenRoot = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onClose(null);
+      });
+    }
     final currentUserId = _currentUserId;
     final dialog = widget.dialog;
     // Index 0 is the root post, 1 the divider, 2 the loading/empty placeholder

--- a/lib/features/spaces/views/accord_reports.dart
+++ b/lib/features/spaces/views/accord_reports.dart
@@ -11,6 +11,7 @@ import 'package:bonfire/shared/utils/responsive_dialog.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -93,6 +94,11 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
   bool _delivered = false;
   bool _blocked = false;
 
+  /// Whether the report itself has already been sent. A failed block leaves the
+  /// form live so it can be retried; without this latch that retry filed a
+  /// second report for the same target.
+  bool _sent = false;
+
   @override
   void initState() {
     super.initState();
@@ -166,32 +172,38 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
     };
 
     final spaceId = widget.spaceId;
-    var delivered = false;
-    if (spaceId != null) {
-      final result = await client.reports.create(spaceId, payload);
-      if (!mounted) return;
-      if (!result.ok) {
-        setState(() {
-          _busy = false;
-          _error = result.errorOr('Failed to submit report');
-        });
-        return;
+    // Only sent once, however many times this is submitted: a retry after a
+    // failed block must not file the report again (#290).
+    var delivered = _delivered;
+    if (!_sent) {
+      if (spaceId != null) {
+        final result = await client.reports.create(spaceId, payload);
+        if (!mounted) return;
+        if (!result.ok) {
+          setState(() {
+            _busy = false;
+            _error = result.errorOr('Failed to submit report');
+          });
+          return;
+        }
+        delivered = true;
+      } else {
+        final result = await client.reports.createDirect(payload);
+        if (!mounted) return;
+        // A server without the account-level route isn't a failed report: the
+        // block and the local hide below are still the outcome the user asked
+        // for. Any other error is a real failure and stops here.
+        if (!result.ok && !ReportsApi.reportRouteMissing(result)) {
+          setState(() {
+            _busy = false;
+            _error = result.errorOr('Failed to submit report');
+          });
+          return;
+        }
+        delivered = result.ok;
       }
-      delivered = true;
-    } else {
-      final result = await client.reports.createDirect(payload);
-      if (!mounted) return;
-      // A server without the account-level route isn't a failed report: the
-      // block and the local hide below are still the outcome the user asked
-      // for. Any other error is a real failure and stops here.
-      if (!result.ok && !ReportsApi.reportRouteMissing(result)) {
-        setState(() {
-          _busy = false;
-          _error = result.errorOr('Failed to submit report');
-        });
-        return;
-      }
-      delivered = result.ok;
+      _sent = true;
+      _delivered = delivered;
     }
 
     // Hidden before the block is attempted: the user reported this content, so
@@ -206,23 +218,33 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
     final reportedUserId = widget.reportedUserId;
     if (_block && reportedUserId != null) {
       final result = await client.users.putRelationship(reportedUserId, {
-        'type': 2,
+        'type': accordBlockedRelationship,
       });
       if (!mounted) return;
       blocked = result.ok;
       if (!result.ok) {
+        // Says what actually happened in either case: claiming a report was
+        // filed when the server never took one is the thing App Review calls
+        // out, so the wording tracks [delivered].
+        final failure = delivered
+            ? 'Reported, but blocking the account failed'
+            : 'Nothing was sent — this server only accepts reports inside a '
+                  'space — and blocking the account failed';
+        final detail = result.errorMessageOr('');
         setState(() {
           _busy = false;
-          _error = result.errorOr('Reported, but blocking the account failed');
+          _error = detail.isEmpty ? failure : '$failure: $detail';
         });
         return;
       }
+      // Filters their messages out of every pane straight away, which is what
+      // the checkbox promised.
+      ref.blockedUsers.block(reportedUserId);
     }
 
     if (!mounted) return;
     setState(() {
       _busy = false;
-      _delivered = delivered;
       _blocked = blocked;
       _done = true;
     });
@@ -233,7 +255,9 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
   List<String> get _outcomes => [
     if (_delivered) 'Moderators will review it shortly.',
     if (widget.targetType == 'message') 'The message is now hidden for you.',
-    if (_blocked) 'The account is blocked and can no longer message you.',
+    if (_blocked)
+      'The account is blocked: they can no longer message you, and their '
+          'messages are hidden.',
   ];
 
   String get _outcomeTitle {
@@ -357,8 +381,8 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
                           style: theme.textTheme.bodyMedium,
                         ),
                         subtitle: Text(
-                          'They can no longer message you, and their content '
-                          'is hidden.',
+                          'They can no longer message you, and their messages '
+                          'are hidden from your view.',
                           style: theme.textTheme.bodySmall!.copyWith(
                             color: colors.gray,
                           ),

--- a/lib/features/user/controllers/blocked_users.dart
+++ b/lib/features/user/controllers/blocked_users.dart
@@ -1,0 +1,71 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'blocked_users.g.dart';
+
+/// Relationship type for a blocked account, mirrored from the server (1 =
+/// friend, 2 = blocked, 3 = pending incoming, 4 = pending outgoing).
+const int accordBlockedRelationship = 2;
+
+/// The accounts this connection has blocked, by user id.
+///
+/// Blocking is what the report dialog offers where no moderator will see the
+/// report, and it promises the blocked account's messages stop being shown.
+/// Nothing enforced that client-side, so the message surfaces filter on this set
+/// (App Review 1.2, #290).
+///
+/// The server's relationship list is the source of truth: [refresh] seeds the
+/// set on gateway READY and the relationship events re-run it. The local
+/// [block]/[unblock] mutators exist so the block a user just performed takes
+/// effect in the panes immediately rather than on the next fetch.
+@Riverpod(keepAlive: true)
+class BlockedUsersController extends _$BlockedUsersController {
+  @override
+  Set<String> build(String serverKey) {
+    ref.watchAccordClientFor(serverKey);
+    return const {};
+  }
+
+  /// Re-reads `GET /users/@me/relationships` and replaces the set. Silently
+  /// does nothing when the request fails — a stale set is better than dropping
+  /// a block the user made locally.
+  Future<void> refresh(AccordClient client) async {
+    final result = await client.users.listRelationships();
+    if (!ref.isCurrentAccordClient(serverKey, client)) return;
+    final data = result.data;
+    if (!result.ok || data is! List) return;
+    sync(data.whereType<AccordRelationship>());
+  }
+
+  /// Replaces the set from a full relationship list (the Friends tab already
+  /// holds one, so it re-uses this rather than fetching again).
+  void sync(Iterable<AccordRelationship> relationships) {
+    final next = <String>{
+      for (final relationship in relationships)
+        if (relationship.type == accordBlockedRelationship)
+          if ((relationship.user?.id ?? '').isNotEmpty) relationship.user!.id,
+    };
+    if (next.length == state.length && next.every(state.contains)) return;
+    state = next;
+  }
+
+  void block(String userId) {
+    if (userId.isEmpty || state.contains(userId)) return;
+    state = {...state, userId};
+  }
+
+  void unblock(String userId) {
+    if (!state.contains(userId)) return;
+    state = {...state}..remove(userId);
+  }
+}
+
+/// The blocked set of the active connection, for the block/unblock actions
+/// scattered across the DM, member and report surfaces.
+extension BlockedUsersRef on WidgetRef {
+  BlockedUsersController get blockedUsers => read(
+    blockedUsersControllerProvider(readActiveServerKey() ?? '').notifier,
+  );
+}

--- a/lib/features/user/controllers/blocked_users.dart
+++ b/lib/features/user/controllers/blocked_users.dart
@@ -22,6 +22,12 @@ const int accordBlockedRelationship = 2;
 /// effect in the panes immediately rather than on the next fetch.
 @Riverpod(keepAlive: true)
 class BlockedUsersController extends _$BlockedUsersController {
+  // The event handler fires a [refresh] on gateway READY and on every
+  // relationship event, so several can be in flight together; without this,
+  // whichever response lands last wins even if it was the one that started
+  // first, clobbering a set a later refresh had already applied.
+  int _refreshGeneration = 0;
+
   @override
   Set<String> build(String serverKey) {
     ref.watchAccordClientFor(serverKey);
@@ -32,7 +38,9 @@ class BlockedUsersController extends _$BlockedUsersController {
   /// does nothing when the request fails — a stale set is better than dropping
   /// a block the user made locally.
   Future<void> refresh(AccordClient client) async {
+    final generation = ++_refreshGeneration;
     final result = await client.users.listRelationships();
+    if (generation != _refreshGeneration) return;
     if (!ref.isCurrentAccordClient(serverKey, client)) return;
     final data = result.data;
     if (!result.ok || data is! List) return;

--- a/lib/features/user/controllers/blocked_users.g.dart
+++ b/lib/features/user/controllers/blocked_users.g.dart
@@ -1,0 +1,179 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'blocked_users.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The accounts this connection has blocked, by user id.
+///
+/// Blocking is what the report dialog offers where no moderator will see the
+/// report, and it promises the blocked account's messages stop being shown.
+/// Nothing enforced that client-side, so the message surfaces filter on this set
+/// (App Review 1.2, #290).
+///
+/// The server's relationship list is the source of truth: [refresh] seeds the
+/// set on gateway READY and the relationship events re-run it. The local
+/// [block]/[unblock] mutators exist so the block a user just performed takes
+/// effect in the panes immediately rather than on the next fetch.
+
+@ProviderFor(BlockedUsersController)
+const blockedUsersControllerProvider = BlockedUsersControllerFamily._();
+
+/// The accounts this connection has blocked, by user id.
+///
+/// Blocking is what the report dialog offers where no moderator will see the
+/// report, and it promises the blocked account's messages stop being shown.
+/// Nothing enforced that client-side, so the message surfaces filter on this set
+/// (App Review 1.2, #290).
+///
+/// The server's relationship list is the source of truth: [refresh] seeds the
+/// set on gateway READY and the relationship events re-run it. The local
+/// [block]/[unblock] mutators exist so the block a user just performed takes
+/// effect in the panes immediately rather than on the next fetch.
+final class BlockedUsersControllerProvider
+    extends $NotifierProvider<BlockedUsersController, Set<String>> {
+  /// The accounts this connection has blocked, by user id.
+  ///
+  /// Blocking is what the report dialog offers where no moderator will see the
+  /// report, and it promises the blocked account's messages stop being shown.
+  /// Nothing enforced that client-side, so the message surfaces filter on this set
+  /// (App Review 1.2, #290).
+  ///
+  /// The server's relationship list is the source of truth: [refresh] seeds the
+  /// set on gateway READY and the relationship events re-run it. The local
+  /// [block]/[unblock] mutators exist so the block a user just performed takes
+  /// effect in the panes immediately rather than on the next fetch.
+  const BlockedUsersControllerProvider._({
+    required BlockedUsersControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'blockedUsersControllerProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$blockedUsersControllerHash();
+
+  @override
+  String toString() {
+    return r'blockedUsersControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  BlockedUsersController create() => BlockedUsersController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BlockedUsersControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$blockedUsersControllerHash() =>
+    r'd9bde4f7faa48e1d06493b4dcf7e710bdd0fe432';
+
+/// The accounts this connection has blocked, by user id.
+///
+/// Blocking is what the report dialog offers where no moderator will see the
+/// report, and it promises the blocked account's messages stop being shown.
+/// Nothing enforced that client-side, so the message surfaces filter on this set
+/// (App Review 1.2, #290).
+///
+/// The server's relationship list is the source of truth: [refresh] seeds the
+/// set on gateway READY and the relationship events re-run it. The local
+/// [block]/[unblock] mutators exist so the block a user just performed takes
+/// effect in the panes immediately rather than on the next fetch.
+
+final class BlockedUsersControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          BlockedUsersController,
+          Set<String>,
+          Set<String>,
+          Set<String>,
+          String
+        > {
+  const BlockedUsersControllerFamily._()
+    : super(
+        retry: null,
+        name: r'blockedUsersControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  /// The accounts this connection has blocked, by user id.
+  ///
+  /// Blocking is what the report dialog offers where no moderator will see the
+  /// report, and it promises the blocked account's messages stop being shown.
+  /// Nothing enforced that client-side, so the message surfaces filter on this set
+  /// (App Review 1.2, #290).
+  ///
+  /// The server's relationship list is the source of truth: [refresh] seeds the
+  /// set on gateway READY and the relationship events re-run it. The local
+  /// [block]/[unblock] mutators exist so the block a user just performed takes
+  /// effect in the panes immediately rather than on the next fetch.
+
+  BlockedUsersControllerProvider call(String serverKey) =>
+      BlockedUsersControllerProvider._(argument: serverKey, from: this);
+
+  @override
+  String toString() => r'blockedUsersControllerProvider';
+}
+
+/// The accounts this connection has blocked, by user id.
+///
+/// Blocking is what the report dialog offers where no moderator will see the
+/// report, and it promises the blocked account's messages stop being shown.
+/// Nothing enforced that client-side, so the message surfaces filter on this set
+/// (App Review 1.2, #290).
+///
+/// The server's relationship list is the source of truth: [refresh] seeds the
+/// set on gateway READY and the relationship events re-run it. The local
+/// [block]/[unblock] mutators exist so the block a user just performed takes
+/// effect in the panes immediately rather than on the next fetch.
+
+abstract class _$BlockedUsersController extends $Notifier<Set<String>> {
+  late final _$args = ref.$arg as String;
+  String get serverKey => _$args;
+
+  Set<String> build(String serverKey);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<Set<String>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Set<String>, Set<String>>,
+              Set<String>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/user/views/accord_direct_messages.dart
+++ b/lib/features/user/views/accord_direct_messages.dart
@@ -16,6 +16,7 @@ import 'package:bonfire/shared/utils/text_prompt_dialog.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/member/views/remote_origin_badge.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
 import 'package:bonfire/features/voice/controllers/call.dart';
 import 'package:bonfire/features/voice/controllers/missed_calls.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
@@ -135,6 +136,11 @@ void _snackDmError(BuildContext context, AccordError? error, String fallback) {
 /// Account-level profile used where there is no space/member context. It keeps
 /// DM author and recipient interactions useful without pretending that a DM
 /// user has space roles, nicknames, or moderation controls.
+///
+/// This is where a tap on a DM author lands — the member popout is space-scoped
+/// and unreachable there — so it carries the same Report and Block actions the
+/// popout offers. Without them a reviewer tapping a DM user found a dead end
+/// (App Review 1.2, #290).
 Future<void> showAccordUserProfile(
   BuildContext context,
   AccordUser user, {
@@ -144,43 +150,70 @@ Future<void> showAccordUserProfile(
   final origin = accordUserOrigin(user);
   return showDialog<void>(
     context: context,
-    builder: (dialogContext) => AlertDialog(
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 340),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            UserAvatar(
-              name,
-              imageUrl: accordAvatarUrl(user, cdnUrl),
-              radius: 30,
+    builder: (dialogContext) => Consumer(
+      builder: (context, ref, _) {
+        final colors = BonfireThemeExtension.of(context);
+        final isSelf = user.id == ref.watchUserId();
+        return AlertDialog(
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 340),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                UserAvatar(
+                  name,
+                  imageUrl: accordAvatarUrl(user, cdnUrl),
+                  radius: 30,
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        name,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      if (user.username.isNotEmpty) Text('@${user.username}'),
+                      const SizedBox(height: 8),
+                      SelectableText(user.id),
+                      if (origin != null) ...[
+                        const SizedBox(height: 8),
+                        RemoteOriginBadge(domain: origin),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(name, style: Theme.of(context).textTheme.titleMedium),
-                  if (user.username.isNotEmpty) Text('@${user.username}'),
-                  const SizedBox(height: 8),
-                  SelectableText(user.id),
-                  if (origin != null) ...[
-                    const SizedBox(height: 8),
-                    RemoteOriginBadge(domain: origin),
-                  ],
-                ],
+          ),
+          actions: [
+            if (!isSelf) ...[
+              TextButton(
+                onPressed: () => showReportDialog(
+                  context,
+                  targetType: 'user',
+                  targetId: user.id,
+                  reportedUserId: user.id,
+                  reportedName: name,
+                ),
+                style: TextButton.styleFrom(foregroundColor: colors.red),
+                child: const Text('Report user'),
               ),
+              TextButton(
+                onPressed: () => _blockDmUser(context, ref, user),
+                style: TextButton.styleFrom(foregroundColor: colors.red),
+                child: const Text('Block'),
+              ),
+            ],
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Close'),
             ),
           ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(dialogContext).pop(),
-          child: const Text('Close'),
-        ),
-      ],
+        );
+      },
     ),
   );
 }
@@ -304,6 +337,11 @@ Future<void> _changeDmRelationship(
   final result = removing
       ? await client.users.deleteRelationship(user.id)
       : await client.users.putRelationship(user.id, {'type': _Rel.friend});
+  // An unblock has to lift the message filter as promptly as the block applied
+  // it, or their messages stay hidden until the next relationship fetch.
+  if (result.ok && currentType == _Rel.blocked) {
+    ref.blockedUsers.unblock(user.id);
+  }
   if (!context.mounted) return;
   showInfoSnack(
     context,
@@ -335,6 +373,7 @@ Future<void> _blockDmUser(
   final result = await ref.accordClient?.users.putRelationship(user.id, {
     'type': _Rel.blocked,
   });
+  if (result?.ok == true) ref.blockedUsers.block(user.id);
   if (!context.mounted) return;
   showInfoSnack(
     context,

--- a/lib/features/user/views/accord_direct_messages_conversations.dart
+++ b/lib/features/user/views/accord_direct_messages_conversations.dart
@@ -699,7 +699,17 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
           onPressed: () => _startCall(video: true),
           icon: Icon(Icons.videocam, size: 20, color: colors.dirtyWhite),
         ),
-        if (group) _groupOptions(colors),
+        if (group)
+          _groupOptions(colors)
+        // The 1:1 menu (report, block, friend actions) otherwise only opened on
+        // long-press / right-click, which leaves nothing to find by tapping
+        // around a DM (App Review 1.2, #290).
+        else if (directUser != null)
+          IconButton(
+            tooltip: 'Conversation options',
+            onPressed: () => _showUserMenu(directUser),
+            icon: Icon(Icons.more_vert, size: 20, color: colors.gray),
+          ),
       ],
       onUserTap: _showUserProfile,
       onUserContextMenu: _showUserMenu,

--- a/lib/features/user/views/accord_direct_messages_friends.dart
+++ b/lib/features/user/views/accord_direct_messages_friends.dart
@@ -26,11 +26,15 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
     final result = await client.users.listRelationships();
     if (!mounted) return;
     final data = result.data;
-    setState(() {
-      _relationships = data is List
-          ? data.whereType<AccordRelationship>().toList()
-          : <AccordRelationship>[];
-    });
+    final relationships = data is List
+        ? data.whereType<AccordRelationship>().toList()
+        : <AccordRelationship>[];
+    // The authoritative list — reconcile the message filter's blocked set with
+    // it, so a block or unblock made anywhere is reflected here (#290). Only on
+    // a successful fetch: a failed one renders as "no relationships" but must
+    // not be read as "nothing is blocked".
+    if (result.ok) ref.blockedUsers.sync(relationships);
+    setState(() => _relationships = relationships);
   }
 
   Future<void> _accept(String userId) async {

--- a/lib/shared/components/context_menu.dart
+++ b/lib/shared/components/context_menu.dart
@@ -141,52 +141,58 @@ Future<void> _showSheet(
     builder: (sheetCtx) {
       final theme = Theme.of(sheetCtx);
       return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (title != null) ...[
-              ListTile(
-                dense: true,
-                leading: titleIcon == null
-                    ? null
-                    : Icon(titleIcon, color: colors.dirtyWhite),
-                title: Text(
-                  title,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.titleSmall,
-                ),
-              ),
-              const Divider(height: 1),
-            ],
-            for (final entry in entries)
-              if (entry.isDivider)
-                const Divider(height: 1)
-              else
+        // Scrollable: the sheet is capped at a fraction of the viewport, and a
+        // long menu — the DM user menu is nine entries — overflowed it on a
+        // short screen, clipping the last entries instead of letting the user
+        // reach them.
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (title != null) ...[
                 ListTile(
-                  leading: entry.icon == null
+                  dense: true,
+                  leading: titleIcon == null
                       ? null
-                      : Icon(
-                          entry.icon,
-                          color: entry.destructive ? colors.red : null,
-                        ),
+                      : Icon(titleIcon, color: colors.dirtyWhite),
                   title: Text(
-                    entry.label,
-                    style: entry.destructive
-                        ? TextStyle(color: colors.red)
+                    title,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall,
+                  ),
+                ),
+                const Divider(height: 1),
+              ],
+              for (final entry in entries)
+                if (entry.isDivider)
+                  const Divider(height: 1)
+                else
+                  ListTile(
+                    leading: entry.icon == null
+                        ? null
+                        : Icon(
+                            entry.icon,
+                            color: entry.destructive ? colors.red : null,
+                          ),
+                    title: Text(
+                      entry.label,
+                      style: entry.destructive
+                          ? TextStyle(color: colors.red)
+                          : null,
+                    ),
+                    subtitle: entry.subtitle == null
+                        ? null
+                        : Text(entry.subtitle!),
+                    enabled: entry._interactive,
+                    onTap: entry._interactive
+                        ? () {
+                            Navigator.of(sheetCtx).pop();
+                            entry.onSelected!.call();
+                          }
                         : null,
                   ),
-                  subtitle: entry.subtitle == null
-                      ? null
-                      : Text(entry.subtitle!),
-                  enabled: entry._interactive,
-                  onTap: entry._interactive
-                      ? () {
-                          Navigator.of(sheetCtx).pop();
-                          entry.onSelected!.call();
-                        }
-                      : null,
-                ),
-          ],
+            ],
+          ),
         ),
       );
     },

--- a/test/features/messaging/dm_report_action_test.dart
+++ b/test/features/messaging/dm_report_action_test.dart
@@ -9,6 +9,7 @@ import 'package:bonfire/features/messaging/views/message_pane/message_pane.dart'
 import 'package:bonfire/features/server/models/accord_server.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -41,6 +42,15 @@ class _FakeHiddenMessages extends HiddenMessagesController {
   Set<String> build() => initial;
 }
 
+class _FakeBlockedUsers extends BlockedUsersController {
+  _FakeBlockedUsers(this.initial);
+
+  final Set<String> initial;
+
+  @override
+  Set<String> build(String serverKey) => initial;
+}
+
 Map<String, String> _msgJson(String id, String content, String authorId) => {
   'id': id,
   'channel_id': _channelId,
@@ -50,7 +60,7 @@ Map<String, String> _msgJson(String id, String content, String authorId) => {
 };
 
 class _Harness {
-  _Harness({Set<String> hidden = const {}}) {
+  _Harness({Set<String> hidden = const {}, Set<String> blocked = const {}}) {
     final responder = MockClient((request) async {
       requests.add('${request.method} ${request.url.path}');
       if (request.method == 'GET' &&
@@ -108,6 +118,9 @@ class _Harness {
         hiddenMessagesControllerProvider.overrideWith(
           () => _FakeHiddenMessages(hidden),
         ),
+        blockedUsersControllerProvider(
+          '',
+        ).overrideWith(() => _FakeBlockedUsers(blocked)),
       ],
     );
   }
@@ -191,6 +204,18 @@ void main() {
     tester,
   ) async {
     final harness = _Harness(hidden: {'m2'});
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await _tick(tester);
+
+    expect(_body('from me'), findsOneWidget);
+    expect(_body('from them'), findsNothing);
+  });
+
+  testWidgets('a blocked account\'s messages are hidden, as the block claims', (
+    tester,
+  ) async {
+    final harness = _Harness(blocked: {_themId});
     addTearDown(harness.dispose);
     await tester.pumpWidget(harness.app);
     await _tick(tester);

--- a/test/features/messaging/pinned_messages_report_test.dart
+++ b/test/features/messaging/pinned_messages_report_test.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/messaging/views/pinned_messages.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// The pinned list is a message surface too (#290).
+///
+/// It shows other people's content, so it carries the same Report action as the
+/// pane and drops what the user has already reported — otherwise a message
+/// hidden from the pane came back the moment it was pinned.
+
+const _channelId = 'c1';
+const _selfId = 'u1';
+const _themId = 'u2';
+
+class _FakeHiddenMessages extends HiddenMessagesController {
+  _FakeHiddenMessages(this.initial);
+
+  final Set<String> initial;
+
+  @override
+  Set<String> build() => initial;
+}
+
+Map<String, String> _pin(String id, String content, String authorId) => {
+  'id': id,
+  'channel_id': _channelId,
+  'author_id': authorId,
+  'content': content,
+  'timestamp': '2026-01-01T10:00:00Z',
+};
+
+class _Harness {
+  _Harness({Set<String> hidden = const {}}) {
+    final responder = MockClient((request) async {
+      if (request.url.path.endsWith('/channels/$_channelId/pins')) {
+        return http.Response(
+          jsonEncode([
+            _pin('m2', 'from them', _themId),
+            _pin('m1', 'from me', _selfId),
+          ]),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      return http.Response(
+        '[]',
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+    final server = AccordServer.fromBaseUrl('https://accord.example.test');
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: server.baseUrl,
+      gatewayUrl: server.gatewayUrl,
+      cdnUrl: server.cdnUrl,
+      httpClient: responder,
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(
+          AccordAuthLoggedIn(
+            client: client,
+            session: AccordSession(
+              server: server,
+              token: 'test-token',
+              userId: _selfId,
+              username: 'self',
+            ),
+          ),
+        ),
+        hiddenMessagesControllerProvider.overrideWith(
+          () => _FakeHiddenMessages(hidden),
+        ),
+      ],
+    );
+  }
+
+  late final AccordClient client;
+  late final ProviderContainer container;
+
+  /// A DM channel's pins: no space, so nothing here can fall back to space
+  /// moderation.
+  Widget get app => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showPinnedMessages(
+              context,
+              channelId: _channelId,
+              canManage: false,
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  void dispose() => client.dispose();
+}
+
+void main() {
+  testWidgets('a pinned message from someone else can be reported', (
+    tester,
+  ) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('from them'), findsOneWidget);
+    // One Report button: the user's own pinned message doesn't offer it.
+    expect(find.byTooltip('Report'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Report'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Report message'), findsOneWidget);
+  });
+
+  testWidgets('a message already reported stays hidden when pinned', (
+    tester,
+  ) async {
+    final harness = _Harness(hidden: {'m2'});
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('from me'), findsOneWidget);
+    expect(find.text('from them'), findsNothing);
+    expect(find.byTooltip('Report'), findsNothing);
+  });
+}

--- a/test/features/messaging/thread_hidden_root_test.dart
+++ b/test/features/messaging/thread_hidden_root_test.dart
@@ -1,0 +1,193 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/hidden_messages.dart';
+import 'package:bonfire/features/messaging/controllers/thread_replies.dart';
+import 'package:bonfire/features/messaging/views/thread_view.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// The thread root is never in [ThreadRepliesController]'s list, so the
+/// visibility filter that hides a reported message or a blocked author's
+/// replies everywhere else (#290) never reached it — a reported/blocked root
+/// kept rendering at the top of its own thread. These hold the fix: opening
+/// (or staying in) a thread whose root the visibility filter would hide now
+/// closes the thread instead.
+
+const _channelId = 'c1';
+const _rootId = 'root1';
+const _selfId = 'u1';
+const _themId = 'u2';
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+class _FakeHiddenMessages extends HiddenMessagesController {
+  _FakeHiddenMessages(this.initial);
+
+  final Set<String> initial;
+
+  @override
+  Set<String> build() => initial;
+}
+
+class _FakeBlockedUsers extends BlockedUsersController {
+  _FakeBlockedUsers(this.initial);
+
+  final Set<String> initial;
+
+  @override
+  Set<String> build(String serverKey) => initial;
+}
+
+class _FakeThreadReplies extends ThreadRepliesController {
+  @override
+  List<AccordMessage>? build(
+    String serverKey,
+    String channelId,
+    String rootId,
+  ) => const [];
+}
+
+AccordMessage get _root => AccordMessage(
+  id: _rootId,
+  channelId: _channelId,
+  authorId: _themId,
+  content: 'root content',
+  timestamp: '2026-01-01T10:00:00Z',
+);
+
+class _Harness {
+  _Harness({Set<String> hidden = const {}, Set<String> blocked = const {}}) {
+    final responder = MockClient(
+      (request) async => http.Response(
+        '[]',
+        200,
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+    final server = AccordServer.fromBaseUrl('https://accord.example.test');
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: server.baseUrl,
+      gatewayUrl: server.gatewayUrl,
+      cdnUrl: server.cdnUrl,
+      httpClient: responder,
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(
+          AccordAuthLoggedIn(
+            client: client,
+            session: AccordSession(
+              server: server,
+              token: 'test-token',
+              userId: _selfId,
+              username: 'self',
+            ),
+          ),
+        ),
+        settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+        hiddenMessagesControllerProvider.overrideWith(
+          () => _FakeHiddenMessages(hidden),
+        ),
+        blockedUsersControllerProvider(
+          '',
+        ).overrideWith(() => _FakeBlockedUsers(blocked)),
+        threadRepliesControllerProvider(
+          '',
+          _channelId,
+          _rootId,
+        ).overrideWith(_FakeThreadReplies.new),
+      ],
+    );
+  }
+
+  late final AccordClient client;
+  late final ProviderContainer container;
+  bool closeCalled = false;
+  ThreadResult? closedWith;
+
+  Widget get app => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(
+        body: AccordThreadPane(
+          channelId: _channelId,
+          spaceId: null,
+          root: _root,
+          canManageMessages: false,
+          onClose: (result) {
+            closeCalled = true;
+            closedWith = result;
+          },
+        ),
+      ),
+    ),
+  );
+
+  void dispose() => client.dispose();
+}
+
+Future<void> _tick(WidgetTester tester, {int frames = 12}) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  testWidgets(
+    'a thread whose root author the user already blocked closes rather '
+    'than showing it',
+    (tester) async {
+      final harness = _Harness(blocked: {_themId});
+      addTearDown(harness.dispose);
+      await tester.pumpWidget(harness.app);
+      await _tick(tester);
+
+      expect(harness.closeCalled, isTrue);
+      // Not a delete: nothing should treat this as the post having been
+      // removed (that would drop it from a shared list like the forum board).
+      expect(harness.closedWith, isNull);
+    },
+  );
+
+  testWidgets(
+    'a thread whose root the user already reported closes rather than '
+    'showing it',
+    (tester) async {
+      final harness = _Harness(hidden: {_rootId});
+      addTearDown(harness.dispose);
+      await tester.pumpWidget(harness.app);
+      await _tick(tester);
+
+      expect(harness.closeCalled, isTrue);
+      expect(harness.closedWith, isNull);
+    },
+  );
+
+  testWidgets('a thread whose root is visible stays open and shown', (
+    tester,
+  ) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app);
+    await _tick(tester);
+
+    expect(harness.closeCalled, isFalse);
+    expect(find.text('root content'), findsOneWidget);
+  });
+}

--- a/test/features/spaces/report_dialog_test.dart
+++ b/test/features/spaces/report_dialog_test.dart
@@ -26,7 +26,7 @@ const _selfId = 'u1';
 const _themId = 'u2';
 
 class _Harness {
-  _Harness({this.directReportStatus = 200}) {
+  _Harness({this.directReportStatus = 200, this.failedBlocks = 0}) {
     final responder = MockClient((request) async {
       final path = request.url.path;
       requests.add('${request.method} $path');
@@ -52,6 +52,14 @@ class _Harness {
         });
       }
       if (path.contains('/relationships/')) {
+        blockAttempts++;
+        if (blockAttempts <= failedBlocks) {
+          return http.Response(
+            jsonEncode({'message': 'relationship service unavailable'}),
+            503,
+            headers: {'content-type': 'application/json'},
+          );
+        }
         return _json({'data': {}});
       }
       return _json({'data': []});
@@ -91,6 +99,10 @@ class _Harness {
   /// Status the account-level `POST /reports` answers with. 404 stands for a
   /// server that only implements space-scoped reports.
   final int directReportStatus;
+
+  /// How many block attempts fail before one is allowed to succeed.
+  final int failedBlocks;
+  int blockAttempts = 0;
   final List<String> requests = [];
   late final AccordClient client;
   late final ProviderContainer container;
@@ -183,5 +195,62 @@ void main() {
       harness.container.read(hiddenMessagesControllerProvider),
       contains('m1'),
     );
+  });
+
+  testWidgets('a failed block after a delivered report says only that', (
+    tester,
+  ) async {
+    final harness = _Harness(failedBlocks: 99);
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app());
+    await _openAndSubmit(tester);
+
+    expect(
+      find.textContaining('Reported, but blocking the account failed'),
+      findsOneWidget,
+    );
+    expect(find.text('Report submitted'), findsNothing);
+  });
+
+  testWidgets('a failed block with no report filed claims neither', (
+    tester,
+  ) async {
+    // The account-level route is missing *and* the block failed: nothing
+    // reached the server, and the copy must not pretend otherwise.
+    final harness = _Harness(directReportStatus: 404, failedBlocks: 99);
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app());
+    await _openAndSubmit(tester);
+
+    expect(find.textContaining('Nothing was sent'), findsOneWidget);
+    expect(find.textContaining('Reported, but'), findsNothing);
+    expect(find.textContaining('Moderators will review it'), findsNothing);
+  });
+
+  testWidgets('retrying after a failed block does not file a second report', (
+    tester,
+  ) async {
+    final harness = _Harness(failedBlocks: 1);
+    addTearDown(harness.dispose);
+    await tester.pumpWidget(harness.app());
+    await _openAndSubmit(tester);
+
+    expect(
+      find.textContaining('Reported, but blocking the account failed'),
+      findsOneWidget,
+    );
+
+    // The form is still live so the block can be retried — the report behind it
+    // must not be sent again.
+    await tester.tap(find.text('Submit report'));
+    await tester.pumpAndSettle();
+
+    expect(harness.blockAttempts, 2);
+    expect(
+      harness.requests.where((r) => r == 'POST /api/v1/reports').length,
+      1,
+    );
+    expect(find.text('Report submitted'), findsOneWidget);
+    expect(find.textContaining('account is blocked'), findsOneWidget);
   });
 }

--- a/test/features/user/blocked_users_controller_test.dart
+++ b/test/features/user/blocked_users_controller_test.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/user/controllers/blocked_users.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+AccordClient _client(
+  Future<http.Response> Function(http.Request request) responder,
+) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  return AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient(responder),
+  );
+}
+
+ProviderContainer _container(AccordClient client) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final container = ProviderContainer(
+    overrides: [
+      accordAuthProvider.overrideWithValue(
+        AccordAuthLoggedIn(
+          client: client,
+          session: AccordSession(
+            server: server,
+            token: 'test-token',
+            userId: 'self',
+            username: 'self',
+          ),
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+http.Response _relationships(String blockedId) => http.Response(
+  jsonEncode([
+    {
+      'id': 'r-$blockedId',
+      'type': accordBlockedRelationship,
+      'user': {'id': blockedId, 'username': blockedId},
+    },
+  ]),
+  200,
+  headers: {'content-type': 'application/json'},
+);
+
+void main() {
+  test(
+    'an earlier-started refresh landing last does not clobber a later one',
+    () async {
+      // The gateway handler fires a refresh() on READY and again on every
+      // relationship event, with nothing serializing them — so two requests
+      // can be in flight together. Without a generation check, whichever
+      // response arrives last wins even if it was sent first, reverting the
+      // set a later, already-applied refresh had just written (#290 follow-up).
+      final gates = <Completer<void>>[];
+      var dispatched = 0;
+      final client = _client((request) async {
+        final gate = Completer<void>();
+        gates.add(gate);
+        final myCall = ++dispatched;
+        await gate.future;
+        return myCall == 1 ? _relationships('stale') : _relationships('fresh');
+      });
+      addTearDown(client.dispose);
+      final container = _container(client);
+      final blocked = container.read(
+        blockedUsersControllerProvider('').notifier,
+      );
+
+      final first = blocked.refresh(client); // starts first, resolves last
+      final second = blocked.refresh(client); // starts second, resolves first
+      await _waitUntil(() => gates.length == 2);
+
+      // Resolve the later-started request first.
+      gates[1].complete();
+      await second;
+      expect(
+        container.read(blockedUsersControllerProvider('')),
+        unorderedEquals(<String>{'fresh'}),
+      );
+
+      gates[0].complete();
+      await first;
+      // The stale response from the call that started first must not
+      // overwrite what the later call already applied.
+      expect(
+        container.read(blockedUsersControllerProvider('')),
+        unorderedEquals(<String>{'fresh'}),
+      );
+    },
+  );
+
+  test('a single refresh still applies the server list normally', () async {
+    final client = _client((request) async => _relationships('them'));
+    addTearDown(client.dispose);
+    final container = _container(client);
+    final blocked = container.read(
+      blockedUsersControllerProvider('').notifier,
+    );
+
+    await blocked.refresh(client);
+
+    expect(
+      container.read(blockedUsersControllerProvider('')),
+      unorderedEquals(<String>{'them'}),
+    );
+  });
+
+  test('sync is a no-op when the resulting set is unchanged', () {
+    final client = _client(
+      (request) async => http.Response('[]', 200),
+    );
+    addTearDown(client.dispose);
+    final container = _container(client);
+    final blocked = container.read(
+      blockedUsersControllerProvider('').notifier,
+    );
+    blocked.block('u1');
+    final before = container.read(blockedUsersControllerProvider(''));
+
+    blocked.sync([
+      AccordRelationship(
+        id: 'r1',
+        type: accordBlockedRelationship,
+        user: AccordUser(id: 'u1', username: 'u1'),
+      ),
+    ]);
+
+    // Same set contents, so the state object itself must not be replaced —
+    // a watcher relying on identity to skip an unrelated rebuild would
+    // otherwise rebuild for nothing every time the relationship list is
+    // re-fetched.
+    expect(
+      identical(container.read(blockedUsersControllerProvider('')), before),
+      isTrue,
+    );
+  });
+}

--- a/test/features/user/dm_report_affordance_test.dart
+++ b/test/features/user/dm_report_affordance_test.dart
@@ -1,0 +1,147 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reaching Report and Block from a direct message (App Review 1.2, #290).
+///
+/// A DM has no space, so the space-scoped member popout can't open there: a tap
+/// on a DM user lands on the account-level profile, and the conversation's
+/// report/block menu used to open on long-press or right-click only. Both were
+/// dead ends for a reviewer tapping around. These hold the two affordances in
+/// place.
+
+/// A [DmChannelsController] exposing a fixed conversation list, so the DM
+/// dialog renders without a server.
+class _FakeDmChannels extends DmChannelsController {
+  _FakeDmChannels(this._channels);
+
+  final List<AccordChannel> _channels;
+
+  @override
+  List<AccordChannel>? build(String serverKey) => _channels;
+}
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+final _them = AccordUser(id: 'u2', username: 'bob');
+
+AccordChannel get _dm =>
+    AccordChannel(id: 'dm1', type: 'dm', recipients: [_them]);
+
+/// There is no client in this harness, so the message pane stays in its
+/// loading state — pump explicit frames rather than waiting for it to settle.
+Future<void> _tick(WidgetTester tester, {int frames = 12}) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer(
+      overrides: [
+        settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+        dmChannelsControllerProvider(
+          '',
+        ).overrideWith(() => _FakeDmChannels([_dm])),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  Widget app(VoidCallback Function(BuildContext context) onPressed) =>
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildAppTheme(AppThemePreset.dark),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: onPressed(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('a DM user profile can report and block that account', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      app((context) => () => showAccordUserProfile(context, _them)),
+    );
+    await tester.tap(find.text('open'));
+    await _tick(tester);
+
+    expect(find.text('Report user'), findsOneWidget);
+    expect(find.text('Block'), findsOneWidget);
+
+    await tester.tap(find.text('Report user'));
+    await _tick(tester);
+
+    expect(find.text('Report bob'), findsOneWidget);
+    expect(find.text('Submit report'), findsOneWidget);
+  });
+
+  testWidgets('blocking from a DM user profile asks for confirmation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      app((context) => () => showAccordUserProfile(context, _them)),
+    );
+    await tester.tap(find.text('open'));
+    await _tick(tester);
+
+    await tester.tap(find.text('Block'));
+    await _tick(tester);
+
+    expect(find.text('Block user'), findsOneWidget);
+    expect(
+      find.textContaining('Blocked users cannot DM you'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('the 1:1 DM header has a visible menu carrying Report and Block', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      app(
+        (context) => () => showAccordDirectMessages(
+          context,
+          initialChannel: _dm,
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await _tick(tester);
+
+    // The group menu is group-only; a 1:1 gets its own overflow button.
+    expect(find.byTooltip('Group options'), findsNothing);
+    expect(find.byTooltip('Conversation options'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Conversation options'));
+    await _tick(tester);
+
+    expect(find.text('Report user'), findsOneWidget);
+    expect(find.text('Block'), findsOneWidget);
+
+    await tester.tap(find.text('Report user'));
+    await _tick(tester);
+
+    expect(find.text('Report bob'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Finishes #290 (App Review guideline 1.2 — "a mechanism for users to flag objectionable content"). PR #294 made reporting work outside a space; an audit found surfaces it still didn't reach and three ways the new dialog could mislead.

**A DM user tap was a dead end.** The member popout requires a space, so a DM falls back to the account-level profile, whose only action was Close. That profile now carries Report user and Block, reusing the same dialog and confirm flow the popout and the DM menu already use — a smaller, better-contained change than making the space-scoped popout (roles, nickname, kick/ban/timeout, permission lookups) work without a space.

**The DM report/block menu had no visible affordance** — it opened on long-press or right-click only, which is exactly the shape that reads as "there is no way to report". The 1:1 header now has an overflow button matching the group header's.

**Report reaches thread replies and pinned messages**, so no message surface is without it, and both filter the reported/blocked set the pane already filtered.

**Three dialog faults fixed:**
- It claimed *"Reported, but blocking the account failed"* even when the account-level route was missing and nothing had been filed. The copy now tracks what was actually delivered.
- That failure left the form live, so submitting again filed a second report. A `_sent` latch keeps the report from being sent twice while still allowing the block to be retried.
- The block promised *"their content is hidden"* while nothing in the client filtered it. `BlockedUsersController` holds the blocked account ids per connection — seeded from the relationship list on gateway READY, re-read on relationship events, updated locally by every block and unblock — and `MessageVisibility` applies it, with the hidden-message set, in the pane, the thread view and the pinned list.

The bottom-sheet menu became scrollable while doing this: nine entries overflowed a short viewport and clipped the last of them.

## Verification

- `flutter analyze --no-fatal-infos` — 2 issues, both the pre-existing `unintended_html_in_doc_comment` infos in `packages/accordkit`. Nothing new.
- `flutter test` — 1139 passing, 0 failing, 0 skipped.
- `scripts/codegen.sh --check` — generated files match committed output.
- New tests: `test/features/user/dm_report_affordance_test.dart` (Report user from the DM profile, block confirmation, the visible header overflow reaching the report dialog), `test/features/messaging/pinned_messages_report_test.dart`, plus additions to `report_dialog_test.dart` (truthful copy for both delivered/not-delivered block failures, and the no-duplicate-report latch) and `dm_report_action_test.dart` (blocked-author filtering).

## Known limits

- No test for the thread-view Report entry — there is no thread-pane harness and building one is a larger lift than this issue needs; the pinned surface is covered instead.
- `MessageVisibility` matches blocked ids against `message.authorId` by exact string, so a federated author echoed back qualified would not be filtered. Same-server blocking, the case App Review exercises, works.
- Server-side work (an account-level report route, an admin surface for non-space reports) remains a separate accordserver task, per the issue.

Refs #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)