### PR TITLE
fix(app-store): remove the pre-release surfaces a reviewer can reach

### DIFF
--- a/lib/features/developer/controllers/mcp_server_controller.dart
+++ b/lib/features/developer/controllers/mcp_server_controller.dart
@@ -1,6 +1,7 @@
 import 'package:bonfire/features/developer/services/mcp_server.dart';
 import 'package:bonfire/features/developer/services/mcp_tools.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'mcp_server_controller.g.dart';
@@ -40,8 +41,15 @@ const int _activityLogCap = 100;
 /// tool groups are read live by the server, so changing those takes effect
 /// without a restart.
 ///
+/// The desktop-only part is enforced here rather than assumed: [McpServer]
+/// resolves to the real `dart:io` implementation on *any* platform with
+/// `dart:library.io` — which includes iOS and Android — so without this gate a
+/// persisted `developerMode` flag would start a real HTTP listener on a phone or
+/// inside a store build. [isDeveloperModeAvailable] is the single source of
+/// truth, shared with the settings UI that offers the toggle.
+///
 /// On web (no `dart:io`) the [McpServer] facade is a no-op, so this controller
-/// is inert there.
+/// is inert there too.
 @Riverpod(keepAlive: true)
 class McpServerController extends _$McpServerController {
   McpServer? _server;
@@ -54,6 +62,7 @@ class McpServerController extends _$McpServerController {
   McpServerState build() {
     final settings = ref.watch(settingsControllerProvider);
     final shouldRun =
+        isDeveloperModeAvailable &&
         settings.developerMode &&
         settings.mcpEnabled &&
         settings.mcpToken.trim().isNotEmpty;

--- a/lib/features/developer/controllers/mcp_server_controller.g.dart
+++ b/lib/features/developer/controllers/mcp_server_controller.g.dart
@@ -15,8 +15,15 @@ part of 'mcp_server_controller.dart';
 /// tool groups are read live by the server, so changing those takes effect
 /// without a restart.
 ///
+/// The desktop-only part is enforced here rather than assumed: [McpServer]
+/// resolves to the real `dart:io` implementation on *any* platform with
+/// `dart:library.io` — which includes iOS and Android — so without this gate a
+/// persisted `developerMode` flag would start a real HTTP listener on a phone or
+/// inside a store build. [isDeveloperModeAvailable] is the single source of
+/// truth, shared with the settings UI that offers the toggle.
+///
 /// On web (no `dart:io`) the [McpServer] facade is a no-op, so this controller
-/// is inert there.
+/// is inert there too.
 
 @ProviderFor(McpServerController)
 const mcpServerControllerProvider = McpServerControllerProvider._();
@@ -28,8 +35,15 @@ const mcpServerControllerProvider = McpServerControllerProvider._();
 /// tool groups are read live by the server, so changing those takes effect
 /// without a restart.
 ///
+/// The desktop-only part is enforced here rather than assumed: [McpServer]
+/// resolves to the real `dart:io` implementation on *any* platform with
+/// `dart:library.io` — which includes iOS and Android — so without this gate a
+/// persisted `developerMode` flag would start a real HTTP listener on a phone or
+/// inside a store build. [isDeveloperModeAvailable] is the single source of
+/// truth, shared with the settings UI that offers the toggle.
+///
 /// On web (no `dart:io`) the [McpServer] facade is a no-op, so this controller
-/// is inert there.
+/// is inert there too.
 final class McpServerControllerProvider
     extends $NotifierProvider<McpServerController, McpServerState> {
   /// Owns the desktop-only local MCP server lifecycle, driven by the persisted
@@ -39,8 +53,15 @@ final class McpServerControllerProvider
   /// tool groups are read live by the server, so changing those takes effect
   /// without a restart.
   ///
+  /// The desktop-only part is enforced here rather than assumed: [McpServer]
+  /// resolves to the real `dart:io` implementation on *any* platform with
+  /// `dart:library.io` — which includes iOS and Android — so without this gate a
+  /// persisted `developerMode` flag would start a real HTTP listener on a phone or
+  /// inside a store build. [isDeveloperModeAvailable] is the single source of
+  /// truth, shared with the settings UI that offers the toggle.
+  ///
   /// On web (no `dart:io`) the [McpServer] facade is a no-op, so this controller
-  /// is inert there.
+  /// is inert there too.
   const McpServerControllerProvider._()
     : super(
         from: null,
@@ -69,7 +90,7 @@ final class McpServerControllerProvider
 }
 
 String _$mcpServerControllerHash() =>
-    r'6a2734149fa1b62c8d4299e6e0d4ceb4d3e39983';
+    r'4729c9d96fe693efdf6b902c15ea5fdae1f1bc88';
 
 /// Owns the desktop-only local MCP server lifecycle, driven by the persisted
 /// [SettingsController] flags. The server runs only while Developer Mode **and**
@@ -78,8 +99,15 @@ String _$mcpServerControllerHash() =>
 /// tool groups are read live by the server, so changing those takes effect
 /// without a restart.
 ///
+/// The desktop-only part is enforced here rather than assumed: [McpServer]
+/// resolves to the real `dart:io` implementation on *any* platform with
+/// `dart:library.io` — which includes iOS and Android — so without this gate a
+/// persisted `developerMode` flag would start a real HTTP listener on a phone or
+/// inside a store build. [isDeveloperModeAvailable] is the single source of
+/// truth, shared with the settings UI that offers the toggle.
+///
 /// On web (no `dart:io`) the [McpServer] facade is a no-op, so this controller
-/// is inert there.
+/// is inert there too.
 
 abstract class _$McpServerController extends $Notifier<McpServerState> {
   McpServerState build();

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -94,12 +94,18 @@ class AccordSettingsScreen extends ConsumerWidget {
               const Divider(height: 24),
               const _ServerDirectorySection(),
               const Divider(height: 24),
-              const _UpdatesSection(),
-              const Divider(height: 24),
+              // Store builds update through the store and never expose the
+              // GitHub self-updater; Developer Mode is desktop-only (#292).
+              if (!isAppStoreBuild) ...[
+                const _UpdatesSection(),
+                const Divider(height: 24),
+              ],
               const _BackupSection(),
               const Divider(height: 24),
-              _DeveloperSection(settings: settings, controller: controller),
-              const Divider(height: 24),
+              if (isDeveloperModeAvailable) ...[
+                _DeveloperSection(settings: settings, controller: controller),
+                const Divider(height: 24),
+              ],
               const OnboardingHelpSection(),
               const Divider(height: 24),
               const _AboutSection(),
@@ -311,11 +317,15 @@ class _CategoryPane extends ConsumerWidget {
         const _VoiceVideoSection(),
       ],
       SettingsCategory.system => <Widget>[
-        const _UpdatesSection(),
+        // Store builds update through the store and never expose the GitHub
+        // self-updater (#292).
+        if (!isAppStoreBuild) const _UpdatesSection(),
         const _BackupSection(),
       ],
       SettingsCategory.advanced => <Widget>[
-        _DeveloperSection(settings: settings, controller: controller),
+        // The local MCP server is desktop-only and never in a store build.
+        if (isDeveloperModeAvailable)
+          _DeveloperSection(settings: settings, controller: controller),
         const OnboardingHelpSection(),
         const _AboutSection(),
       ],

--- a/lib/features/settings/views/connections_settings_page.dart
+++ b/lib/features/settings/views/connections_settings_page.dart
@@ -43,6 +43,10 @@ class ConnectionsScreen extends ConsumerStatefulWidget {
 class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
   bool _loading = true;
   String? _error;
+
+  /// True once the server has told us it has no connections endpoint at all
+  /// (see [_unsupportedStatuses]). Distinct from "loaded, but empty".
+  bool _unsupported = false;
   List<_Connection> _connections = const [];
   final Set<String> _disconnecting = {};
 
@@ -66,10 +70,19 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
     setState(() {
       _loading = true;
       _error = null;
+      _unsupported = false;
     });
     final result = await client.users.listConnections();
     if (!mounted) return;
     if (!result.ok) {
+      if (_unsupportedStatuses.contains(result.statusCode)) {
+        setState(() {
+          _loading = false;
+          _unsupported = true;
+          _connections = const [];
+        });
+        return;
+      }
       setState(() {
         _loading = false;
         _error = 'Failed to load connections.';
@@ -133,6 +146,9 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
   @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
+    // Embedded, on a server without the endpoint: drop the card entirely rather
+    // than leave a "Connections" heading that can never hold anything (#292).
+    if (widget.embedded && _unsupported) return const SizedBox.shrink();
     if (widget.embedded) {
       return Column(
         mainAxisSize: MainAxisSize.min,
@@ -177,7 +193,7 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            _emptyMessage,
+            _unsupported ? _unsupportedMessage : _emptyMessage,
             textAlign: TextAlign.center,
             style: _hint(colors),
           ),
@@ -215,9 +231,20 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
     return _connectionTiles(colors);
   }
 
+  /// HTTP statuses that mean "this server has no connections endpoint": the
+  /// route is absent (404), unimplemented (501), or exists but doesn't answer
+  /// GET (405). None of them is something the user can retry or fix, so they
+  /// render as a neutral statement of capability rather than a red error — the
+  /// live server currently 404s here, which is what put a permanent "Failed to
+  /// load connections." at the top of the Account pane (#292).
+  static const _unsupportedStatuses = {404, 405, 501};
+
   static const _emptyMessage =
       'No connections linked.\n\nLinked third-party accounts (OAuth) will '
       'appear here.';
+
+  static const _unsupportedMessage =
+      "This server doesn't support linked third-party accounts.";
 
   TextStyle _hint(BonfireThemeExtension colors) =>
       Theme.of(context).textTheme.bodyMedium!.copyWith(color: colors.gray);

--- a/lib/features/updates/controllers/update_controller.dart
+++ b/lib/features/updates/controllers/update_controller.dart
@@ -156,8 +156,9 @@ class UpdateController extends _$UpdateController {
   /// periodic check. Safe to call repeatedly — the timer is armed only once.
   Future<void> maybeCheckOnStartup() async {
     // App Store builds update through the store; never check GitHub or arm the
-    // periodic timer (see [kAppStoreBuild]).
-    if (kAppStoreBuild) return;
+    // periodic timer (see [kAppStoreBuild]). [check] is a no-op there too, so
+    // this is belt-and-braces for the timer.
+    if (isAppStoreBuild) return;
     // The web build ships whatever the server serves — there's nothing to
     // download or install, so never check for releases or show the banner.
     if (UniversalPlatform.isWeb) return;
@@ -175,7 +176,13 @@ class UpdateController extends _$UpdateController {
 
   /// Fetches the latest release. [manual] checks just surface errors to the
   /// user. Returns the resulting state.
+  ///
+  /// A no-op on app-store builds: those must never reach GitHub for release
+  /// information at all, so `latest` stays null and every downstream surface
+  /// (banner, Updates page, install path) stays empty. The store build's only
+  /// update channel is the store.
   Future<UpdateState> check({bool manual = false}) async {
+    if (isAppStoreBuild) return state;
     if (state.checking) return state;
     state = state.copyWith(checking: true, clearError: true);
     try {
@@ -344,6 +351,7 @@ class UpdateController extends _$UpdateController {
   /// null when none is found (the caller then falls back to the release page).
   /// Always null on web/iOS (no self-served binary applies).
   String? platformAssetUrl() {
+    if (isAppStoreBuild) return null;
     if (UniversalPlatform.isWeb || UniversalPlatform.isIOS) return null;
     return _assetForExts(_downloadExts)?.url;
   }
@@ -358,7 +366,9 @@ class UpdateController extends _$UpdateController {
   /// writability / privilege gating, so a package-manager install with no
   /// applicable path yields no asset here and the UI offers a manual download.
   bool get canInstallInPlace =>
-      !kAppStoreBuild && UpdateInstaller.isSupported && platformAsset() != null;
+      !isAppStoreBuild &&
+      UpdateInstaller.isSupported &&
+      platformAsset() != null;
 
   /// Whether applying the staged update will prompt for administrator
   /// authentication — a Linux system-package (`.deb`) reinstall via pkexec. Lets
@@ -412,6 +422,7 @@ class UpdateController extends _$UpdateController {
   /// one-click path); otherwise downloads + verifies first. Surfaces
   /// progress/errors via [state].
   Future<void> applyUpdate() async {
+    if (isAppStoreBuild) return;
     if (state.installing) return;
     final installer = UpdateInstaller();
     try {

--- a/lib/features/updates/controllers/update_controller.g.dart
+++ b/lib/features/updates/controllers/update_controller.g.dart
@@ -83,7 +83,7 @@ final class UpdateControllerProvider
   }
 }
 
-String _$updateControllerHash() => r'953fb0a2953403518a9d09f3875345d00a452dab';
+String _$updateControllerHash() => r'dca7d04e7e083565ed81c4dcca5aa45647314b11';
 
 /// Checks the project's GitHub Releases for a newer build and exposes the
 /// result. Ports the reference client's `updater.gd`: a startup check plus an

--- a/lib/features/updates/views/update_banner.dart
+++ b/lib/features/updates/views/update_banner.dart
@@ -1,6 +1,7 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/shared/components/app_banner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,11 +14,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// self-install (web/iOS, or an older release with no installable asset) fall
 /// back to the legacy "tap to view" banner that opens the Updates page. The ✕
 /// dismisses the current version until a newer one ships.
+///
+/// Never shown on app-store builds — those update through the store, so there
+/// is no GitHub check to surface (see [isAppStoreBuild]).
 class UpdateBanner extends ConsumerWidget {
   const UpdateBanner({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (isAppStoreBuild) return const SizedBox.shrink();
     final update = ref.watch(updateControllerProvider);
     final notifier = ref.read(updateControllerProvider.notifier);
     final skipped = ref.watch(

--- a/lib/features/updates/views/updates_page.dart
+++ b/lib/features/updates/views/updates_page.dart
@@ -56,9 +56,10 @@ class UpdatesScreen extends ConsumerWidget {
             leading: const Icon(Icons.auto_awesome),
             title: const Text("What's new in this version"),
             subtitle: const Text("Release notes for the build you're running"),
-            trailing: ref.watch(
-              releaseNotesControllerProvider.select((s) => s.loading),
-            )
+            trailing:
+                ref.watch(
+                  releaseNotesControllerProvider.select((s) => s.loading),
+                )
                 ? const SizedBox(
                     width: 16,
                     height: 16,
@@ -67,160 +68,177 @@ class UpdatesScreen extends ConsumerWidget {
                 : const Icon(Icons.chevron_right),
             onTap: () => openCurrentReleaseNotes(context, ref),
           ),
-          SwitchListTile(
-            title: const Text('Check for updates on startup'),
-            value: autoCheck,
-            onChanged: settings.setAutoUpdateCheck,
-          ),
-          const Divider(height: 16),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
-            child: Row(
-              children: [
-                FilledButton.icon(
-                  onPressed: update.checking
-                      ? null
-                      : () => notifier.check(manual: true),
-                  icon: update.checking
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.refresh),
-                  label: Text(
-                    update.checking ? 'Checking…' : 'Check for updates',
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (update.error != null)
+          // App-store builds update through the store and must never query
+          // GitHub for releases, so the whole check/download half of this page
+          // is replaced by a one-line statement of where updates come from.
+          if (isAppStoreBuild)
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: InlineError(update.error!, centered: false),
-            )
-          else if (update.checkedOnce && !available)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Row(
-                children: [
-                  Icon(Icons.check_circle, size: 16, color: colors.green),
-                  const SizedBox(width: 6),
-                  Text(
-                    "You're up to date.",
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodySmall!.copyWith(color: colors.green),
-                  ),
-                ],
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: Text(
+                'Updates are delivered through the app store.',
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall!.copyWith(color: colors.gray),
               ),
+            )
+          else ...[
+            SwitchListTile(
+              title: const Text('Check for updates on startup'),
+              value: autoCheck,
+              onChanged: settings.setAutoUpdateCheck,
             ),
-          if (available && release != null) ...[
             const Divider(height: 16),
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
-              child: Text(
-                'Update available: ${release.name}',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall!.copyWith(color: colors.primary),
-              ),
-            ),
-            // GitHub release bodies are markdown — render them with the app's
-            // own viewer rather than dumping the raw source (#183).
-            if (release.notes.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                child: AccordMarkdownBox(content: release.notes),
-              ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                crossAxisAlignment: WrapCrossAlignment.center,
+              child: Row(
                 children: [
-                  Builder(
-                    builder: (context) {
-                      // Where the platform supports it, download + install in
-                      // place (desktop binary swap / Android APK install);
-                      // otherwise fall back to a plain download link.
-                      if (!kIsWeb && notifier.canInstallInPlace) {
-                        return FilledButton.icon(
-                          onPressed: update.installing
-                              ? null
-                              : () => notifier.applyUpdate(),
-                          icon: update.installing
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2),
-                                )
-                              : Icon(
-                                  update.updateReady
-                                      ? Icons.restart_alt
-                                      : Icons.download,
-                                ),
-                          label: Text(
-                            _installLabel(
-                              update,
-                              notifier.requiresPrivilegedInstall,
-                            ),
-                          ),
-                        );
-                      }
-                      // Prefer the matching platform asset (one-click download
-                      // of the right file); fall back to the release page.
-                      final assetUrl = notifier.platformAssetUrl();
-                      final target = assetUrl ?? release.url;
-                      return FilledButton.icon(
-                        onPressed: target.isEmpty
-                            ? null
-                            : () => launchUrl(
-                                Uri.parse(target),
-                                mode: LaunchMode.externalApplication,
-                              ),
-                        icon: const Icon(Icons.download),
-                        label: Text(
-                          assetUrl != null ? 'Download' : 'View release',
-                        ),
-                      );
-                    },
-                  ),
-                  TextButton(
-                    onPressed: update.installing
+                  FilledButton.icon(
+                    onPressed: update.checking
                         ? null
-                        : () {
-                            notifier.skipCurrent();
-                            Navigator.of(context).maybePop();
-                          },
-                    child: const Text('Skip this version'),
+                        : () => notifier.check(manual: true),
+                    icon: update.checking
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh),
+                    label: Text(
+                      update.checking ? 'Checking…' : 'Check for updates',
+                    ),
                   ),
                 ],
               ),
             ),
-            if (update.phase == UpdatePhase.downloading && update.progress > 0)
+            if (update.error != null)
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                child: LinearProgressIndicator(value: update.progress),
-              ),
-            if (update.installError != null)
+                child: InlineError(update.error!, centered: false),
+              )
+            else if (update.checkedOnce && !available)
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                child: InlineError(update.installError!, centered: false),
-              ),
-            if (kIsWeb)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                child: Text(
-                  'On the web, refresh the page to load the latest version.',
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodySmall!.copyWith(color: colors.gray),
+                child: Row(
+                  children: [
+                    Icon(Icons.check_circle, size: 16, color: colors.green),
+                    const SizedBox(width: 6),
+                    Text(
+                      "You're up to date.",
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodySmall!.copyWith(color: colors.green),
+                    ),
+                  ],
                 ),
               ),
+            if (available && release != null) ...[
+              const Divider(height: 16),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+                child: Text(
+                  'Update available: ${release.name}',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleSmall!.copyWith(color: colors.primary),
+                ),
+              ),
+              // GitHub release bodies are markdown — render them with the app's
+              // own viewer rather than dumping the raw source (#183).
+              if (release.notes.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: AccordMarkdownBox(content: release.notes),
+                ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Builder(
+                      builder: (context) {
+                        // Where the platform supports it, download + install in
+                        // place (desktop binary swap / Android APK install);
+                        // otherwise fall back to a plain download link.
+                        if (!kIsWeb && notifier.canInstallInPlace) {
+                          return FilledButton.icon(
+                            onPressed: update.installing
+                                ? null
+                                : () => notifier.applyUpdate(),
+                            icon: update.installing
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : Icon(
+                                    update.updateReady
+                                        ? Icons.restart_alt
+                                        : Icons.download,
+                                  ),
+                            label: Text(
+                              _installLabel(
+                                update,
+                                notifier.requiresPrivilegedInstall,
+                              ),
+                            ),
+                          );
+                        }
+                        // Prefer the matching platform asset (one-click download
+                        // of the right file); fall back to the release page.
+                        final assetUrl = notifier.platformAssetUrl();
+                        final target = assetUrl ?? release.url;
+                        return FilledButton.icon(
+                          onPressed: target.isEmpty
+                              ? null
+                              : () => launchUrl(
+                                  Uri.parse(target),
+                                  mode: LaunchMode.externalApplication,
+                                ),
+                          icon: const Icon(Icons.download),
+                          label: Text(
+                            assetUrl != null ? 'Download' : 'View release',
+                          ),
+                        );
+                      },
+                    ),
+                    TextButton(
+                      onPressed: update.installing
+                          ? null
+                          : () {
+                              notifier.skipCurrent();
+                              Navigator.of(context).maybePop();
+                            },
+                      child: const Text('Skip this version'),
+                    ),
+                  ],
+                ),
+              ),
+              if (update.phase == UpdatePhase.downloading &&
+                  update.progress > 0)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: LinearProgressIndicator(value: update.progress),
+                ),
+              if (update.installError != null)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: InlineError(update.installError!, centered: false),
+                ),
+              if (kIsWeb)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: Text(
+                    'On the web, refresh the page to load the latest version.',
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodySmall!.copyWith(color: colors.gray),
+                  ),
+                ),
+            ],
           ],
         ],
       ),

--- a/lib/shared/app_info.dart
+++ b/lib/shared/app_info.dart
@@ -2,7 +2,9 @@
 /// server's `serverInfo`.
 library;
 
+import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:universal_platform/universal_platform.dart';
 
 /// The current app version. Populated once at startup by [initAppInfo] from the
 /// version Flutter bakes into the build from `pubspec.yaml` `version:` (the
@@ -34,9 +36,44 @@ Future<void> initAppInfo() async {
 /// App Store Review Guidelines forbid apps that download and run executable
 /// code or self-update outside the store, and the Mac App Store build is
 /// sandboxed (which blocks the swap helper anyway). So when this is true the
-/// in-app updater is disabled entirely: no startup/periodic GitHub check and no
-/// in-place install path. Store builds update through the store.
+/// in-app updater is disabled entirely: no startup/periodic GitHub check, no
+/// manual check, no Updates entry point and no banner. Store builds update
+/// through the store.
+///
+/// Prefer [isAppStoreBuild] at call sites — it is the same value, but overridable
+/// in tests (this const is baked in at compile time and so is always `false` in
+/// a normal `flutter test` run).
 const bool kAppStoreBuild = bool.fromEnvironment('APP_STORE');
+
+/// Forces [isAppStoreBuild] on in tests, which cannot set a `--dart-define`.
+/// Null in production. Mirrors `UpdateInstaller.debugInstallRootWritable`.
+@visibleForTesting
+bool? debugAppStoreBuild;
+
+/// Whether this build must behave as an app-store build — see [kAppStoreBuild].
+///
+/// `kAppStoreBuild ||` keeps the const short-circuit for real store builds (the
+/// compiler still folds the whole expression to `true`), so the updater code is
+/// still statically dead there.
+bool get isAppStoreBuild => kAppStoreBuild || (debugAppStoreBuild ?? false);
+
+/// Overrides [isDeveloperModeAvailable] in tests, which can neither set a
+/// `--dart-define` nor pretend to run on another platform. Null in production.
+@visibleForTesting
+bool? debugDeveloperModeAvailable;
+
+/// Whether Developer Mode (and the local Client MCP server it unlocks) may be
+/// offered on this build at all.
+///
+/// The MCP server binds an HTTP listener on `127.0.0.1` for AI agents running on
+/// the same machine. That only means anything on a desktop the user also runs
+/// agents on: on phones and tablets there is nothing to connect to it, and web
+/// has no `dart:io` server at all. Shipping a debug server (and a settings
+/// toggle describing one) inside a store binary also reads as a pre-release
+/// build to app reviewers. So it is desktop-only, and never on a store build.
+bool get isDeveloperModeAvailable =>
+    debugDeveloperModeAvailable ??
+    (!isAppStoreBuild && UniversalPlatform.isDesktop);
 
 /// `owner/repo` whose GitHub Releases drive the in-app update checker. This is
 /// the Flutter client's own repository (the reference client checks its own

--- a/test/features/developer/mcp_server_controller_test.dart
+++ b/test/features/developer/mcp_server_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bonfire/features/developer/controllers/mcp_server_controller.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
@@ -17,9 +18,60 @@ void main() {
   });
 
   tearDown(() async {
+    debugDeveloperModeAvailable = null;
     await Hive.deleteBoxFromDisk('accord-settings');
     await Hive.close();
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  /// Persists fully-enabled MCP settings on a free port and returns that port.
+  Future<int> seedEnabledSettings() async {
+    final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final port = probe.port;
+    await probe.close();
+    await Hive.box('accord-settings').put(
+      'settings',
+      AccordSettings(
+        developerMode: true,
+        mcpEnabled: true,
+        mcpPort: port,
+        mcpToken: 'test-token',
+      ).toJson(),
+    );
+    return port;
+  }
+
+  test('starts when developer mode is available for this build', () async {
+    // Positive control for the gate below: with the same settings and the
+    // platform gate open, the server really does listen.
+    debugDeveloperModeAvailable = true;
+    await seedEnabledSettings();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(mcpServerControllerProvider);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(container.read(mcpServerControllerProvider).listening, isTrue);
+  });
+
+  test('never starts where developer mode is unavailable', () async {
+    // Mobile and app-store builds: `mcp_server.dart` still resolves to the real
+    // dart:io server (dart.library.io is true on iOS/Android), so the gate has
+    // to be enforced here or a persisted flag would open a listener inside the
+    // store binary (#292).
+    debugDeveloperModeAvailable = false;
+    final port = await seedEnabledSettings();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(settingsControllerProvider).developerMode, isTrue);
+    container.read(mcpServerControllerProvider);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(container.read(mcpServerControllerProvider).listening, isFalse);
+    final canBind = await ServerSocket.bind(InternetAddress.loopbackIPv4, port);
+    await canBind.close();
   });
 
   test(

--- a/test/features/settings/connections_settings_test.dart
+++ b/test/features/settings/connections_settings_test.dart
@@ -1,0 +1,143 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/views/connections_settings_page.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Hosts [ConnectionsScreen] against a client whose
+/// `GET /users/@me/connections` answers [status] with [body].
+Widget _host({
+  required int status,
+  String body = '{}',
+  bool embedded = false,
+}) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final client = AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient((request) async {
+      expect(request.url.path, endsWith('/users/@me/connections'));
+      return http.Response(
+        body,
+        status,
+        headers: {'content-type': 'application/json'},
+      );
+    }),
+  );
+  addTearDown(client.dispose);
+  final session = AccordSession(
+    server: server,
+    token: 'test-token',
+    userId: 'u-self',
+    username: 'self',
+  );
+  return ProviderScope(
+    overrides: [
+      accordAuthProvider.overrideWithValue(
+        AccordAuthLoggedIn(client: client, session: session),
+      ),
+    ],
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(body: ConnectionsScreen(embedded: embedded)),
+    ),
+  );
+}
+
+const _errorText = 'Failed to load connections.';
+
+void main() {
+  group('ConnectionsScreen — server without a connections endpoint', () {
+    // The live server 404s this route, which used to paint a permanent red
+    // "Failed to load connections." across the first settings screen a user
+    // (or an app reviewer) opens (#292).
+    for (final status in const [404, 405, 501]) {
+      testWidgets('$status renders no error in the embedded Account card', (
+        tester,
+      ) async {
+        await tester.pumpWidget(_host(status: status, embedded: true));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_errorText), findsNothing);
+      });
+
+      testWidgets('$status collapses the embedded card entirely', (
+        tester,
+      ) async {
+        await tester.pumpWidget(_host(status: status, embedded: true));
+        await tester.pumpAndSettle();
+
+        // Not even the section heading survives: a card that can never hold
+        // anything is itself a half-built feature.
+        expect(find.text('CONNECTIONS'), findsNothing);
+        expect(tester.getSize(find.byType(ConnectionsScreen)).height, 0);
+      });
+
+      testWidgets('$status states the capability on the standalone page', (
+        tester,
+      ) async {
+        await tester.pumpWidget(_host(status: status));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_errorText), findsNothing);
+        expect(
+          find.textContaining("doesn't support linked third-party accounts"),
+          findsOneWidget,
+        );
+      });
+    }
+  });
+
+  group('ConnectionsScreen — genuine failures still surface', () {
+    for (final status in const [500, 502]) {
+      testWidgets('$status still shows the error (embedded)', (tester) async {
+        await tester.pumpWidget(_host(status: status, embedded: true));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_errorText), findsOneWidget);
+      });
+
+      testWidgets('$status still shows the error (standalone)', (tester) async {
+        await tester.pumpWidget(_host(status: status));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_errorText), findsOneWidget);
+      });
+    }
+  });
+
+  group('ConnectionsScreen — supported server', () {
+    testWidgets('lists the linked accounts it is given', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          status: 200,
+          body: '{"data":[{"id":"1","type":"github","name":"octocat"}]}',
+          embedded: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(_errorText), findsNothing);
+      expect(find.text('github'), findsOneWidget);
+      expect(find.text('octocat'), findsOneWidget);
+    });
+
+    testWidgets('an empty list keeps the neutral empty state', (tester) async {
+      await tester.pumpWidget(_host(status: 200, body: '{"data":[]}'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_errorText), findsNothing);
+      expect(find.textContaining('No connections linked.'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/settings_layout_test.dart
+++ b/test/features/settings/settings_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/settings/views/accord_settings_screen.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -222,6 +223,79 @@ void main() {
       await _selectCategory(tester, 'App');
       expect(_section('Appearance'), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  // Apple rejected 0.2.16 under guideline 2.2 partly because the store build
+  // shipped a live GitHub self-updater and a Developer Mode / local MCP server
+  // toggle — both of which read as an unfinished, non-store build (#292).
+  group('app store builds', () {
+    setUp(() => debugAppStoreBuild = true);
+    tearDown(() => debugAppStoreBuild = null);
+
+    testWidgets('hide the Updates section in the narrow layout', (
+      tester,
+    ) async {
+      await _pumpAt(tester, const Size(600, 8000));
+
+      expect(_section('Updates'), findsNothing);
+      // The rest of System is untouched.
+      expect(_section('Backup'), findsOneWidget);
+    });
+
+    testWidgets('hide the Updates section in the wide System pane', (
+      tester,
+    ) async {
+      await _pumpAt(tester, const Size(1400, 900));
+      await _selectCategory(tester, 'System');
+
+      expect(_section('Updates'), findsNothing);
+      expect(_section('Backup'), findsOneWidget);
+    });
+
+    testWidgets('hide Developer Mode (it implies a non-store build)', (
+      tester,
+    ) async {
+      await _pumpAt(tester, const Size(1400, 900));
+      await _selectCategory(tester, 'Advanced');
+
+      expect(_section('Developer'), findsNothing);
+      expect(find.text('Developer Mode'), findsNothing);
+      expect(_section('About'), findsOneWidget);
+    });
+  });
+
+  group('platforms without a local MCP server (mobile / web)', () {
+    setUp(() => debugDeveloperModeAvailable = false);
+    tearDown(() => debugDeveloperModeAvailable = null);
+
+    testWidgets('hide Developer Mode in the narrow layout', (tester) async {
+      await _pumpAt(tester, const Size(600, 8000));
+
+      expect(_section('Developer'), findsNothing);
+      expect(find.text('Developer Mode'), findsNothing);
+      // Neighbouring sections still render, so nothing else was dropped.
+      expect(_section('Backup'), findsOneWidget);
+      expect(_section('About'), findsOneWidget);
+    });
+
+    testWidgets('hide Developer Mode in the wide Advanced pane', (
+      tester,
+    ) async {
+      await _pumpAt(tester, const Size(1400, 900));
+      await _selectCategory(tester, 'Advanced');
+
+      expect(_section('Developer'), findsNothing);
+      expect(_section('About'), findsOneWidget);
+    });
+
+    testWidgets('the Updates section is untouched (sideload keeps it)', (
+      tester,
+    ) async {
+      await _pumpAt(tester, const Size(1400, 900));
+      await _selectCategory(tester, 'System');
+
+      expect(_section('Updates'), findsOneWidget);
     });
   });
 }

--- a/test/features/updates/update_banner_test.dart
+++ b/test/features/updates/update_banner_test.dart
@@ -4,6 +4,7 @@ import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/models/app_release.dart';
 import 'package:bonfire/features/updates/views/update_banner.dart';
 import 'package:bonfire/features/updates/views/web_update_prompt.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -181,6 +182,22 @@ void main() {
       expect(downloadingState.updateReady, isFalse);
       // updateAvailable is still true while downloading
       expect(downloadingState.updateAvailable, isTrue);
+    });
+
+    testWidgets('never renders on an app store build', (tester) async {
+      // A store binary must not advertise a GitHub release (#292). check() is
+      // already a no-op there, so `latest` can't normally be set — this proves
+      // the banner stays collapsed even if something else populated it.
+      debugAppStoreBuild = true;
+      addTearDown(() => debugAppStoreBuild = null);
+
+      await tester.pumpWidget(
+        _host(update: const UpdateState(latest: _newerRelease)),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Update available'), findsNothing);
+      expect(tester.getSize(find.byType(UpdateBanner)).height, 0);
     });
 
     testWidgets('shows "update available" when phase is failed (fallback)',

--- a/test/features/updates/update_controller_test.dart
+++ b/test/features/updates/update_controller_test.dart
@@ -11,10 +11,11 @@ import 'package:hive_ce/hive.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 // Note: kAppStoreBuild is a compile-time const (bool.fromEnvironment('APP_STORE')).
-// It is always false in unit tests unless built with --dart-define=APP_STORE=true,
-// so the kAppStoreBuild == true early-return paths in maybeCheckOnStartup() and
-// canInstallInPlace cannot be exercised here. Those paths are verified by the
-// CI build itself (store builds) and the integration test matrix.
+// It is always false in unit tests unless built with --dart-define=APP_STORE=true.
+// The controller therefore reads `isAppStoreBuild`, which ORs that const with the
+// test-only `debugAppStoreBuild` override — the same seam as
+// UpdateInstaller.debugInstallRootWritable — so the store-build early returns
+// ARE exercised here (see the "app store builds" group).
 
 late Directory _tempDir;
 
@@ -93,6 +94,7 @@ void main() {
   tearDown(() async {
     UpdateInstaller.debugInstallRootWritable = null;
     UpdateInstaller.debugHasPrivilegedInstaller = null;
+    debugAppStoreBuild = null;
     await Hive.deleteBoxFromDisk('accord-settings');
     await Hive.close();
     if (_tempDir.existsSync()) _tempDir.deleteSync(recursive: true);
@@ -127,6 +129,7 @@ void main() {
       // Sanity-check: the compile-time constant is off for normal test runs.
       // Store-build CI compiles with --dart-define=APP_STORE=true.
       expect(kAppStoreBuild, isFalse);
+      expect(isAppStoreBuild, isFalse);
     });
 
     test('is false on a non-writable install with no privileged installer', () {
@@ -201,6 +204,74 @@ void main() {
       ]);
       expect(controllerOf(c).canInstallInPlace, isTrue);
       expect(controllerOf(c).platformAsset()!.name, endsWith('.tar.gz'));
+    });
+  });
+
+  group('app store builds', () {
+    // Apple rejected 0.2.16 partly because the store binary shipped a live
+    // GitHub self-updater: a reviewer saw "Update available: v0.2.17" and a
+    // link to download the app from GitHub (#292). A store build must not even
+    // ask GitHub what the latest release is.
+    setUp(() => debugAppStoreBuild = true);
+
+    test('check() never reaches GitHub and leaves the state untouched',
+        () async {
+      final c = makeContainer();
+      final before = stateOf(c);
+      final after = await controllerOf(c).check(manual: true);
+
+      // A real request would have flipped checkedOnce (on success *or* error).
+      expect(after.checkedOnce, isFalse);
+      expect(after.checking, isFalse);
+      expect(after.latest, isNull);
+      expect(after.error, isNull);
+      expect(identical(after, before), isTrue);
+    });
+
+    test('maybeCheckOnStartup() is a no-op', () async {
+      final c = makeContainer();
+      await controllerOf(c).maybeCheckOnStartup();
+
+      expect(stateOf(c).checkedOnce, isFalse);
+      expect(stateOf(c).latest, isNull);
+    });
+
+    test('never offers an in-place install or a download link', () {
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+
+      expect(controllerOf(c).canInstallInPlace, isFalse);
+      expect(controllerOf(c).platformAssetUrl(), isNull);
+    });
+
+    test('applyUpdate() is a no-op even with a staged build', () async {
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+      await controllerOf(c).applyUpdate();
+
+      expect(stateOf(c).phase, UpdatePhase.idle);
+      expect(stateOf(c).installError, isNull);
+    });
+
+    test('prepareUpdate() never downloads', () async {
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+      await controllerOf(c).prepareUpdate();
+
+      expect(stateOf(c).phase, UpdatePhase.idle);
+      expect(stateOf(c).stagedArchivePath, isNull);
+    });
+
+    test('the same paths stay live on sideload builds', () async {
+      // Guard against over-gating: the `github` flavor deliberately keeps the
+      // self-updater, so flipping the override back must restore it.
+      if (_hostInstallableExt == null) return; // web/iOS: never in-place anyway
+      debugAppStoreBuild = null;
+      final c = makeContainer();
+      setLatest(c, _fullReleaseAssets);
+
+      expect(controllerOf(c).canInstallInPlace, isTrue);
+      expect(controllerOf(c).platformAssetUrl(), isNotNull);
     });
   });
 

--- a/test/features/updates/updates_page_test.dart
+++ b/test/features/updates/updates_page_test.dart
@@ -3,6 +3,7 @@ import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/updates/controllers/update_controller.dart';
 import 'package:bonfire/features/updates/models/app_release.dart';
 import 'package:bonfire/features/updates/views/updates_page.dart';
+import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -115,6 +116,36 @@ void main() {
       await tester.pump();
 
       expect(find.text('Download & install (admin)'), findsOneWidget);
+    });
+  });
+
+  group('UpdatesScreen on an app store build', () {
+    setUp(() => debugAppStoreBuild = true);
+    tearDown(() => debugAppStoreBuild = null);
+
+    testWidgets('offers no check, no download and no GitHub release link', (
+      tester,
+    ) async {
+      // The Settings entry point is hidden on store builds, but even if the
+      // page were reached it must not advertise a GitHub release (#292).
+      await tester.pumpWidget(
+        _host(update: const UpdateState(latest: _newerRelease)),
+      );
+      await tester.pump();
+
+      expect(find.text('Check for updates'), findsNothing);
+      expect(find.text('Check for updates on startup'), findsNothing);
+      expect(find.text('View release'), findsNothing);
+      expect(find.text('Download'), findsNothing);
+      expect(find.text('Skip this version'), findsNothing);
+      expect(find.textContaining('Update available'), findsNothing);
+      expect(
+        find.text('Updates are delivered through the app store.'),
+        findsOneWidget,
+      );
+      // The running build's own version and notes stay available.
+      expect(find.text('Current version'), findsOneWidget);
+      expect(find.text("What's new in this version"), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
First of two parts for #292 (App Review guideline 2.2 — *"appears to be a pre-release, test, or trial version with a limited feature set … complete, remove, or fully configure any partially implemented features"*). That finding had no located root cause. An investigation ran the app against the live `chat.daccord.gg` at iPad Air viewports and found three literal partially-implemented surfaces on the reviewer's path; this fixes them. The iPad layout and empty-state findings are the second part.

**Settings → Account showed a permanent red "Failed to load connections."** `GET /users/@me/connections` returns 404 on the live server, and any non-`ok` became that error — so the first Settings screen a reviewer opened showed a red failure. There is also no "link account" affordance anywhere in `lib/`, so the section can never hold content. 404/405/501 is now treated as *unsupported* rather than *failed*: the embedded Account pane hides the card and its heading entirely, the standalone page states the capability plainly, and genuine failures (no client, network, 5xx) still show the red error.

**The GitHub self-updater was fully live in the App Store build.** `kAppStoreBuild` is correctly true for iOS (the release workflow passes `--dart-define=APP_STORE=true`), but it gated only `maybeCheckOnStartup()` and `canInstallInPlace`. The Settings → Updates tile, the "Check for updates" button, the available-release block and "View release" were all reachable. v0.2.17 was published to GitHub on 2026-08-27 and the review was 2026-08-30, so a reviewer tapping through Settings would have seen *"Update available: v0.2.17"* and a link to download the app from GitHub — which reads as "this store build is not the real distribution", and touches 3.1.1 / 2.4.5 as well as 2.2.

The whole feature is now gated, not just its UI: `check()`, `applyUpdate()`, `prepareUpdate()` and `platformAssetUrl()` are no-ops on store builds so GitHub is never queried, the banner collapses before reading any provider, and the Updates entry point is removed from both layouts. `UpdatesScreen` keeps the current version and "What's new" (release notes for the *running* build — not a release-availability check) and otherwise says updates come through the app store. **The sideload `github` flavor is unchanged**, with a regression test asserting the self-updater still works there.

**Developer Mode / the MCP server shipped enabled-able.** The Settings → Advanced toggle had no gate, and `mcp_server.dart` exports the live `dart:io` server under `if (dart.library.io)` — true on iOS — so a persisted `developerMode` flag would have opened a 127.0.0.1 listener inside the store binary. `mcp_server_controller.dart`'s doc comment claimed a desktop check that did not exist; `isDeveloperModeAvailable` (desktop **and** not a store build) now implements it, and gates the toggle in both the narrow list and the wide Advanced pane.

## Testing store-only paths

`kAppStoreBuild` stays a compile-time const, so the code is still statically dead in a real store build. Call sites read `isAppStoreBuild` = `kAppStoreBuild || (debugAppStoreBuild ?? false)` — the `||` still folds to `true` under `--dart-define=APP_STORE=true`, but tests can flip the override. This mirrors the existing `UpdateInstaller.debugInstallRootWritable` seam.

31 new tests: connections 404/405/501 → no error and card collapsed, 500/502 → error still shown, 200 → list and empty state intact; the update entry points proven to be no-ops with state untouched (a real HTTP call would flip `checkedOnce` either way); banner collapsed; Updates page stripped; Updates and Developer sections hidden in both layouts; MCP server with a positive control (binds when available) and the gate (port stays free when not).

## Verification

- `flutter analyze --no-fatal-infos` — 2 issues, both the pre-existing `unintended_html_in_doc_comment` infos in `packages/accordkit`.
- `flutter test` — 1161 passing, 0 failing.
- `scripts/codegen.sh --check` — clean.

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)