### PR TITLE
fix(ui): stop an iPad reading as an unfinished build

### DIFF
--- a/lib/features/authentication/views/accord_login.dart
+++ b/lib/features/authentication/views/accord_login.dart
@@ -353,7 +353,10 @@ class _AccordLoginScreenState extends ConsumerState<AccordLoginScreen> {
               ? () => context.push('/switcher')
               : null,
         ),
-        maxWidth: 480,
+        // Wide enough for the welcome screen's three-up highlights on a tablet
+        // or desktop canvas; it collapses itself back to a phone layout below
+        // `kWelcomeWideBreakpoint` (#292).
+        maxWidth: 760,
       ),
       _LoggedOutView.browse => _BrowseView(
         onBack: _goBack,
@@ -635,17 +638,12 @@ class _BrowseView extends StatelessWidget {
                 ],
               ),
             ),
+            // The connect-by-URL / host-your-own footer lives inside
+            // [AccordDiscoveryBody] so the dialog variant gets it too (#292).
             Expanded(
               child: AccordDiscoveryBody(
                 onJoinRequiresAuth: onJoinRequiresAuth,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
-              child: TextButton.icon(
-                onPressed: onManualConnect,
-                icon: const Icon(Icons.link, size: 18),
-                label: const Text('Connect to a server by URL'),
+                onManualConnect: onManualConnect,
               ),
             ),
           ],

--- a/lib/features/authentication/views/welcome_view.dart
+++ b/lib/features/authentication/views/welcome_view.dart
@@ -1,10 +1,61 @@
+import 'package:bonfire/shared/components/self_hosting_dialog.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:flutter/material.dart';
 
-/// First-run / signed-out landing screen: daccord branding, a short pitch, and
-/// the primary path into the public server browser. The Flutter port of the
-/// reference client's `welcome_screen`, kept deliberately compact so choosing
-/// a server remains visible on narrow devices.
+/// Width at or above which the welcome screen lays its value props out
+/// three-up. Below it they are dropped entirely so a phone keeps the
+/// "Browse Servers" button above the fold.
+const double kWelcomeWideBreakpoint = 620;
+
+/// What the app actually does, in the order a newcomer cares about. Kept as
+/// data (and public) so a test can assert the pitch stays on screen without
+/// matching prose in the widget tree.
+@immutable
+class WelcomeHighlight {
+  const WelcomeHighlight({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+}
+
+/// Every claim here is a shipped feature — see the feature list in `README.md`.
+const List<WelcomeHighlight> kWelcomeHighlights = <WelcomeHighlight>[
+  WelcomeHighlight(
+    icon: Icons.forum_outlined,
+    title: 'Messaging',
+    body:
+        'Channels, threads, replies, reactions, custom emoji, file sharing and '
+        'search — plus direct messages.',
+  ),
+  WelcomeHighlight(
+    icon: Icons.headset_mic_outlined,
+    title: 'Voice & video',
+    body:
+        'Join a voice channel or call a friend, turn on your camera, and share '
+        'your screen.',
+  ),
+  WelcomeHighlight(
+    icon: Icons.dns_outlined,
+    title: 'Your server',
+    body:
+        'Connect to as many Accord servers as you like, or run your own. No '
+        'ads, no tracking, no paywalls.',
+  ),
+];
+
+/// First-run / signed-out landing screen: daccord branding, a short pitch, what
+/// the app does, and the two ways in — browse the public directory, or run a
+/// server of your own. The Flutter port of the reference client's
+/// `welcome_screen`.
+///
+/// The pitch breathes into a tablet/desktop canvas (three-up highlights above
+/// [kWelcomeWideBreakpoint]) and stays compact on a phone, where the primary
+/// button has to stay above the fold.
 ///
 /// [onBrowse] opens the server browser (the default next step); [onManualConnect]
 /// jumps straight to the connect-by-URL credentials form; [onSwitchAccount], when
@@ -26,59 +77,180 @@ class WelcomeView extends StatelessWidget {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Center(
-          child: Image.asset('assets/images/icon.png', width: 76, height: 76),
-        ),
-        const SizedBox(height: 14),
-        Text(
-          'Daccord',
-          textAlign: TextAlign.center,
-          style: theme.textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          'Choose an Accord community to start messaging, voice, and video on '
-          'infrastructure you control or trust.',
-          textAlign: TextAlign.center,
-          style: theme.textTheme.bodyLarge?.copyWith(color: colors.gray),
-        ),
-        const SizedBox(height: 24),
-        SizedBox(
-          height: 50,
-          child: ElevatedButton.icon(
-            onPressed: onBrowse,
-            icon: const Icon(Icons.explore_outlined, size: 20),
-            label: const Text('Browse Servers'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: colors.primary,
-              foregroundColor: Colors.white,
-              textStyle: theme.textTheme.titleSmall,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final wide = constraints.maxWidth >= kWelcomeWideBreakpoint;
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Image.asset(
+                'assets/images/icon.png',
+                width: wide ? 88 : 76,
+                height: wide ? 88 : 76,
               ),
+            ),
+            const SizedBox(height: 14),
+            Text(
+              'Daccord',
+              textAlign: TextAlign.center,
+              style:
+                  (wide
+                          ? theme.textTheme.headlineMedium
+                          : theme.textTheme.headlineSmall)
+                      ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Choose an Accord community to start messaging, voice, and video on '
+              'infrastructure you control or trust.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge?.copyWith(color: colors.gray),
+            ),
+            // Wide only, deliberately: on a phone the primary button has to
+            // stay above the fold, so the pitch breathes into a tablet or
+            // desktop canvas rather than bloating a 320pt one.
+            if (wide) ...[
+              const SizedBox(height: 28),
+              const _Highlights(),
+              const SizedBox(height: 28),
+            ] else
+              const SizedBox(height: 24),
+            if (wide)
+              Row(
+                children: [
+                  Expanded(child: _browseButton(theme, colors)),
+                  const SizedBox(width: 12),
+                  Expanded(child: _selfHostButton(context, theme, colors)),
+                ],
+              )
+            else
+              _browseButton(theme, colors),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: onManualConnect,
+              child: Text(
+                'Connect directly to a server',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+            if (onSwitchAccount != null)
+              TextButton(
+                onPressed: onSwitchAccount,
+                child: Text(
+                  'Switch account',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            // Narrow: the self-hosting CTA keeps its full button weight but
+            // sits last, so adding it can't push "Browse Servers" or the
+            // connect-by-URL link below the fold on a small phone.
+            if (!wide) ...[
+              const SizedBox(height: 4),
+              _selfHostButton(context, theme, colors),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _browseButton(ThemeData theme, BonfireThemeExtension colors) =>
+      SizedBox(
+        height: 50,
+        child: ElevatedButton.icon(
+          onPressed: onBrowse,
+          icon: const Icon(Icons.explore_outlined, size: 20),
+          label: const Text('Browse Servers'),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colors.primary,
+            foregroundColor: Colors.white,
+            textStyle: theme.textTheme.titleSmall,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
             ),
           ),
         ),
-        const SizedBox(height: 8),
-        TextButton(
-          onPressed: onManualConnect,
-          child: Text(
-            'Connect directly to a server',
-            style: theme.textTheme.bodyMedium,
+      );
+
+  Widget _selfHostButton(
+    BuildContext context,
+    ThemeData theme,
+    BonfireThemeExtension colors,
+  ) => SizedBox(
+    height: 50,
+    child: OutlinedButton.icon(
+      onPressed: () =>
+          showSelfHostingDialog(context, onConnect: onManualConnect),
+      icon: const Icon(Icons.home_work_outlined, size: 20),
+      label: const Text('Run your own server'),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: colors.dirtyWhite,
+        side: BorderSide(color: colors.primary),
+        textStyle: theme.textTheme.titleSmall,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    ),
+  );
+}
+
+class _Highlights extends StatelessWidget {
+  const _Highlights();
+
+  @override
+  Widget build(BuildContext context) {
+    // [IntrinsicHeight] so the three cards share the tallest one's height —
+    // ragged card bottoms are exactly the "unfinished" look this is fixing.
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final highlight in kWelcomeHighlights) ...[
+            if (highlight != kWelcomeHighlights.first)
+              const SizedBox(width: 12),
+            Expanded(child: _HighlightCard(highlight: highlight)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Tablet/desktop: a card per value prop, three across.
+class _HighlightCard extends StatelessWidget {
+  const _HighlightCard({required this.highlight});
+
+  final WelcomeHighlight highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+      decoration: BoxDecoration(
+        color: colors.foreground,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(highlight.icon, size: 22, color: colors.primary),
+          const SizedBox(height: 10),
+          Text(
+            highlight.title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
           ),
-        ),
-        if (onSwitchAccount != null)
-          TextButton(
-            onPressed: onSwitchAccount,
-            child: Text('Switch account', style: theme.textTheme.bodyMedium),
+          const SizedBox(height: 6),
+          Text(
+            highlight.body,
+            style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
           ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/features/onboarding/models/onboarding_step.dart
+++ b/lib/features/onboarding/models/onboarding_step.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/features/spaces/models/home_layout.dart';
 import 'package:flutter/material.dart';
 
 /// A named hook a live widget can publish so the first-launch tour (#175) can
@@ -58,12 +59,16 @@ class OnboardingStep {
 }
 
 /// Below this width `AccordHomeScreen` moves the rail and channel list into a
-/// drawer and the three-pane layout is gone. Mirrors that screen's private
-/// `_wideLayoutBreakpoint` — the tour must not point at a rail that isn't on
-/// screen, so it branches on exactly the same number rather than on
+/// drawer, so the tour has nothing inline to spotlight. Aliases
+/// [kHomeSidebarBreakpoint] — the tour must not point at a rail that isn't on
+/// screen, so it branches on exactly the width that screen does rather than on
 /// `shouldUseDesktopLayout` (which is true for short-but-wide windows where the
 /// panes are still collapsed).
-const double kOnboardingWideBreakpoint = 720;
+///
+/// The wide tour is also correct for `HomeLayoutMode.medium`: the rail, channel
+/// list and composer it spotlights are all inline there — only the member
+/// roster (which the tour never points at) has moved into a drawer.
+const double kOnboardingWideBreakpoint = kHomeSidebarBreakpoint;
 
 /// The walkthrough, adapted to the layout actually on screen.
 ///

--- a/lib/features/server/views/add_server_dialog.dart
+++ b/lib/features/server/views/add_server_dialog.dart
@@ -409,6 +409,8 @@ class _AddServerDialogState extends ConsumerState<_AddServerDialog>
                 children: [
                   _urlTab(theme, colors),
                   AccordDiscoveryBody(
+                    // Connect-by-URL is the tab next door, not another dialog.
+                    onManualConnect: () => _tabs.animateTo(0),
                     onJoinRequiresAuth: (serverUrl, spaceId) {
                       // Stay in this dialog: pre-fill the URL tab for the
                       // listing's instance and join that space once signed in.

--- a/lib/features/spaces/models/home_layout.dart
+++ b/lib/features/spaces/models/home_layout.dart
@@ -1,0 +1,137 @@
+import 'dart:math' as math;
+
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:flutter/foundation.dart';
+
+/// How many of the home screen's three panes fit side by side.
+///
+/// The panes are, left to right: the space rail + channel list, the message
+/// column, and the member roster. Which of them stay on screen is decided from
+/// the *available width* rather than a device breakpoint — see
+/// [resolveHomeLayout].
+enum HomeLayoutMode {
+  /// Rail + channel list + messages + member roster, all inline.
+  wide,
+
+  /// Rail + channel list + messages inline; the member roster moves into the
+  /// end drawer (reachable from the "Members" button in the tab strip).
+  medium,
+
+  /// Only the message column is inline; the rail + channel list live in the
+  /// navigation drawer and the roster in the end drawer.
+  compact,
+}
+
+/// Fixed width of the space rail (`_SpaceRail`).
+const double kSpaceRailWidth = 72;
+
+/// Width of the draggable divider between the channel list and the messages.
+const double kChannelListHandleWidth = 8;
+
+/// Fixed width of the inline member roster (`AccordMemberList`).
+const double kMemberListWidth = 240;
+
+/// The narrowest the message column is allowed to get before a pane is dropped.
+///
+/// Below roughly this width message bodies wrap to a handful of words per line
+/// and the composer placeholder breaks onto two lines — an iPad Air in portrait
+/// (820pt) used to land there, and read as a broken build to App Review (#292).
+/// Everything above it is a pane that must give way first: the member roster,
+/// then the channel list.
+const double kMinMessagePaneWidth = 420;
+
+/// Width at or above which the rail + channel list can sit beside a usable
+/// message column, i.e. the boundary between [HomeLayoutMode.compact] and
+/// [HomeLayoutMode.medium].
+///
+/// Derived from the panes themselves (rail + the *narrowest* the channel list
+/// is allowed to be + the divider + [kMinMessagePaneWidth]) so it can never
+/// drift out of sync with them.
+const double kHomeSidebarBreakpoint =
+    kSpaceRailWidth +
+    AccordSettings.minChannelListWidth +
+    kChannelListHandleWidth +
+    kMinMessagePaneWidth;
+
+/// Width at or above which the member roster can also stay inline, i.e. the
+/// boundary between [HomeLayoutMode.medium] and [HomeLayoutMode.wide].
+const double kHomeMemberListBreakpoint =
+    kHomeSidebarBreakpoint + kMemberListWidth;
+
+/// The resolved home layout for a given available width.
+@immutable
+class HomeLayout {
+  const HomeLayout({required this.mode, required this.channelListWidth});
+
+  final HomeLayoutMode mode;
+
+  /// The width the channel list should actually be rendered at. Equal to the
+  /// user's persisted preference unless honouring it would push the message
+  /// column below [kMinMessagePaneWidth], in which case the list is trimmed
+  /// (never below [AccordSettings.minChannelListWidth]) rather than the whole
+  /// pane being thrown into a drawer. Meaningless in
+  /// [HomeLayoutMode.compact], where the list is a drawer of its own.
+  final double channelListWidth;
+
+  bool get showsSidebarInline => mode != HomeLayoutMode.compact;
+  bool get showsMemberListInline => mode == HomeLayoutMode.wide;
+
+  @override
+  bool operator ==(Object other) =>
+      other is HomeLayout &&
+      other.mode == mode &&
+      other.channelListWidth == channelListWidth;
+
+  @override
+  int get hashCode => Object.hash(mode, channelListWidth);
+
+  @override
+  String toString() => 'HomeLayout($mode, channelList: $channelListWidth)';
+}
+
+/// Picks the home layout for [width], keeping the message column at least
+/// [kMinMessagePaneWidth] wide.
+///
+/// Panes are given up in order of how much the screen needs them: the member
+/// roster first, then the channel list. Before either is dropped the channel
+/// list is squeezed down towards [AccordSettings.minChannelListWidth], so a
+/// user who dragged the divider wide on a large window doesn't get thrown into
+/// the drawer layout when they shrink it.
+///
+/// [preferredChannelListWidth] is the persisted
+/// [AccordSettings.channelListWidth] (or the live drag width).
+HomeLayout resolveHomeLayout({
+  required double width,
+  required double preferredChannelListWidth,
+}) {
+  final mode = width >= kHomeMemberListBreakpoint
+      ? HomeLayoutMode.wide
+      : width >= kHomeSidebarBreakpoint
+      ? HomeLayoutMode.medium
+      : HomeLayoutMode.compact;
+
+  if (mode == HomeLayoutMode.compact) {
+    return HomeLayout(
+      mode: mode,
+      channelListWidth: AccordSettings.minChannelListWidth,
+    );
+  }
+
+  final reserved =
+      kSpaceRailWidth +
+      kChannelListHandleWidth +
+      kMinMessagePaneWidth +
+      (mode == HomeLayoutMode.wide ? kMemberListWidth : 0);
+  final available = math.max(
+    AccordSettings.minChannelListWidth,
+    width - reserved,
+  );
+  final channelListWidth = preferredChannelListWidth
+      .clamp(
+        AccordSettings.minChannelListWidth,
+        AccordSettings.maxChannelListWidth,
+      )
+      .clamp(AccordSettings.minChannelListWidth, available);
+
+  return HomeLayout(mode: mode, channelListWidth: channelListWidth);
+}

--- a/lib/features/spaces/views/accord_discovery.dart
+++ b/lib/features/spaces/views/accord_discovery.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
+import 'package:bonfire/shared/components/self_hosting_dialog.dart';
 import 'package:bonfire/shared/components/ticker_aware_circle_avatar.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/responsive_dialog.dart';
@@ -110,6 +111,12 @@ class _DiscoveryPanel extends StatelessWidget {
             ),
             Expanded(
               child: AccordDiscoveryBody(
+                // The dialog is modal, so hand off to Add-Server rather than
+                // stacking a second dialog on top of this one.
+                onManualConnect: () {
+                  Navigator.of(context).pop();
+                  showAddServerDialog(context);
+                },
                 // When a listing needs auth, close this panel and either defer
                 // to the host (e.g. the login screen pre-fills its form) or fall
                 // back to opening the Add-Server flow pre-targeted at the
@@ -147,12 +154,21 @@ class _DiscoveryPanel extends StatelessWidget {
 /// auth against that instance: [onJoinRequiresAuth] is invoked so the host can
 /// drive the right flow (switch the Add-Server URL tab, or open it fresh).
 class AccordDiscoveryBody extends ConsumerStatefulWidget {
-  const AccordDiscoveryBody({super.key, this.onJoinRequiresAuth});
+  const AccordDiscoveryBody({
+    super.key,
+    this.onJoinRequiresAuth,
+    this.onManualConnect,
+  });
 
   /// Called when joining requires authenticating against `serverUrl` first
   /// (i.e. there is no live connection to that instance yet). `spaceId` is the
   /// directory listing's space to join once connected.
   final void Function(String serverUrl, String spaceId)? onJoinRequiresAuth;
+
+  /// Called by the "Connect to a server by URL" footer. When omitted the footer
+  /// falls back to the Add-Server dialog, which is the right destination
+  /// everywhere except the signed-out login flow (it drives its own form).
+  final VoidCallback? onManualConnect;
 
   @override
   ConsumerState<AccordDiscoveryBody> createState() =>
@@ -367,37 +383,191 @@ class _AccordDiscoveryBodyState extends ConsumerState<AccordDiscoveryBody> {
             ),
           ),
         const SizedBox(height: 8),
-        Expanded(
+        // Above the list, not inside its empty branch: a failed *join* leaves
+        // the one visible listing on screen, and the error has to be visible
+        // alongside it rather than swallowed (#292).
+        if (_error != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: _DirectoryError(message: _error!),
+          ),
+        // [Flexible] + `shrinkWrap`, not [Expanded]: a one-listing directory
+        // should not leave the footer marooned at the bottom of a tablet-sized
+        // void. A long list still fills the space and scrolls under it.
+        Flexible(
           child: listings == null
               ? const LoadingView()
-              : listings.isEmpty
-              ? Center(
-                  child: Text(
-                    _error ?? 'No servers found',
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                )
-              : ListView.separated(
+              : ListView(
+                  shrinkWrap: true,
                   padding: const EdgeInsets.all(12),
-                  itemCount: listings.length,
-                  separatorBuilder: (_, _) => const SizedBox(height: 8),
-                  itemBuilder: (context, index) {
-                    final listing = listings[index];
-                    final id =
-                        listing['space_id']?.toString() ??
-                        listing['id']?.toString() ??
-                        '';
-                    return _DiscoveryCard(
-                      listing: listing,
-                      colors: colors,
-                      theme: theme,
-                      joining: _joining.contains(id),
-                      onJoin: () => _join(listing),
-                    );
-                  },
+                  children: [
+                    if (listings.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: Text(
+                          'No servers found',
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ),
+                    for (final listing in listings)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: _DiscoveryCard(
+                          listing: listing,
+                          colors: colors,
+                          theme: theme,
+                          joining: _joining.contains(
+                            listing['space_id']?.toString() ??
+                                listing['id']?.toString() ??
+                                '',
+                          ),
+                          onJoin: () => _join(listing),
+                        ),
+                      ),
+                    // A one-card directory reads as a broken feature unless we
+                    // say why it is short. Only shown for an unfiltered browse —
+                    // a search that matched nothing is a different story.
+                    if (listings.length <= 2 &&
+                        _query.text.trim().isEmpty &&
+                        _activeTag == null)
+                      const _SparseDirectoryNote(),
+                  ],
                 ),
         ),
+        _ConnectFooter(onManualConnect: _manualConnect),
       ],
+    );
+  }
+
+  void _manualConnect() {
+    final handler = widget.onManualConnect;
+    if (handler != null) {
+      handler();
+    } else {
+      showAddServerDialog(context);
+    }
+  }
+}
+
+/// The directory's error line. Always painted above the results so a failed
+/// join (which leaves the listings on screen) still reports itself.
+class _DirectoryError extends StatelessWidget {
+  const _DirectoryError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(Icons.error_outline, size: 18, color: colors.red),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodyMedium?.copyWith(color: colors.red),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Why an almost-empty public directory is not a broken feature.
+class _SparseDirectoryNote extends StatelessWidget {
+  const _SparseDirectoryNote();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      margin: const EdgeInsets.only(top: 4),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline, size: 18, color: colors.dirtyWhite),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'This list is short on purpose',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Only communities that choose to advertise themselves appear in the '
+            'public directory. Most Accord communities are private or '
+            'self-hosted, so you usually reach them from an invite link, or by '
+            'connecting straight to the server they run.',
+            style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Pinned below the results in every host of [AccordDiscoveryBody]: the two
+/// ways into a server that isn't in the directory. Always visible, so an empty
+/// or one-line directory is never a dead end.
+class _ConnectFooter extends StatelessWidget {
+  const _ConnectFooter({required this.onManualConnect});
+
+  final VoidCallback onManualConnect;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: colors.background)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Not listed here? Any Accord server works.',
+            style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              FilledButton.icon(
+                onPressed: onManualConnect,
+                icon: const Icon(Icons.link, size: 18),
+                label: const Text('Connect to a server by URL'),
+              ),
+              TextButton.icon(
+                onPressed: () =>
+                    showSelfHostingDialog(context, onConnect: onManualConnect),
+                icon: const Icon(Icons.home_work_outlined, size: 18),
+                label: const Text('Host your own'),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -29,6 +29,7 @@ import 'package:bonfire/features/server/models/accord_server.dart';
 import 'package:bonfire/features/server/views/add_server_dialog.dart';
 import 'package:bonfire/features/spaces/controllers/spaces.dart';
 import 'package:bonfire/features/spaces/controllers/role_preview.dart';
+import 'package:bonfire/features/spaces/models/home_layout.dart';
 import 'package:bonfire/features/spaces/models/space_folder.dart';
 import 'package:bonfire/features/spaces/views/role_preview_banner.dart';
 import 'package:bonfire/features/spaces/views/accord_discovery.dart';
@@ -125,10 +126,6 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
   /// Scaffold for the narrow (mobile) layout, so the channel-list drawer and
   /// member-list end-drawer can be opened/closed programmatically.
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  /// Below this width the three panes can't sit side-by-side, so the channel
-  /// list and member list move into drawers (see [build]).
-  static const double _wideLayoutBreakpoint = 720;
 
   @override
   void initState() {
@@ -612,9 +609,22 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
       ),
     );
 
-    final messageArea = Column(
+    // [membersButton] is the escape hatch for the medium layout, where the
+    // roster has been pushed into the end drawer to keep the message column
+    // readable; the wide layout keeps it inline and passes false.
+    Widget messageArea({required bool membersButton}) => Column(
       children: [
-        _TabStrip(onSelect: _selectTab),
+        Row(
+          children: [
+            Expanded(child: _TabStrip(onSelect: _selectTab)),
+            if (membersButton)
+              IconButton(
+                tooltip: 'Members',
+                icon: Icon(Icons.people_alt_outlined, color: colors.dirtyWhite),
+                onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
+              ),
+          ],
+        ),
         Expanded(
           child: MessagePane(
             channel: channels?.firstWhereOrNull((c) => c.id == shownChannelId),
@@ -634,18 +644,28 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
 
     final hasMembers = effectiveSpaceId != null;
 
+    Widget? memberEndDrawer() => hasMembers
+        ? Drawer(
+            width: 260,
+            backgroundColor: colors.background,
+            child: SafeArea(child: AccordMemberList(spaceId: effectiveSpaceId)),
+          )
+        : null;
+
     final body = LayoutBuilder(
       builder: (context, constraints) {
-        final wide = constraints.maxWidth >= _wideLayoutBreakpoint;
-        if (wide) {
-          final savedWidth = ref.watch(
-            settingsControllerProvider.select((s) => s.channelListWidth),
-          );
-          final channelWidth = (_dragChannelWidth ?? savedWidth).clamp(
-            AccordSettings.minChannelListWidth,
-            AccordSettings.maxChannelListWidth,
-          );
-          return Stack(
+        // Panes are kept or dropped by the width they'd leave the message
+        // column, not by a device breakpoint — see [resolveHomeLayout].
+        final savedWidth = ref.watch(
+          settingsControllerProvider.select((s) => s.channelListWidth),
+        );
+        final layout = resolveHomeLayout(
+          width: constraints.maxWidth,
+          preferredChannelListWidth: _dragChannelWidth ?? savedWidth,
+        );
+        if (layout.showsSidebarInline) {
+          final channelWidth = layout.channelListWidth;
+          final panes = Stack(
             children: [
               Row(
                 children: [
@@ -671,13 +691,29 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
                       setState(() => _dragChannelWidth = null);
                     },
                   ),
-                  Expanded(child: messageArea),
-                  if (hasMembers && _memberListVisible)
+                  Expanded(
+                    child: messageArea(
+                      membersButton:
+                          hasMembers && !layout.showsMemberListInline,
+                    ),
+                  ),
+                  if (layout.showsMemberListInline &&
+                      hasMembers &&
+                      _memberListVisible)
                     AccordMemberList(spaceId: effectiveSpaceId),
                 ],
               ),
               pip,
             ],
+          );
+          if (layout.showsMemberListInline) return panes;
+          // Medium: the roster is an end drawer, so this half of the tree needs
+          // its own Scaffold to host it.
+          return Scaffold(
+            key: _scaffoldKey,
+            backgroundColor: colors.background,
+            endDrawer: memberEndDrawer(),
+            body: panes,
           );
         }
         // Narrow: rail + channel list move into a drawer, members into an
@@ -717,15 +753,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
                 ),
               ),
             ),
-            endDrawer: hasMembers
-                ? Drawer(
-                    width: 260,
-                    backgroundColor: colors.background,
-                    child: SafeArea(
-                      child: AccordMemberList(spaceId: effectiveSpaceId),
-                    ),
-                  )
-                : null,
+            endDrawer: memberEndDrawer(),
             body: Stack(
               children: [
                 // Inset the mobile chrome below the OS status bar / nav bar.

--- a/lib/features/voice/views/voice_lobby.dart
+++ b/lib/features/voice/views/voice_lobby.dart
@@ -1,0 +1,343 @@
+import 'package:bonfire/features/channels/controllers/accord_channels.dart';
+import 'package:bonfire/features/member/controllers/accord_members.dart';
+import 'package:bonfire/features/member/utils/member_display.dart';
+import 'package:bonfire/features/member/views/accord_member_avatar.dart';
+import 'package:bonfire/features/user/controllers/accord_users.dart';
+import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:bonfire/features/voice/controllers/voice_states.dart';
+import 'package:bonfire/features/voice/utils/participant_display.dart';
+import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:collection/collection.dart' show IterableExtension;
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The pre-join state: participants already in the channel plus a Join button.
+///
+/// This is what opening a voice channel shows — selecting a channel never
+/// connects (#202), so the lobby is the only thing standing between a stray
+/// click and an audible join. [compact] lays it out as a fixed-height strip
+/// above the chat panel for the narrow layout, where a centred column would
+/// either push the chat off-screen or be pushed off itself.
+class VoiceLobbyBody extends ConsumerWidget {
+  const VoiceLobbyBody({
+    required this.channelId,
+    required this.spaceId,
+    this.channelName,
+    this.compact = false,
+  });
+
+  final String channelId;
+  final String? spaceId;
+
+  /// Titles the pre-join card. Null in the DM-call case, where the header
+  /// already names who is being called.
+  final String? channelName;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = BonfireThemeExtension.of(context);
+    final states = ref.watch(
+      voiceStatesControllerProvider(ref.readActiveServerKey() ?? '').select(
+        (cache) => voiceStatesFor(cache, channelId),
+      ),
+    );
+    final members = spaceId == null
+        ? null
+        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId!));
+    final users = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
+    final cdnUrl = ref.watchCdnUrl();
+
+    // Viewing a lobby while a call is running elsewhere is a normal state now
+    // (clicking channel B no longer drags you out of channel A), so say so
+    // rather than letting the lobby read as "you're in this channel".
+    final (activeChannelId, activeSpaceId) = ref.watch(
+      voiceControllerProvider.select((v) => (v.channelId, v.spaceId)),
+    );
+    final elsewhere = activeChannelId != null && activeChannelId != channelId;
+    String? activeName;
+    if (elsewhere && activeSpaceId != null) {
+      activeName = ref.watch(
+        accordChannelsControllerProvider(ref.readActiveServerKey() ?? '', activeSpaceId).select(
+          (channels) =>
+              channels?.firstWhereOrNull((c) => c.id == activeChannelId)?.name,
+        ),
+      );
+    }
+
+    final avatars = <Widget>[];
+    for (final vs in states) {
+      final display = participantDisplay(
+        vs.userId,
+        members: members,
+        users: users,
+        cdnUrl: cdnUrl,
+      );
+      avatars.add(
+        _LobbyAvatar(
+          name: display.name,
+          avatarUrl: display.avatarUrl,
+          bg: display.color,
+          compact: compact,
+        ),
+      );
+    }
+
+    // A bare "No one is here yet" line over a Join button reads as an
+    // unfinished feature — voice/video/screen share is a headline feature and
+    // has to look like one at rest (#292). Both presentations show the same
+    // pre-join card: the channel it belongs to, who is already in it, the
+    // media state you would join with, and what joining actually does.
+    // [compact] only tightens it so the text chat below still has room.
+    final theme = Theme.of(context);
+    final selfMute = ref.watch(
+      voiceControllerProvider.select((v) => v.selfMute),
+    );
+
+    final joinButton = FilledButton.icon(
+      style: FilledButton.styleFrom(backgroundColor: colors.green),
+      onPressed: spaceId == null
+          ? null
+          : () => ref
+                .read(voiceControllerProvider.notifier)
+                .join(channelId, spaceId!),
+      icon: const Icon(Icons.call),
+      label: const Text('Join Voice'),
+    );
+
+    final note = elsewhere
+        ? Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              activeName == null
+                  ? "You're connected to another voice channel — joining moves you."
+                  : "You're connected to #$activeName — joining moves you.",
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall!.copyWith(color: colors.gray),
+            ),
+          )
+        : null;
+
+    final card = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Icons.volume_up,
+              size: compact ? 18 : 20,
+              color: colors.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                channelName == null || channelName!.isEmpty
+                    ? 'Voice channel'
+                    : channelName!,
+                overflow: TextOverflow.ellipsis,
+                style:
+                    (compact
+                            ? theme.textTheme.titleSmall
+                            : theme.textTheme.titleMedium)
+                        ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          switch (states.length) {
+            0 => "No one is here yet — you'd be the first.",
+            1 => '1 person is in this channel.',
+            _ => '${states.length} people are in this channel.',
+          },
+          style:
+              (compact ? theme.textTheme.bodySmall : theme.textTheme.bodyMedium)
+                  ?.copyWith(color: colors.gray),
+        ),
+        if (states.isNotEmpty) ...[
+          SizedBox(height: compact ? 10 : 18),
+          if (compact)
+            SizedBox(
+              height: 62,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: [
+                  for (final avatar in avatars)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: avatar,
+                    ),
+                ],
+              ),
+            )
+          else
+            Wrap(spacing: 12, runSpacing: 12, children: avatars),
+        ],
+        SizedBox(height: compact ? 10 : 18),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _PreJoinChip(
+              icon: selfMute ? Icons.mic_off : Icons.mic,
+              label: selfMute ? 'Joining muted' : 'Microphone will be live',
+            ),
+            const _PreJoinChip(
+              icon: Icons.videocam_off,
+              label: 'Camera starts off',
+            ),
+            if (!kIsWeb)
+              const _PreJoinChip(
+                icon: Icons.screen_share_outlined,
+                label: 'Screen share available',
+              ),
+          ],
+        ),
+        SizedBox(height: compact ? 10 : 16),
+        Text(
+          compact
+              ? 'Turn your camera on or share a screen once you are in.'
+              : 'Joining connects you to the call. Once in, you can mute, turn '
+                    'your camera on, share a screen, and chat alongside the '
+                    'call — and you stay until you disconnect.',
+          style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+        ),
+        SizedBox(height: compact ? 12 : 20),
+        SizedBox(height: 44, child: joinButton),
+        if (note != null) note,
+        if (!compact) ...[
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => showVoiceSettings(context),
+              icon: const Icon(Icons.settings, size: 18),
+              label: const Text('Voice settings'),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    // Compact: a fixed block above the chat panel, so joining never requires
+    // closing the chat first (#202).
+    if (compact) {
+      return Container(
+        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+        decoration: BoxDecoration(
+          color: colors.foreground,
+          border: Border(
+            bottom: BorderSide(color: colors.background, width: 1),
+          ),
+        ),
+        child: card,
+      );
+    }
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(24, 22, 24, 22),
+            decoration: BoxDecoration(
+              color: colors.foreground,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: card,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One "here is what you'll join with" pill on the pre-join card. Read-only:
+/// the media toggles only take effect once a LiveKit session exists, so the
+/// card reports state rather than pretending to change it.
+class _PreJoinChip extends StatelessWidget {
+  const _PreJoinChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: colors.dirtyWhite),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.labelMedium?.copyWith(color: colors.dirtyWhite),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LobbyAvatar extends StatelessWidget {
+  const _LobbyAvatar({
+    required this.name,
+    required this.avatarUrl,
+    required this.bg,
+    this.compact = false,
+  });
+
+  final String name;
+  final String? avatarUrl;
+  final Color bg;
+
+  /// Smaller, for the narrow layout's participant strip.
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    final initial = accordInitial(name);
+    return SizedBox(
+      width: compact ? 56 : 72,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AccordMemberAvatar(
+            avatarUrl: avatarUrl,
+            initial: initial,
+            radius: compact ? 18 : 24,
+            backgroundColor: bg,
+            initialStyle: TextStyle(fontSize: compact ? 14 : 18),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: Theme.of(
+              context,
+            ).textTheme.labelSmall!.copyWith(color: colors.dirtyWhite),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/voice/views/voice_lobby.dart
+++ b/lib/features/voice/views/voice_lobby.dart
@@ -23,6 +23,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// either push the chat off-screen or be pushed off itself.
 class VoiceLobbyBody extends ConsumerWidget {
   const VoiceLobbyBody({
+    super.key,
     required this.channelId,
     required this.spaceId,
     this.channelName,

--- a/lib/features/voice/views/voice_view.dart
+++ b/lib/features/voice/views/voice_view.dart
@@ -173,7 +173,11 @@ class _VoiceChannelViewState extends ConsumerState<VoiceChannelView> {
                   _spotlightUserId = _spotlightUserId == userId ? null : userId,
             ),
           )
-        : _LobbyBody(channelId: widget.channelId, spaceId: widget.spaceId);
+        : _LobbyBody(
+            channelId: widget.channelId,
+            spaceId: widget.spaceId,
+            channelName: widget.channelName,
+          );
 
     if (!_chatOpen) return primary;
 
@@ -209,6 +213,7 @@ class _VoiceChannelViewState extends ConsumerState<VoiceChannelView> {
             _LobbyBody(
               channelId: widget.channelId,
               spaceId: widget.spaceId,
+              channelName: widget.channelName,
               compact: true,
             ),
             Expanded(child: chat),
@@ -324,11 +329,16 @@ class _LobbyBody extends ConsumerWidget {
   const _LobbyBody({
     required this.channelId,
     required this.spaceId,
+    this.channelName,
     this.compact = false,
   });
 
   final String channelId;
   final String? spaceId;
+
+  /// Titles the pre-join card. Null in the DM-call case, where the header
+  /// already names who is being called.
+  final String? channelName;
   final bool compact;
 
   @override
@@ -380,12 +390,15 @@ class _LobbyBody extends ConsumerWidget {
       );
     }
 
-    final empty = Text(
-      'No one is here yet',
-      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-        color: colors.gray,
-        fontSize: compact ? 12 : null,
-      ),
+    // A bare "No one is here yet" line over a Join button reads as an
+    // unfinished feature — voice/video/screen share is a headline feature and
+    // has to look like one at rest (#292). Both presentations show the same
+    // pre-join card: the channel it belongs to, who is already in it, the
+    // media state you would join with, and what joining actually does.
+    // [compact] only tightens it so the text chat below still has room.
+    final theme = Theme.of(context);
+    final selfMute = ref.watch(
+      voiceControllerProvider.select((v) => v.selfMute),
     );
 
     final joinButton = FilledButton.icon(
@@ -407,52 +420,54 @@ class _LobbyBody extends ConsumerWidget {
                   ? "You're connected to another voice channel — joining moves you."
                   : "You're connected to #$activeName — joining moves you.",
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: colors.gray,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall!.copyWith(color: colors.gray),
             ),
           )
         : null;
 
-    if (!compact) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (states.isEmpty)
-                empty
-              else
-                Wrap(
-                  alignment: WrapAlignment.center,
-                  spacing: 12,
-                  runSpacing: 12,
-                  children: avatars,
-                ),
-              const SizedBox(height: 24),
-              joinButton,
-              if (note != null) note,
-            ],
-          ),
+    final card = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Icons.volume_up,
+              size: compact ? 18 : 20,
+              color: colors.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                channelName == null || channelName!.isEmpty
+                    ? 'Voice channel'
+                    : channelName!,
+                overflow: TextOverflow.ellipsis,
+                style:
+                    (compact
+                            ? theme.textTheme.titleSmall
+                            : theme.textTheme.titleMedium)
+                        ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+          ],
         ),
-      );
-    }
-
-    // Compact strip: a single row of participants (scrolled horizontally when
-    // the channel is busy) over a full-width Join button, both above the chat.
-    return Container(
-      padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
-      decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: colors.foreground, width: 1)),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (states.isEmpty)
-            Center(child: empty)
-          else
+        const SizedBox(height: 4),
+        Text(
+          switch (states.length) {
+            0 => "No one is here yet — you'd be the first.",
+            1 => '1 person is in this channel.',
+            _ => '${states.length} people are in this channel.',
+          },
+          style:
+              (compact ? theme.textTheme.bodySmall : theme.textTheme.bodyMedium)
+                  ?.copyWith(color: colors.gray),
+        ),
+        if (states.isNotEmpty) ...[
+          SizedBox(height: compact ? 10 : 18),
+          if (compact)
             SizedBox(
               height: 62,
               child: ListView(
@@ -465,10 +480,119 @@ class _LobbyBody extends ConsumerWidget {
                     ),
                 ],
               ),
+            )
+          else
+            Wrap(spacing: 12, runSpacing: 12, children: avatars),
+        ],
+        SizedBox(height: compact ? 10 : 18),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _PreJoinChip(
+              icon: selfMute ? Icons.mic_off : Icons.mic,
+              label: selfMute ? 'Joining muted' : 'Microphone will be live',
             ),
-          const SizedBox(height: 10),
-          joinButton,
-          if (note != null) note,
+            const _PreJoinChip(
+              icon: Icons.videocam_off,
+              label: 'Camera starts off',
+            ),
+            if (!kIsWeb)
+              const _PreJoinChip(
+                icon: Icons.screen_share_outlined,
+                label: 'Screen share available',
+              ),
+          ],
+        ),
+        SizedBox(height: compact ? 10 : 16),
+        Text(
+          compact
+              ? 'Turn your camera on or share a screen once you are in.'
+              : 'Joining connects you to the call. Once in, you can mute, turn '
+                    'your camera on, share a screen, and chat alongside the '
+                    'call — and you stay until you disconnect.',
+          style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+        ),
+        SizedBox(height: compact ? 12 : 20),
+        SizedBox(height: 44, child: joinButton),
+        if (note != null) note,
+        if (!compact) ...[
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => showVoiceSettings(context),
+              icon: const Icon(Icons.settings, size: 18),
+              label: const Text('Voice settings'),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    // Compact: a fixed block above the chat panel, so joining never requires
+    // closing the chat first (#202).
+    if (compact) {
+      return Container(
+        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+        decoration: BoxDecoration(
+          color: colors.foreground,
+          border: Border(
+            bottom: BorderSide(color: colors.background, width: 1),
+          ),
+        ),
+        child: card,
+      );
+    }
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(24, 22, 24, 22),
+            decoration: BoxDecoration(
+              color: colors.foreground,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: card,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One "here is what you'll join with" pill on the pre-join card. Read-only:
+/// the media toggles only take effect once a LiveKit session exists, so the
+/// card reports state rather than pretending to change it.
+class _PreJoinChip extends StatelessWidget {
+  const _PreJoinChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: colors.dirtyWhite),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.labelMedium?.copyWith(color: colors.dirtyWhite),
+          ),
         ],
       ),
     );
@@ -562,17 +686,24 @@ class _ConnectedBody extends ConsumerWidget {
     // Rebuild on any room change (track added/removed, speaker changes).
     ref.watch(voiceControllerProvider.select((v) => v.tick));
     final states = ref.watch(
-      voiceStatesControllerProvider(ref.readActiveServerKey() ?? '').select(
-        (cache) => voiceStatesFor(cache, channelId),
-      ),
+      voiceStatesControllerProvider(
+        ref.readActiveServerKey() ?? '',
+      ).select((cache) => voiceStatesFor(cache, channelId)),
     );
     final speaking = ref.watch(
       voiceControllerProvider.select((v) => v.speakingUserIds),
     );
     final members = spaceId == null
         ? null
-        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId!));
-    final users = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
+        : ref.watch(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              spaceId!,
+            ),
+          );
+    final users = ref.watch(
+      accordUsersControllerProvider(ref.readActiveServerKey() ?? ''),
+    );
     final cdnUrl = ref.watchCdnUrl();
     final myId = ref.watchUserId();
     final session = ref.read(voiceControllerProvider.notifier).session;

--- a/lib/features/voice/views/voice_view.dart
+++ b/lib/features/voice/views/voice_view.dart
@@ -3,7 +3,6 @@ import 'dart:async' show unawaited;
 import 'package:accordkit/accordkit.dart'
     show AccordMember, AccordUser, AccordVoiceState;
 import 'package:bonfire/shared/utils/client_access.dart';
-import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/user/controllers/accord_users.dart';
@@ -19,7 +18,7 @@ import 'package:bonfire/features/voice/views/voice_text_panel.dart';
 import 'package:bonfire/shared/components/horizontal_wheel_scroll.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:bonfire/features/member/views/accord_member_avatar.dart';
-import 'package:collection/collection.dart' show IterableExtension;
+import 'package:bonfire/features/voice/views/voice_lobby.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -173,7 +172,7 @@ class _VoiceChannelViewState extends ConsumerState<VoiceChannelView> {
                   _spotlightUserId = _spotlightUserId == userId ? null : userId,
             ),
           )
-        : _LobbyBody(
+        : VoiceLobbyBody(
             channelId: widget.channelId,
             spaceId: widget.spaceId,
             channelName: widget.channelName,
@@ -210,7 +209,7 @@ class _VoiceChannelViewState extends ConsumerState<VoiceChannelView> {
         // closing the chat first (#202).
         return Column(
           children: [
-            _LobbyBody(
+            VoiceLobbyBody(
               channelId: widget.channelId,
               spaceId: widget.spaceId,
               channelName: widget.channelName,
@@ -311,334 +310,6 @@ class _RingingBanner extends StatelessWidget {
                 context,
               ).textTheme.bodyMedium!.copyWith(color: colors.dirtyWhite),
             ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// The pre-join state: participants already in the channel plus a Join button.
-///
-/// This is what opening a voice channel shows — selecting a channel never
-/// connects (#202), so the lobby is the only thing standing between a stray
-/// click and an audible join. [compact] lays it out as a fixed-height strip
-/// above the chat panel for the narrow layout, where a centred column would
-/// either push the chat off-screen or be pushed off itself.
-class _LobbyBody extends ConsumerWidget {
-  const _LobbyBody({
-    required this.channelId,
-    required this.spaceId,
-    this.channelName,
-    this.compact = false,
-  });
-
-  final String channelId;
-  final String? spaceId;
-
-  /// Titles the pre-join card. Null in the DM-call case, where the header
-  /// already names who is being called.
-  final String? channelName;
-  final bool compact;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = BonfireThemeExtension.of(context);
-    final states = ref.watch(
-      voiceStatesControllerProvider(ref.readActiveServerKey() ?? '').select(
-        (cache) => voiceStatesFor(cache, channelId),
-      ),
-    );
-    final members = spaceId == null
-        ? null
-        : ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId!));
-    final users = ref.watch(accordUsersControllerProvider(ref.readActiveServerKey() ?? ''));
-    final cdnUrl = ref.watchCdnUrl();
-
-    // Viewing a lobby while a call is running elsewhere is a normal state now
-    // (clicking channel B no longer drags you out of channel A), so say so
-    // rather than letting the lobby read as "you're in this channel".
-    final (activeChannelId, activeSpaceId) = ref.watch(
-      voiceControllerProvider.select((v) => (v.channelId, v.spaceId)),
-    );
-    final elsewhere = activeChannelId != null && activeChannelId != channelId;
-    String? activeName;
-    if (elsewhere && activeSpaceId != null) {
-      activeName = ref.watch(
-        accordChannelsControllerProvider(ref.readActiveServerKey() ?? '', activeSpaceId).select(
-          (channels) =>
-              channels?.firstWhereOrNull((c) => c.id == activeChannelId)?.name,
-        ),
-      );
-    }
-
-    final avatars = <Widget>[];
-    for (final vs in states) {
-      final display = participantDisplay(
-        vs.userId,
-        members: members,
-        users: users,
-        cdnUrl: cdnUrl,
-      );
-      avatars.add(
-        _LobbyAvatar(
-          name: display.name,
-          avatarUrl: display.avatarUrl,
-          bg: display.color,
-          compact: compact,
-        ),
-      );
-    }
-
-    // A bare "No one is here yet" line over a Join button reads as an
-    // unfinished feature — voice/video/screen share is a headline feature and
-    // has to look like one at rest (#292). Both presentations show the same
-    // pre-join card: the channel it belongs to, who is already in it, the
-    // media state you would join with, and what joining actually does.
-    // [compact] only tightens it so the text chat below still has room.
-    final theme = Theme.of(context);
-    final selfMute = ref.watch(
-      voiceControllerProvider.select((v) => v.selfMute),
-    );
-
-    final joinButton = FilledButton.icon(
-      style: FilledButton.styleFrom(backgroundColor: colors.green),
-      onPressed: spaceId == null
-          ? null
-          : () => ref
-                .read(voiceControllerProvider.notifier)
-                .join(channelId, spaceId!),
-      icon: const Icon(Icons.call),
-      label: const Text('Join Voice'),
-    );
-
-    final note = elsewhere
-        ? Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: Text(
-              activeName == null
-                  ? "You're connected to another voice channel — joining moves you."
-                  : "You're connected to #$activeName — joining moves you.",
-              textAlign: TextAlign.center,
-              style: Theme.of(
-                context,
-              ).textTheme.bodySmall!.copyWith(color: colors.gray),
-            ),
-          )
-        : null;
-
-    final card = Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Row(
-          children: [
-            Icon(
-              Icons.volume_up,
-              size: compact ? 18 : 20,
-              color: colors.primary,
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                channelName == null || channelName!.isEmpty
-                    ? 'Voice channel'
-                    : channelName!,
-                overflow: TextOverflow.ellipsis,
-                style:
-                    (compact
-                            ? theme.textTheme.titleSmall
-                            : theme.textTheme.titleMedium)
-                        ?.copyWith(fontWeight: FontWeight.w700),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 4),
-        Text(
-          switch (states.length) {
-            0 => "No one is here yet — you'd be the first.",
-            1 => '1 person is in this channel.',
-            _ => '${states.length} people are in this channel.',
-          },
-          style:
-              (compact ? theme.textTheme.bodySmall : theme.textTheme.bodyMedium)
-                  ?.copyWith(color: colors.gray),
-        ),
-        if (states.isNotEmpty) ...[
-          SizedBox(height: compact ? 10 : 18),
-          if (compact)
-            SizedBox(
-              height: 62,
-              child: ListView(
-                scrollDirection: Axis.horizontal,
-                children: [
-                  for (final avatar in avatars)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8),
-                      child: avatar,
-                    ),
-                ],
-              ),
-            )
-          else
-            Wrap(spacing: 12, runSpacing: 12, children: avatars),
-        ],
-        SizedBox(height: compact ? 10 : 18),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            _PreJoinChip(
-              icon: selfMute ? Icons.mic_off : Icons.mic,
-              label: selfMute ? 'Joining muted' : 'Microphone will be live',
-            ),
-            const _PreJoinChip(
-              icon: Icons.videocam_off,
-              label: 'Camera starts off',
-            ),
-            if (!kIsWeb)
-              const _PreJoinChip(
-                icon: Icons.screen_share_outlined,
-                label: 'Screen share available',
-              ),
-          ],
-        ),
-        SizedBox(height: compact ? 10 : 16),
-        Text(
-          compact
-              ? 'Turn your camera on or share a screen once you are in.'
-              : 'Joining connects you to the call. Once in, you can mute, turn '
-                    'your camera on, share a screen, and chat alongside the '
-                    'call — and you stay until you disconnect.',
-          style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
-        ),
-        SizedBox(height: compact ? 12 : 20),
-        SizedBox(height: 44, child: joinButton),
-        if (note != null) note,
-        if (!compact) ...[
-          const SizedBox(height: 4),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: () => showVoiceSettings(context),
-              icon: const Icon(Icons.settings, size: 18),
-              label: const Text('Voice settings'),
-            ),
-          ),
-        ],
-      ],
-    );
-
-    // Compact: a fixed block above the chat panel, so joining never requires
-    // closing the chat first (#202).
-    if (compact) {
-      return Container(
-        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
-        decoration: BoxDecoration(
-          color: colors.foreground,
-          border: Border(
-            bottom: BorderSide(color: colors.background, width: 1),
-          ),
-        ),
-        child: card,
-      );
-    }
-
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 460),
-          child: Container(
-            padding: const EdgeInsets.fromLTRB(24, 22, 24, 22),
-            decoration: BoxDecoration(
-              color: colors.foreground,
-              borderRadius: BorderRadius.circular(14),
-            ),
-            child: card,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// One "here is what you'll join with" pill on the pre-join card. Read-only:
-/// the media toggles only take effect once a LiveKit session exists, so the
-/// card reports state rather than pretending to change it.
-class _PreJoinChip extends StatelessWidget {
-  const _PreJoinChip({required this.icon, required this.label});
-
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: colors.background,
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 16, color: colors.dirtyWhite),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: Theme.of(
-              context,
-            ).textTheme.labelMedium?.copyWith(color: colors.dirtyWhite),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LobbyAvatar extends StatelessWidget {
-  const _LobbyAvatar({
-    required this.name,
-    required this.avatarUrl,
-    required this.bg,
-    this.compact = false,
-  });
-
-  final String name;
-  final String? avatarUrl;
-  final Color bg;
-
-  /// Smaller, for the narrow layout's participant strip.
-  final bool compact;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    final initial = accordInitial(name);
-    return SizedBox(
-      width: compact ? 56 : 72,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          AccordMemberAvatar(
-            avatarUrl: avatarUrl,
-            initial: initial,
-            radius: compact ? 18 : 24,
-            backgroundColor: bg,
-            initialStyle: TextStyle(fontSize: compact ? 14 : 18),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            style: Theme.of(
-              context,
-            ).textTheme.labelSmall!.copyWith(color: colors.dirtyWhite),
           ),
         ],
       ),

--- a/lib/shared/components/self_hosting_dialog.dart
+++ b/lib/shared/components/self_hosting_dialog.dart
@@ -1,0 +1,141 @@
+import 'package:bonfire/features/onboarding/views/onboarding_help.dart'
+    show openOnboardingHelpUrl;
+import 'package:bonfire/shared/app_info.dart' show kGithubRepo;
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// The self-hosting guide (desktop tray app vs. a Docker/VPS deployment).
+const String kDaccordSelfHostingUrl =
+    'https://github.com/$kGithubRepo/blob/master/docs/self-hosting/overview.md';
+
+/// Explains the two supported ways to host your own Accord server (the desktop
+/// tray app, or an always-on Docker/VPS deployment) and how you get back into
+/// the client afterwards. Mirrors `docs/self-hosting/overview.md`; the guide
+/// itself is one tap away.
+///
+/// Self-hosting is a headline feature, so it has a presence on both signed-out
+/// surfaces that would otherwise be mostly empty on a tablet — the welcome
+/// screen and the server directory (#292).
+///
+/// [onConnect], when non-null, adds a "Connect by URL" action that closes the
+/// dialog and hands back to the host's connect-by-URL flow.
+Future<void> showSelfHostingDialog(
+  BuildContext context, {
+  VoidCallback? onConnect,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      final theme = Theme.of(dialogContext);
+      final colors = BonfireThemeExtension.of(dialogContext);
+      return AlertDialog(
+        icon: Icon(Icons.home_work_outlined, color: colors.primary),
+        title: const Text('Run your own server'),
+        content: SizedBox(
+          width: 420,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Daccord talks to Accord servers, and anyone can run one. '
+                  'Your community keeps its own accounts, messages, uploads '
+                  'and voice traffic — this app never proxies them.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colors.gray,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const _HostingOption(
+                  icon: Icons.desktop_windows_outlined,
+                  title: 'The Accord desktop app',
+                  body:
+                      'A tray app for Windows, macOS and Linux that bundles '
+                      'the server and voice server and configures itself on '
+                      'first launch. Best for friends and small communities.',
+                ),
+                const SizedBox(height: 12),
+                const _HostingOption(
+                  icon: Icons.dns_outlined,
+                  title: 'A server deployment',
+                  body:
+                      'Run accordserver with Docker on a Linux machine or VPS '
+                      'for an always-on community, with your own domain name '
+                      'and HTTPS.',
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Once it is running, come back here and connect with its URL.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colors.gray,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Close'),
+          ),
+          if (onConnect != null)
+            TextButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                onConnect();
+              },
+              child: const Text('Connect by URL'),
+            ),
+          FilledButton(
+            onPressed: () => openOnboardingHelpUrl(kDaccordSelfHostingUrl),
+            child: const Text('Read the guide'),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+class _HostingOption extends StatelessWidget {
+  const _HostingOption({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = BonfireThemeExtension.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 20, color: colors.dirtyWhite),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Text(
+                body,
+                style: theme.textTheme.bodySmall?.copyWith(color: colors.gray),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/authentication/welcome_view_test.dart
+++ b/test/features/authentication/welcome_view_test.dart
@@ -40,4 +40,60 @@ void main() {
     expect(browsed, isTrue);
     expect(connected, isTrue);
   });
+
+  testWidgets('a tablet canvas gets the pitch and a self-hosting CTA', (
+    tester,
+  ) async {
+    // iPad Air 11" landscape — the device App Review rejected 0.2.16 on (#292).
+    await tester.binding.setSurfaceSize(const Size(1180, 820));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    var connected = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: Scaffold(
+          body: Center(
+            child: SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 760),
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: WelcomeView(
+                    onBrowse: () {},
+                    onManualConnect: () => connected = true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Every value prop is on screen, not just the logo and one sentence.
+    for (final highlight in kWelcomeHighlights) {
+      expect(find.text(highlight.title), findsOneWidget);
+      expect(find.text(highlight.body), findsOneWidget);
+    }
+
+    // The self-hosting CTA carries comparable weight to "Browse Servers": same
+    // height, sitting beside it rather than buried in a text link.
+    final browse = find.widgetWithText(ElevatedButton, 'Browse Servers');
+    final selfHost = find.widgetWithText(OutlinedButton, 'Run your own server');
+    expect(browse, findsOneWidget);
+    expect(selfHost, findsOneWidget);
+    expect(tester.getSize(selfHost).height, tester.getSize(browse).height);
+    expect(tester.getCenter(selfHost).dy, tester.getCenter(browse).dy);
+
+    await tester.tap(selfHost);
+    await tester.pumpAndSettle();
+    expect(find.text('The Accord desktop app'), findsOneWidget);
+    expect(find.text('A server deployment'), findsOneWidget);
+
+    await tester.tap(find.text('Connect by URL'));
+    await tester.pumpAndSettle();
+    expect(connected, isTrue);
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/test/features/spaces/accord_discovery_test.dart
+++ b/test/features/spaces/accord_discovery_test.dart
@@ -25,15 +25,20 @@ Widget _host(AccordDiscoveryBrowse browse) => ProviderScope(
   ),
 );
 
-RestResult _spaces(String name, {List<String> tags = const []}) =>
-    RestResult.success(200, [
-      {
-        'space_id': name.toLowerCase().replaceAll(' ', '-'),
-        'server_url': 'https://accord.example.test',
-        'name': name,
-        'tags': tags,
-      },
-    ]);
+RestResult _spaces(
+  String name, {
+  List<String> tags = const [],
+  String serverUrl = 'https://accord.example.test',
+}) => RestResult.success(200, [
+  {
+    'space_id': name.toLowerCase().replaceAll(' ', '-'),
+    'server_url': serverUrl,
+    'name': name,
+    'tags': tags,
+  },
+]);
+
+const _sparseHeading = 'This list is short on purpose';
 
 void main() {
   testWidgets('an older search cannot replace the latest results', (
@@ -110,4 +115,96 @@ void main() {
     );
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
+
+  testWidgets('a near-empty directory explains itself and offers a way in', (
+    tester,
+  ) async {
+    Future<RestResult> browse({
+      required String masterUrl,
+      required String query,
+      required String tag,
+    }) async => _spaces('Daccord Official');
+
+    await tester.pumpWidget(_host(browse));
+    await tester.pump();
+
+    expect(find.text('Daccord Official'), findsOneWidget);
+    expect(find.text(_sparseHeading), findsOneWidget);
+    expect(find.text('Connect to a server by URL'), findsOneWidget);
+    expect(find.text('Host your own'), findsOneWidget);
+  });
+
+  testWidgets('an empty directory still offers the manual-connect footer', (
+    tester,
+  ) async {
+    Future<RestResult> browse({
+      required String masterUrl,
+      required String query,
+      required String tag,
+    }) async => RestResult.success(200, const []);
+
+    await tester.pumpWidget(_host(browse));
+    await tester.pump();
+
+    expect(find.text('No servers found'), findsOneWidget);
+    expect(find.text(_sparseHeading), findsOneWidget);
+    expect(find.text('Connect to a server by URL'), findsOneWidget);
+  });
+
+  testWidgets('a search that matched nothing is not blamed on the directory', (
+    tester,
+  ) async {
+    Future<RestResult> browse({
+      required String masterUrl,
+      required String query,
+      required String tag,
+    }) async => query.isEmpty
+        ? _spaces('Daccord Official')
+        : RestResult.success(200, const []);
+
+    await tester.pumpWidget(_host(browse));
+    await tester.pump();
+    expect(find.text(_sparseHeading), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'nothing matches this');
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+
+    expect(find.text('No servers found'), findsOneWidget);
+    expect(find.text(_sparseHeading), findsNothing);
+    // The way out of a dead end is still there.
+    expect(find.text('Connect to a server by URL'), findsOneWidget);
+  });
+
+  testWidgets(
+    'a failed join reports itself while the listing stays on screen',
+    (tester) async {
+      // A listing with no server URL fails in `_join` before any network call,
+      // which is exactly the case that used to render nothing at all: the
+      // error was only painted inside the `listings.isEmpty` branch (#292).
+      Future<RestResult> browse({
+        required String masterUrl,
+        required String query,
+        required String tag,
+      }) async => _spaces('Daccord Official', serverUrl: '');
+
+      await tester.pumpWidget(_host(browse));
+      await tester.pump();
+      expect(find.text('Daccord Official'), findsOneWidget);
+      expect(
+        find.text('This listing is missing its server details'),
+        findsNothing,
+      );
+
+      await tester.tap(find.text('Join'));
+      await tester.pump();
+
+      expect(
+        find.text('This listing is missing its server details'),
+        findsOneWidget,
+      );
+      // ...and the listing it applies to is still visible next to it.
+      expect(find.text('Daccord Official'), findsOneWidget);
+    },
+  );
 }

--- a/test/features/spaces/home_layout_test.dart
+++ b/test/features/spaces/home_layout_test.dart
@@ -1,0 +1,120 @@
+import 'package:bonfire/features/onboarding/models/onboarding_step.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/spaces/models/home_layout.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The width the message column actually gets under [layout] at [width].
+double _messagePaneWidth(HomeLayout layout, double width) {
+  if (layout.mode == HomeLayoutMode.compact) return width;
+  return width -
+      kSpaceRailWidth -
+      layout.channelListWidth -
+      kChannelListHandleWidth -
+      (layout.showsMemberListInline ? kMemberListWidth : 0);
+}
+
+HomeLayout _at(
+  double width, {
+  double channelListWidth = AccordSettings.defaultChannelListWidth,
+}) => resolveHomeLayout(
+  width: width,
+  preferredChannelListWidth: channelListWidth,
+);
+
+void main() {
+  group('resolveHomeLayout at the viewports App Review used (#292)', () {
+    test('iPad Air landscape (1180) keeps all three panes', () {
+      final layout = _at(1180);
+      expect(layout.mode, HomeLayoutMode.wide);
+      expect(layout.channelListWidth, AccordSettings.defaultChannelListWidth);
+      expect(_messagePaneWidth(layout, 1180), greaterThan(600));
+    });
+
+    test('iPad Air portrait (820) drops the member list, not the channels', () {
+      final layout = _at(820);
+      expect(layout.mode, HomeLayoutMode.medium);
+      expect(layout.showsSidebarInline, isTrue);
+      expect(layout.showsMemberListInline, isFalse);
+      // The regression: three panes at 820 left the message column (~280)
+      // narrower than the member list it sat next to.
+      expect(_messagePaneWidth(layout, 820), greaterThan(kMemberListWidth));
+    });
+
+    test('iPad 1024x768 landscape keeps all three panes', () {
+      expect(_at(1024).mode, HomeLayoutMode.wide);
+    });
+
+    test('iPad 1024x768 portrait (768) drops the member list', () {
+      final layout = _at(768);
+      expect(layout.mode, HomeLayoutMode.medium);
+      expect(_messagePaneWidth(layout, 768), greaterThan(kMemberListWidth));
+    });
+
+    test('phone (393) uses the drawer layout', () {
+      expect(_at(393).mode, HomeLayoutMode.compact);
+    });
+  });
+
+  group('the message column never falls below its minimum', () {
+    test('across every width that keeps a pane inline', () {
+      for (var width = kHomeSidebarBreakpoint; width <= 2000; width += 1) {
+        for (final preferred in <double>[
+          AccordSettings.minChannelListWidth,
+          AccordSettings.defaultChannelListWidth,
+          AccordSettings.maxChannelListWidth,
+        ]) {
+          final layout = _at(width, channelListWidth: preferred);
+          expect(
+            _messagePaneWidth(layout, width),
+            greaterThanOrEqualTo(kMinMessagePaneWidth),
+            reason: 'width=$width preferredChannelList=$preferred',
+          );
+        }
+      }
+    });
+  });
+
+  group('panes are given up in order', () {
+    test('the member list goes before the channel list', () {
+      expect(_at(kHomeMemberListBreakpoint).mode, HomeLayoutMode.wide);
+      expect(_at(kHomeMemberListBreakpoint - 1).mode, HomeLayoutMode.medium);
+      expect(_at(kHomeSidebarBreakpoint).mode, HomeLayoutMode.medium);
+      expect(_at(kHomeSidebarBreakpoint - 1).mode, HomeLayoutMode.compact);
+    });
+
+    test(
+      'a dragged-wide channel list is squeezed before a pane is dropped',
+      () {
+        // 1000pt with a 420pt channel list would leave 268pt of messages; the
+        // list is trimmed instead of the roster being thrown into a drawer.
+        final layout = _at(1000, channelListWidth: 420);
+        expect(layout.mode, HomeLayoutMode.wide);
+        expect(layout.channelListWidth, lessThan(420));
+        expect(
+          layout.channelListWidth,
+          greaterThanOrEqualTo(AccordSettings.minChannelListWidth),
+        );
+        expect(_messagePaneWidth(layout, 1000), kMinMessagePaneWidth);
+      },
+    );
+
+    test('a preference that already fits is honoured exactly', () {
+      expect(_at(1600, channelListWidth: 380).channelListWidth, 380);
+    });
+
+    test('the preference is clamped to the settings range', () {
+      expect(
+        _at(2000, channelListWidth: 10).channelListWidth,
+        AccordSettings.minChannelListWidth,
+      );
+      expect(
+        _at(2000, channelListWidth: 5000).channelListWidth,
+        AccordSettings.maxChannelListWidth,
+      );
+    });
+  });
+
+  test('the onboarding tour branches on the same width as the panes', () {
+    expect(kOnboardingWideBreakpoint, kHomeSidebarBreakpoint);
+  });
+}


### PR DESCRIPTION
Second of two parts for #292 (App Review guideline 2.2). [#302](https://github.com/DaccordProject/daccord/pull/302) removes the three half-built surfaces; this fixes the layout and empty states an iPad Air reviewer actually looked at. Findings come from running the app in a browser at iPad viewports against the live `chat.daccord.gg`.

**iPad portrait forced a three-pane desktop layout into an unusable message column.** `_wideLayoutBreakpoint = 720` sat just under the iPad Air's 820pt portrait width, so at 820: rail 72 + channel list ~219 + member list 240 left **~280pt for messages** — narrower than the member list. Body text wrapped to three or four words a line and the composer placeholder wrapped onto two. The phone at 393pt looked strictly better because it used the drawer layout.

Replaced with `resolveHomeLayout(width, preferredChannelListWidth)`, a pure function returning wide / medium / compact:

```
kHomeSidebarBreakpoint    = 72 + minChannelListWidth(180) + 8 + 420 = 680
kHomeMemberListBreakpoint = 680 + 240 = 920
```

Derived from the panes rather than from a device width, so the thresholds can't drift from the widths actually rendered, and panes are given up in the order the screen needs them least (roster to the end drawer first, then the channel list). A user who dragged the divider wide gets the list squeezed back toward its minimum rather than thrown into a drawer. 1180 → wide (640pt messages), **820 → medium (520pt)**, 1024 → wide, 768 → medium, 393 → compact. `kOnboardingWideBreakpoint` now aliases `kHomeSidebarBreakpoint`.

**The signed-out funnel was three near-empty screens on a 1180x820 canvas.** Welcome was a logo, one sentence and one button in ~700px of black. Above 620pt it now carries three value-prop cards (claims checked against `README.md`) and a full-weight "Run your own server" button opening a shared `showSelfHostingDialog` describing the two paths from `docs/self-hosting/overview.md`. Phone layout is untouched except that button, placed last so nothing above it moves.

**The directory shows one listing** (`master.daccord.gg` returns `"total":1`) followed by ~570px of black. Sparse unfiltered results now carry an honest "this list is short on purpose" note, and the connect-by-URL / host-your-own footer moved into `AccordDiscoveryBody` so all three hosts get it — including the discovery *dialog*, which had no manual-connect path at all. **Bug fixed:** `_error` was only painted inside the `listings.isEmpty` branch, so a failed Join on the one visible listing rendered nothing.

**A voice channel at rest was a ~60px strip.** Both presentations now render a pre-join card: channel name, participant summary, read-only mic/camera/screen-share chips, what joining does. Worth noting — the voice view's own `_sidePanelBreakpoint = 720` meant an iPad **always** got the compact strip, so fixing only the non-compact branch would have changed nothing on the rejected device. No transport logic touched.

## Verification

- `flutter analyze --no-fatal-infos` — 2 issues, both the pre-existing `unintended_html_in_doc_comment` infos in `packages/accordkit`.
- `flutter test` — 1146 passing, 0 failing (cold and warm runs identical), including 16 new tests.
- `scripts/codegen.sh --check` — clean; no `@riverpod` file touched.
- Screenshots taken at 1180x820, 820x1180, 1024x768 and 393x852 before and after each change.

## Notes

- `AccordDiscoveryBody` gained an `onManualConnect` parameter and an always-rendered footer; all three call sites are updated.
- Left alone deliberately: the Discover Servers *dialog* still reserves its full 600pt height, so a one-listing directory leaves black below the footer inside the dialog frame. Tightening it means unpicking the `Expanded`/`mainAxisSize` chain and risks the long-list case.

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)