### PR TITLE
fix(ui): explain the failures and drop the dead controls guideline 2.2 found

### DIFF
--- a/docs/complexity-audit.md
+++ b/docs/complexity-audit.md
@@ -277,6 +277,13 @@ and the full test suite (431 tests) staying green.
 - **B2 [Δ fix]** — `backgroundConnectionControllerProvider` wired into
   `MainWindow` per its own doc comment; the Android "Background connection"
   settings toggle previously did nothing.
+- **B2 follow-up (#306)** — the settings *toggle* itself was missing:
+  `AccordSettings.backgroundConnection` had a reader and no setter, so the
+  wired-up service was unreachable from the UI. Added
+  `SettingsController.setBackgroundConnection` and a Notifications-section
+  switch, both gated on the new `isBackgroundConnectionAvailable` (Android,
+  non-store) that `BackgroundConnectionController` now shares, so the switch
+  cannot appear where the service does not exist.
 - **F1** — the message-pane cluster (list/row/composer/reactions/attachments/
   mute button) moved out of `spaces/views/` into
   `messaging/views/message_pane/` as one library with `MessagePane` as its

--- a/docs/voice-and-video/voice-channels.md
+++ b/docs/voice-and-video/voice-channels.md
@@ -47,3 +47,5 @@ Click the **Camera** button to share your camera feed. Other participants see yo
 ## Voice Settings
 
 Access voice and video settings from the voice bar settings button or from **App Settings > Voice & Video**. Here you can configure your input/output devices and other audio preferences.
+
+The **Output device** picker is shown on desktop and Android, where the platform can honour an explicit choice. iOS routes call audio itself — use Control Centre, the AirPlay picker, or plug in a headset — so the app does not offer a picker that iOS would ignore.

--- a/lib/features/channels/controllers/muted_channels.dart
+++ b/lib/features/channels/controllers/muted_channels.dart
@@ -3,6 +3,24 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'muted_channels.g.dart';
 
+/// Outcome of [MutedChannelsController.setMuted].
+///
+/// A plain `bool` could not tell "the server rejected it" apart from "another
+/// tap for this channel is still in flight", so every caller had to treat the
+/// in-flight case as a failure — or, as they did, say nothing at all (#306).
+enum MuteResult {
+  /// The server accepted the change; the optimistic state stands.
+  ok,
+
+  /// The server rejected it (or there was no client); the state rolled back and
+  /// the caller must tell the user.
+  failed,
+
+  /// Ignored because the same channel is already being updated. Not a failure —
+  /// the in-flight request still owns the outcome.
+  busy,
+}
+
 /// Server-backed channel mutes for one connected account.
 ///
 /// Both the channel header and context menu use this cache so opening either
@@ -23,8 +41,11 @@ class MutedChannelsController extends _$MutedChannelsController {
 
   /// Optimistically updates [channelId], rolling back when the server rejects
   /// the change. Repeated taps while the same channel is in flight are ignored.
-  Future<bool> setMuted(String channelId, bool muted) async {
-    if (!_updating.add(channelId)) return false;
+  ///
+  /// Returns [MuteResult.failed] when the rollback happened, so the caller can
+  /// say why the toggle sprang back instead of leaving it unexplained.
+  Future<MuteResult> setMuted(String channelId, bool muted) async {
+    if (!_updating.add(channelId)) return MuteResult.busy;
     final previous = state.value ?? const <String>{};
     final wasMuted = previous.contains(channelId);
     final next = {...previous};
@@ -37,16 +58,16 @@ class MutedChannelsController extends _$MutedChannelsController {
           .clientForKey(serverKey);
       if (client == null) {
         _rollback(channelId, wasMuted);
-        return false;
+        return MuteResult.failed;
       }
       final result = muted
           ? await client.channels.mute(channelId)
           : await client.channels.unmute(channelId);
       if (!result.ok) _rollback(channelId, wasMuted);
-      return result.ok;
+      return result.ok ? MuteResult.ok : MuteResult.failed;
     } catch (_) {
       _rollback(channelId, wasMuted);
-      return false;
+      return MuteResult.failed;
     } finally {
       _updating.remove(channelId);
     }

--- a/lib/features/channels/controllers/muted_channels.g.dart
+++ b/lib/features/channels/controllers/muted_channels.g.dart
@@ -64,7 +64,7 @@ final class MutedChannelsControllerProvider
 }
 
 String _$mutedChannelsControllerHash() =>
-    r'479efe0709e0f04aa8225ae33c6b60fdafc9ab86';
+    r'f6c660e096a20220f545602edd8c75bb86372470';
 
 /// Server-backed channel mutes for one connected account.
 ///

--- a/lib/features/channels/utils/toggle_channel_mute.dart
+++ b/lib/features/channels/utils/toggle_channel_mute.dart
@@ -1,0 +1,28 @@
+import 'package:bonfire/features/channels/controllers/muted_channels.dart';
+import 'package:bonfire/shared/utils/rest_result_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Flips [channelId]'s server-side mute and reports a rejection to the user.
+///
+/// The controller updates optimistically and rolls back when the server says
+/// no; without this the switch just sprang back with no explanation (#306).
+/// Shared by the channel header's notification menu and the channel context
+/// menu so both say the same thing. [MuteResult.busy] is deliberately silent —
+/// the request that is still in flight owns the outcome.
+Future<void> toggleChannelMute(
+  BuildContext context,
+  WidgetRef ref, {
+  required String serverKey,
+  required String channelId,
+  required bool muted,
+}) async {
+  final result = await ref
+      .read(mutedChannelsControllerProvider(serverKey).notifier)
+      .setMuted(channelId, !muted);
+  if (result != MuteResult.failed || !context.mounted) return;
+  showInfoSnack(
+    context,
+    muted ? 'Failed to unmute channel' : 'Failed to mute channel',
+  );
+}

--- a/lib/features/channels/views/channel_context_menu.dart
+++ b/lib/features/channels/views/channel_context_menu.dart
@@ -5,6 +5,7 @@ import 'package:bonfire/features/channels/views/channel_management.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/channels/controllers/muted_channels.dart';
 import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
+import 'package:bonfire/features/channels/utils/toggle_channel_mute.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/shared/components/context_menu.dart';
 import 'package:flutter/material.dart';
@@ -84,9 +85,13 @@ Future<void> showChannelContextMenu(
           ? null
           : () {
               if (activeKey != null) {
-                ref
-                    .read(mutedChannelsControllerProvider(activeKey).notifier)
-                    .setMuted(channel.id, !muted);
+                toggleChannelMute(
+                  hostContext,
+                  ref,
+                  serverKey: activeKey,
+                  channelId: channel.id,
+                  muted: muted,
+                );
               }
             },
     ),

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -12,6 +12,7 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/muted_channels.dart';
+import 'package:bonfire/features/channels/utils/toggle_channel_mute.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
 import 'package:bonfire/features/member/utils/permissions.dart';

--- a/lib/features/messaging/views/message_pane/mute_button.dart
+++ b/lib/features/messaging/views/message_pane/mute_button.dart
@@ -77,9 +77,13 @@ class _MuteButton extends ConsumerWidget {
                   AccordSettings.channelNotifNothing,
                 );
           case _NotifAction.toggleMute:
-            ref
-                .read(mutedChannelsControllerProvider(activeKey).notifier)
-                .setMuted(channelId, !muted);
+            toggleChannelMute(
+              context,
+              ref,
+              serverKey: activeKey,
+              channelId: channelId,
+              muted: muted,
+            );
         }
       },
       itemBuilder: (context) => [

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -193,7 +193,13 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     final confirmed = await confirmDeletePost(context, isPost: true);
     if (confirmed != true) return;
     final result = await client.messages.delete(widget.channelId, _root.id);
-    if (!mounted || !result.ok) return;
+    if (!mounted) return;
+    // A rejected delete used to close nothing and say nothing, so the post
+    // looked like it had simply refused to go (#306).
+    if (!result.ok) {
+      showErrorSnack(context, result, prefix: 'Failed to delete post');
+      return;
+    }
     widget.onClose(const ThreadResult.deleted());
   }
 

--- a/lib/features/notifications/controllers/background_connection.dart
+++ b/lib/features/notifications/controllers/background_connection.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:universal_platform/universal_platform.dart';
 
 part 'background_connection.g.dart';
 
@@ -33,7 +32,9 @@ class BackgroundConnectionController extends _$BackgroundConnectionController {
     // without BackgroundConnectionService in their manifest, so never try to start
     // it — that would crash on an undeclared service. Background delivery on Play
     // awaits a server-side push system; the sideload build keeps this feature.
-    if (!UniversalPlatform.isAndroid || kAppStoreBuild) return;
+    // Shared with the settings toggle so the two can never disagree about
+    // whether the feature exists on this build.
+    if (!isBackgroundConnectionAvailable) return;
     final enabled = ref.watch(
       settingsControllerProvider.select((s) => s.backgroundConnection),
     );

--- a/lib/features/notifications/controllers/background_connection.g.dart
+++ b/lib/features/notifications/controllers/background_connection.g.dart
@@ -70,7 +70,7 @@ final class BackgroundConnectionControllerProvider
 }
 
 String _$backgroundConnectionControllerHash() =>
-    r'95f84c977258b1d1ed5f24ab7f6fbc7afb7e1732';
+    r'ec16f3a6ed7db3463654442c4a7f4984ec7f72aa';
 
 /// Starts/stops the Android foreground service (`BackgroundConnectionService`)
 /// that exempts the app process from Android's cached-app freezer while

--- a/lib/features/settings/controllers/settings.dart
+++ b/lib/features/settings/controllers/settings.dart
@@ -107,6 +107,11 @@ class SettingsController extends _$SettingsController {
   void setSuppressEveryone(bool suppress) =>
       _update(state.copyWith(suppressEveryone: suppress));
 
+  /// Turns the Android background-connection foreground service on or off.
+  /// `BackgroundConnectionController` watches this and starts/stops the service.
+  void setBackgroundConnection(bool enabled) =>
+      _update(state.copyWith(backgroundConnection: enabled));
+
   void setSoundsEnabled(bool enabled) =>
       _update(state.copyWith(soundsEnabled: enabled));
 

--- a/lib/features/settings/controllers/settings.g.dart
+++ b/lib/features/settings/controllers/settings.g.dart
@@ -51,7 +51,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'be9474487c6a2a0407da260d77793f71e16004a5';
+    r'cdd178bb927865d5c20146e2a5341d251094da19';
 
 /// Local client preferences (theme, notifications, recent emoji), persisted to
 /// the `accord-settings` Hive box (opened in `setupHive`). Watched by `main`

--- a/lib/features/settings/models/accord_settings.dart
+++ b/lib/features/settings/models/accord_settings.dart
@@ -179,7 +179,8 @@ class AccordSettings {
   /// LiveKit audio capture options. Mirrors `config_voice.gd` `input_device`.
   final String audioInputDeviceId;
 
-  /// Selected speaker/output device ID (empty = system default; desktop only).
+  /// Selected speaker/output device ID (empty = system default). Only offered
+  /// where the platform can honour it — see `canPickAudioOutputDevice`.
   /// Mirrors `config_voice.gd` `output_device`.
   final String audioOutputDeviceId;
 

--- a/lib/features/settings/views/accord_settings_screen.dart
+++ b/lib/features/settings/views/accord_settings_screen.dart
@@ -491,6 +491,20 @@ class _NotificationsSection extends StatelessWidget {
               ? controller.setSuppressEveryone
               : null,
         ),
+        // Android sideload builds only — see [isBackgroundConnectionAvailable].
+        // Without this entry the foreground service could not be turned on at
+        // all, so the whole feature was unreachable from the UI (#306).
+        if (isBackgroundConnectionAvailable)
+          SwitchListTile(
+            key: const Key('background-connection-switch'),
+            title: const Text('Stay connected in the background'),
+            subtitle: const Text(
+              'Keeps notifications arriving while the app is closed. Shows a '
+              'permanent notification and uses more battery.',
+            ),
+            value: settings.backgroundConnection,
+            onChanged: controller.setBackgroundConnection,
+          ),
       ],
     );
   }

--- a/lib/features/spaces/views/accord_home_rail.dart
+++ b/lib/features/spaces/views/accord_home_rail.dart
@@ -460,7 +460,8 @@ class _SpaceRail extends ConsumerWidget {
                   selected: false,
                   cdnUrl: connOf[railSpace.key]?.cdnUrl,
                   serverKey: connOf[railSpace.key]?.serverKey ?? '',
-                  onTap: () {},
+                  // Identification only — the row's action is "Unhide".
+                  onTap: null,
                 ),
                 title: Text(
                   railSpace.space.name,

--- a/lib/features/spaces/views/accord_home_rail_tiles.dart
+++ b/lib/features/spaces/views/accord_home_rail_tiles.dart
@@ -585,7 +585,11 @@ class _SpaceIcon extends ConsumerWidget {
   final AccordSpace space;
   final bool selected;
   final String? cdnUrl;
-  final VoidCallback onTap;
+
+  /// Null where the icon is shown for identification only (the hidden-servers
+  /// sheet, whose row action is its own "Unhide" button) — a no-op `onTap`
+  /// would present the icon as interactive when it isn't (#306).
+  final VoidCallback? onTap;
 
   /// The connection that owns this space, so the unread badge reads that
   /// server's read state (snowflakes collide across servers).

--- a/lib/features/user/views/accord_direct_messages_friends.dart
+++ b/lib/features/user/views/accord_direct_messages_friends.dart
@@ -37,38 +37,52 @@ class _FriendsTabState extends ConsumerState<_FriendsTab> {
     setState(() => _relationships = relationships);
   }
 
+  /// Runs a relationship mutation and reports a rejection in [_error] (rendered
+  /// as an [InlineError] under the list) rather than leaving the row unchanged
+  /// with no explanation (#306). Clears any previous message on the way in, so
+  /// a retry that works doesn't leave a stale complaint on screen.
+  Future<void> _mutate(
+    Future<RestResult> Function() op,
+    String failureFallback,
+  ) async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final result = await op();
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      _error = result.ok ? null : result.errorMessageOr(failureFallback);
+    });
+    if (result.ok) await _load();
+  }
+
   Future<void> _accept(String userId) async {
     final client = _client;
     if (client == null) return;
-    setState(() => _busy = true);
-    final result = await client.users.putRelationship(userId, {
-      'type': _Rel.friend,
-    });
-    if (!mounted) return;
-    setState(() => _busy = false);
-    if (result.ok) await _load();
+    await _mutate(
+      () => client.users.putRelationship(userId, {'type': _Rel.friend}),
+      'Could not accept that friend request.',
+    );
   }
 
   Future<void> _remove(String userId) async {
     final client = _client;
     if (client == null) return;
-    setState(() => _busy = true);
-    final result = await client.users.deleteRelationship(userId);
-    if (!mounted) return;
-    setState(() => _busy = false);
-    if (result.ok) await _load();
+    await _mutate(
+      () => client.users.deleteRelationship(userId),
+      'Could not remove that relationship.',
+    );
   }
 
   Future<void> _block(String userId) async {
     final client = _client;
     if (client == null) return;
-    setState(() => _busy = true);
-    final result = await client.users.putRelationship(userId, {
-      'type': _Rel.blocked,
-    });
-    if (!mounted) return;
-    setState(() => _busy = false);
-    if (result.ok) await _load();
+    await _mutate(
+      () => client.users.putRelationship(userId, {'type': _Rel.blocked}),
+      'Could not block that user.',
+    );
   }
 
   Future<void> _addFriend() async {

--- a/lib/features/voice/services/voice_session.dart
+++ b/lib/features/voice/services/voice_session.dart
@@ -457,7 +457,9 @@ class VoiceSession {
     });
   }
 
-  /// Switches the speaker/output device (desktop only; empty = default).
+  /// Switches the speaker/output device (empty = default). Only meaningful
+  /// where `canPickAudioOutputDevice` is true — i.e. everywhere but iOS and
+  /// web, which is where the settings page offers the picker.
   Future<void> setAudioOutputDevice(String deviceId) =>
       _applyOutputDevice(deviceId);
 

--- a/lib/features/voice/utils/audio_output_support.dart
+++ b/lib/features/voice/utils/audio_output_support.dart
@@ -1,0 +1,36 @@
+/// Which platforms can actually honour an explicit speaker/output-device
+/// choice, so the Voice & Video page only offers the control where it does
+/// something.
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// Forces [canPickAudioOutputDevice] in tests, which cannot pretend to run on
+/// another platform. Null in production. Mirrors `debugAppStoreBuild`.
+@visibleForTesting
+bool? debugCanPickAudioOutputDevice;
+
+/// Whether this platform supports choosing the audio output device.
+///
+/// The output-device picker is backed by `rtc.Helper.selectAudioOutput`
+/// (`VoiceSession.setAudioOutputDevice`), and what that call *is* differs by
+/// platform:
+///
+/// * **Desktop** — a real device switch (`RTCAudioDeviceModule.setOutputDevice`
+///   on macOS, the equivalent on Windows/Linux). LiveKit's own
+///   `Hardware.selectAudioOutput` is desktop-only for exactly this reason.
+/// * **Android** — also real: enumeration returns `AudioSwitchManager` type
+///   names and `selectAudioOutput` takes the same names back, so earpiece /
+///   speaker / wired / Bluetooth all round-trip.
+/// * **iOS** — neither. Enumeration only ever returns the route already in use
+///   (plus a synthetic "Speaker" entry), and the write degrades to
+///   `AVAudioSession.overrideOutputAudioPort`, which understands nothing but
+///   that one literal `"Speaker"` id. So the dropdown could never offer a
+///   device you were not already on, and picking "System default" wrote
+///   nothing at all — a control that looked functional and did nothing (#306).
+///   iOS owns output routing itself (Control Centre, the AirPlay picker, plugging
+///   in a headset), so there is no capability to expose here.
+/// * **Web** — `setSinkId` is not wired through this path at all.
+bool get canPickAudioOutputDevice =>
+    debugCanPickAudioOutputDevice ??
+    (!kIsWeb && defaultTargetPlatform != TargetPlatform.iOS);

--- a/lib/features/voice/views/voice_settings_screen.dart
+++ b/lib/features/voice/views/voice_settings_screen.dart
@@ -4,9 +4,9 @@ import 'package:bonfire/shared/components/section_header.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
 import 'package:bonfire/features/voice/utils/afk_logic.dart';
+import 'package:bonfire/features/voice/utils/audio_output_support.dart';
 import 'package:bonfire/features/voice/views/mic_level_meter.dart';
 import 'package:bonfire/theme/theme.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:livekit_client/livekit_client.dart';
@@ -116,9 +116,10 @@ class _VoiceSettingsScreenState extends ConsumerState<VoiceSettingsScreen> {
             onChanged: controller.setInputSensitivity,
           ),
           const Divider(height: 24),
-          if (!kIsWeb) ...[
+          if (canPickAudioOutputDevice) ...[
             SectionHeader('Output device'),
             _DeviceDropdown(
+              key: const Key('audio-output-dropdown'),
               devices: _audioOutputs,
               loading: _loadingDevices,
               selectedId: settings.audioOutputDeviceId,
@@ -299,6 +300,7 @@ class _VoiceSettingsScreenState extends ConsumerState<VoiceSettingsScreen> {
 /// A device picker with a leading "System default" option (empty id).
 class _DeviceDropdown extends StatelessWidget {
   const _DeviceDropdown({
+    super.key,
     required this.devices,
     required this.loading,
     required this.selectedId,

--- a/lib/shared/app_info.dart
+++ b/lib/shared/app_info.dart
@@ -75,6 +75,25 @@ bool get isDeveloperModeAvailable =>
     debugDeveloperModeAvailable ??
     (!isAppStoreBuild && UniversalPlatform.isDesktop);
 
+/// Overrides [isBackgroundConnectionAvailable] in tests, which can neither set
+/// a `--dart-define` nor pretend to run on another platform. Null in
+/// production.
+@visibleForTesting
+bool? debugBackgroundConnectionAvailable;
+
+/// Whether the Android background-connection foreground service may be offered
+/// at all — the single source of truth shared by the settings toggle and
+/// `BackgroundConnectionController`, so the switch can never be shown where
+/// flipping it does nothing.
+///
+/// Android-only (nothing else has a cached-app freezer to escape), and never in
+/// a store build: the Play AAB (`--flavor play` + `APP_STORE=true`) ships
+/// without `BackgroundConnectionService` in its manifest, so starting it would
+/// crash.
+bool get isBackgroundConnectionAvailable =>
+    debugBackgroundConnectionAvailable ??
+    (!isAppStoreBuild && UniversalPlatform.isAndroid);
+
 /// `owner/repo` whose GitHub Releases drive the in-app update checker. This is
 /// the Flutter client's own repository (the reference client checks its own
 /// Godot repo). See [kGithubLatestReleaseUrl].

--- a/test/features/channels/muted_channels_controller_test.dart
+++ b/test/features/channels/muted_channels_controller_test.dart
@@ -76,7 +76,7 @@ void main() {
     expect(container.read(provider).value, {'existing', 'new'});
     release.complete();
 
-    expect(await update, isFalse);
+    expect(await update, MuteResult.failed);
     expect(container.read(provider).value, {'existing'});
   });
 
@@ -101,10 +101,10 @@ void main() {
 
     final first = notifier.setMuted('channel', true);
     await started.future;
-    expect(await notifier.setMuted('channel', true), isFalse);
+    expect(await notifier.setMuted('channel', true), MuteResult.busy);
     expect(updateCalls, 1);
     release.complete();
 
-    expect(await first, isTrue);
+    expect(await first, MuteResult.ok);
   });
 }

--- a/test/features/channels/toggle_channel_mute_test.dart
+++ b/test/features/channels/toggle_channel_mute_test.dart
@@ -1,0 +1,100 @@
+import 'package:bonfire/features/channels/controllers/muted_channels.dart';
+import 'package:bonfire/features/channels/utils/toggle_channel_mute.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A rejected mute used to roll the optimistic toggle back in silence — the
+/// switch sprang and nothing said why (#306). Both surfaces that toggle a mute
+/// (the channel header's notification menu, the channel context menu) now go
+/// through [toggleChannelMute], so these lock the reporting in one place.
+
+/// Returns a fixed [MuteResult] instead of talking to a server, and records the
+/// arguments it was called with.
+class _FakeMutedChannels extends MutedChannelsController {
+  _FakeMutedChannels(this._result);
+
+  final MuteResult _result;
+  final List<(String, bool)> calls = [];
+
+  @override
+  Future<Set<String>> build(String serverKey) async => const {};
+
+  @override
+  Future<MuteResult> setMuted(String channelId, bool muted) async {
+    calls.add((channelId, muted));
+    return _result;
+  }
+}
+
+Future<_FakeMutedChannels> _tapToggle(
+  WidgetTester tester,
+  MuteResult result, {
+  bool muted = false,
+}) async {
+  final fake = _FakeMutedChannels(result);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        mutedChannelsControllerProvider('server').overrideWith(() => fake),
+      ],
+      child: MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) => TextButton(
+              onPressed: () => toggleChannelMute(
+                context,
+                ref,
+                serverKey: 'server',
+                channelId: 'c1',
+                muted: muted,
+              ),
+              child: const Text('toggle'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('toggle'));
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+void main() {
+  testWidgets('a rejected mute says so instead of just springing back', (
+    tester,
+  ) async {
+    final fake = await _tapToggle(tester, MuteResult.failed);
+
+    expect(fake.calls, [('c1', true)]);
+    expect(find.text('Failed to mute channel'), findsOneWidget);
+  });
+
+  testWidgets('a rejected unmute names the direction it failed in', (
+    tester,
+  ) async {
+    final fake = await _tapToggle(tester, MuteResult.failed, muted: true);
+
+    expect(fake.calls, [('c1', false)]);
+    expect(find.text('Failed to unmute channel'), findsOneWidget);
+  });
+
+  testWidgets('a successful mute stays quiet', (tester) async {
+    await _tapToggle(tester, MuteResult.ok);
+
+    expect(find.byType(SnackBar), findsNothing);
+  });
+
+  testWidgets('a repeat tap while one is in flight is not an error', (
+    tester,
+  ) async {
+    // MuteResult.busy means the earlier request still owns the outcome;
+    // reporting it would be a false alarm.
+    await _tapToggle(tester, MuteResult.busy);
+
+    expect(find.byType(SnackBar), findsNothing);
+  });
+}

--- a/test/features/messaging/thread_delete_error_test.dart
+++ b/test/features/messaging/thread_delete_error_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/views/thread_view.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Deleting a forum post whose DELETE the server refuses used to do nothing at
+/// all — the dialog stayed open, the post stayed put, and nothing said why
+/// (#306).
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+final _root = AccordMessage(
+  id: 'm1',
+  channelId: 'c1',
+  authorId: 'u1',
+  content: 'the post body',
+  title: 'A post',
+);
+
+/// Answers replies with an empty list and the post's DELETE with
+/// [deleteStatus].
+Widget _host({
+  required int deleteStatus,
+  required List<ThreadResult?> closes,
+}) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final client = AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient((request) async {
+      if (request.method == 'DELETE') {
+        return http.Response(
+          jsonEncode({'message': 'post is locked'}),
+          deleteStatus,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      return http.Response(
+        jsonEncode({'data': <Object>[]}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }),
+  );
+  addTearDown(client.dispose);
+
+  return ProviderScope(
+    overrides: [
+      accordAuthProvider.overrideWithValue(
+        AccordAuthLoggedIn(
+          client: client,
+          session: AccordSession(
+            server: server,
+            token: 'test-token',
+            userId: 'u1',
+            username: 'me',
+          ),
+        ),
+      ),
+      settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+    ],
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      home: Scaffold(
+        body: AccordThreadPane(
+          channelId: 'c1',
+          spaceId: null,
+          root: _root,
+          canManageMessages: true,
+          onClose: closes.add,
+        ),
+      ),
+    ),
+  );
+}
+
+/// Long-presses the root post, picks Delete, and confirms.
+Future<void> _deleteRoot(WidgetTester tester) async {
+  // The row is keyed by message id; its body is markdown, not a plain Text.
+  await tester.longPress(find.byKey(const ValueKey('m1')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Delete'));
+  await tester.pumpAndSettle();
+  // The confirmation dialog's own Delete button.
+  await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a refused post delete says why and keeps the thread open', (
+    tester,
+  ) async {
+    final closes = <ThreadResult?>[];
+    await tester.pumpWidget(_host(deleteStatus: 403, closes: closes));
+    await tester.pumpAndSettle();
+
+    await _deleteRoot(tester);
+
+    expect(find.textContaining('Failed to delete post'), findsOneWidget);
+    expect(closes, isEmpty);
+  });
+
+  testWidgets('an accepted delete closes the thread without complaint', (
+    tester,
+  ) async {
+    final closes = <ThreadResult?>[];
+    await tester.pumpWidget(_host(deleteStatus: 200, closes: closes));
+    await tester.pumpAndSettle();
+
+    await _deleteRoot(tester);
+
+    expect(find.textContaining('Failed to delete post'), findsNothing);
+    expect(closes.length, 1);
+  });
+}

--- a/test/features/settings/background_connection_setting_test.dart
+++ b/test/features/settings/background_connection_setting_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/settings/views/accord_settings_screen.dart';
+import 'package:bonfire/shared/app_info.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+/// `AccordSettings.backgroundConnection` drives the Android foreground service
+/// that keeps the gateway alive while the app is backgrounded, but it had a
+/// reader and no setter, so nothing in the UI could ever turn it on (#306).
+/// These cover the setter's persistence, the settings entry, and the platform
+/// gate the entry shares with `BackgroundConnectionController`.
+
+const _switch = Key('background-connection-switch');
+
+/// Keeps the screen off Hive — a Hive write inside a `testWidgets` fake-async
+/// zone never settles, so persistence is covered by the plain test below.
+class _MemorySettingsController extends SettingsController {
+  final List<bool> backgroundWrites = [];
+
+  @override
+  AccordSettings build() => const AccordSettings();
+
+  @override
+  void setBackgroundConnection(bool enabled) {
+    backgroundWrites.add(enabled);
+    state = state.copyWith(backgroundConnection: enabled);
+  }
+}
+
+/// A viewport tall enough to lay the whole (lazy) settings list out at once, so
+/// a `findsNothing` means absent rather than merely unbuilt.
+Future<_MemorySettingsController> _pumpTall(WidgetTester tester) async {
+  final settings = _MemorySettingsController();
+  tester.view.physicalSize = const Size(600, 8000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [settingsControllerProvider.overrideWith(() => settings)],
+      child: MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: const AccordSettingsScreen(),
+      ),
+    ),
+  );
+  await tester.pump();
+  return settings;
+}
+
+void main() {
+  tearDown(() => debugBackgroundConnectionAvailable = null);
+
+  group('the setter that was missing', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('accord-bgconn-test');
+      Hive.init(tempDir.path);
+      await Hive.openBox('accord-settings');
+    });
+
+    tearDown(() async {
+      await Hive.deleteBoxFromDisk('accord-settings');
+      await Hive.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('setBackgroundConnection persists through the settings box', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(settingsControllerProvider).backgroundConnection,
+        isFalse,
+      );
+      container
+          .read(settingsControllerProvider.notifier)
+          .setBackgroundConnection(true);
+
+      expect(
+        container.read(settingsControllerProvider).backgroundConnection,
+        isTrue,
+      );
+      // Read it back the way a restart would, not just the in-memory state.
+      expect(
+        Hive.box('accord-settings').get('settings'),
+        containsPair('backgroundConnection', true),
+      );
+    });
+  });
+
+  testWidgets('the toggle is offered where the service exists, and writes', (
+    tester,
+  ) async {
+    debugBackgroundConnectionAvailable = true;
+    final settings = await _pumpTall(tester);
+
+    expect(find.byKey(_switch), findsOneWidget);
+    expect(tester.widget<SwitchListTile>(find.byKey(_switch)).value, isFalse);
+
+    await tester.tap(find.byKey(_switch));
+    await tester.pump();
+
+    expect(settings.backgroundWrites, [true]);
+    expect(tester.widget<SwitchListTile>(find.byKey(_switch)).value, isTrue);
+  });
+
+  testWidgets('the toggle is hidden where the service cannot run', (
+    tester,
+  ) async {
+    // Non-Android, or a store build whose manifest omits the service.
+    debugBackgroundConnectionAvailable = false;
+    await _pumpTall(tester);
+
+    expect(find.byKey(_switch), findsNothing);
+    // The rest of the Notifications section is unaffected.
+    expect(find.text('Enable notifications'), findsOneWidget);
+  });
+}

--- a/test/features/user/friends_action_error_test.dart
+++ b/test/features/user/friends_action_error_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Accept / decline / remove / block on the Friends tab used to fail in
+/// complete silence: the row simply stayed as it was. The `_error` banner the
+/// tab already rendered was never assigned to (#306). These pin it down.
+
+class _FakeSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+class _FakeDmChannels extends DmChannelsController {
+  @override
+  List<AccordChannel>? build(String serverKey) => const [];
+}
+
+http.Response _json(Object body, [int status = 200]) => http.Response(
+  jsonEncode(body),
+  status,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Serves one incoming friend request and answers every mutation with
+/// [mutationStatus] / [mutationMessage].
+ProviderContainer _container({
+  required int mutationStatus,
+  String? mutationMessage,
+}) {
+  final server = AccordServer.fromBaseUrl('https://accord.example.test');
+  final client = AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: server.baseUrl,
+    gatewayUrl: server.gatewayUrl,
+    cdnUrl: server.cdnUrl,
+    httpClient: MockClient((request) async {
+      if (request.method == 'GET') {
+        return _json({
+          'data': [
+            {
+              'id': 'r1',
+              'type': 3, // pending incoming
+              'user': {'id': 'u2', 'username': 'bob'},
+            },
+          ],
+        });
+      }
+      return _json({
+        if (mutationMessage != null) 'message': mutationMessage,
+      }, mutationStatus);
+    }),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      accordAuthProvider.overrideWithValue(
+        AccordAuthLoggedIn(
+          client: client,
+          session: AccordSession(
+            server: server,
+            token: 'test-token',
+            userId: 'u1',
+            username: 'me',
+          ),
+        ),
+      ),
+      settingsControllerProvider.overrideWith(_FakeSettingsController.new),
+      dmChannelsControllerProvider('').overrideWith(_FakeDmChannels.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  addTearDown(client.dispose);
+  return container;
+}
+
+/// Opens the DM dialog and switches to the Friends tab.
+Future<void> _openFriends(WidgetTester tester, ProviderContainer container) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildAppTheme(AppThemePreset.dark),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showAccordDirectMessages(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Friends'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a rejected accept reports the server\'s reason', (tester) async {
+    final container = _container(
+      mutationStatus: 403,
+      mutationMessage: 'That user is not accepting friend requests',
+    );
+    await _openFriends(tester, container);
+    expect(find.text('bob'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Accept'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('That user is not accepting friend requests'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a rejected decline falls back to our own wording', (
+    tester,
+  ) async {
+    // A failure the server gave no words for.
+    final container = _container(mutationStatus: 500, mutationMessage: '');
+    await _openFriends(tester, container);
+
+    await tester.tap(find.byTooltip('Decline'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not remove that relationship.'), findsOneWidget);
+  });
+
+  testWidgets('a successful action leaves no error behind', (tester) async {
+    final container = _container(mutationStatus: 200);
+    await _openFriends(tester, container);
+
+    await tester.tap(find.byTooltip('Accept'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Could not'), findsNothing);
+  });
+}

--- a/test/features/voice/voice_settings_screen_test.dart
+++ b/test/features/voice/voice_settings_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:bonfire/features/voice/utils/audio_output_support.dart';
 import 'package:bonfire/features/voice/views/voice_settings_screen.dart';
 import 'package:bonfire/theme/app_theme.dart';
 import 'package:flutter/material.dart';
@@ -36,7 +37,46 @@ Widget _host(AccordSettings settings) => ProviderScope(
   ),
 );
 
+/// Lays the whole (lazy) list out at once so a `findsNothing` means the control
+/// is absent rather than merely unbuilt.
+Future<void> _pumpTall(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(600, 6000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(_host(const AccordSettings()));
+  await tester.pump();
+}
+
 void main() {
+  group('output device picker (#306)', () {
+    tearDown(() => debugCanPickAudioOutputDevice = null);
+
+    testWidgets('is offered where the platform can honour the choice', (
+      tester,
+    ) async {
+      debugCanPickAudioOutputDevice = true;
+      await _pumpTall(tester);
+
+      expect(find.text('OUTPUT DEVICE'), findsOneWidget);
+      expect(find.byKey(const Key('audio-output-dropdown')), findsOneWidget);
+    });
+
+    testWidgets('is not offered where the write would be swallowed (iOS)', (
+      tester,
+    ) async {
+      debugCanPickAudioOutputDevice = false;
+      await _pumpTall(tester);
+
+      expect(find.text('OUTPUT DEVICE'), findsNothing);
+      expect(find.byKey(const Key('audio-output-dropdown')), findsNothing);
+      // The rest of the voice stack is untouched — only the one dead control
+      // goes, never the feature.
+      expect(find.text('INPUT DEVICE'), findsOneWidget);
+      expect(find.text('Output volume'), findsOneWidget);
+      expect(find.text('CAMERA'), findsOneWidget);
+    });
+  });
+
   testWidgets('screen-share quality is its own section, labelled apart from '
       'the camera', (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
Second half of #306, completing it. [#307](https://github.com/DaccordProject/daccord/pull/307) covered the data layer; this covers the controls. Apple's 2.2 wording was "complete, remove, or fully configure any partially implemented features" — these are the leftovers of that class.

## Three optimistic actions that reverted silently

All now report through the mechanisms already used nearby (`showInfoSnack` / `showErrorSnack` / `InlineError`), keeping the optimistic update and rollback unchanged.

- **Channel mute.** `setMuted` returned a `bool` that conflated "server rejected" with "another tap is still in flight", so naively reporting failure would have raised a false alarm on a double-tap. It now returns `MuteResult { ok, failed, busy }`, and a shared `toggleChannelMute()` snacks on `failed` only. Both call sites go through it so the wording can't drift.
- **Friends accept / remove / block.** The `_error` field was declared *and rendered* but never assigned — dead reporting machinery sitting right there. A `_mutate()` helper now sets it from the server's own message where there is one, and clears it on the way in so a successful retry doesn't leave a stale complaint.
- **Thread / post delete.** `if (!mounted || !result.ok) return;` became a real error, with the thread left open.

## Three dead controls

**Hidden-servers icon (`onTap: () {}`) — affordance removed.** The only plausible meaning of a tap is "select this space", and selecting a hidden space *is* unhiding it, which the row already offers as an explicit Unhide button one widget away. `_SpaceIcon.onTap` is now nullable and the sheet passes `null`, so the icon is identification only.

**iOS audio-output picker — not offered on iOS, kept everywhere it works.** Checked the stack rather than assuming: on desktop `selectAudioOutput` is a real `setOutputDevice`; on **Android** it round-trips `AudioSwitchManager` names and genuinely switches earpiece/speaker/wired/Bluetooth; on **iOS** it degrades to `overrideOutputAudioPort`, which recognises nothing but the literal id `"Speaker"`, and `enumerateDevices` returns only the route already in use plus a synthetic Speaker entry — so the picker could never offer a device you weren't already on, and "System default" was dropped entirely. LiveKit's own `Hardware.selectAudioOutput` refuses off-desktop for the same reason. iOS owns routing via Control Centre / AirPlay / headset.

Per CLAUDE.md, voice must not be stubbed or hidden — **no capability was removed**. Input device, volumes, sensitivity, mic test, AFK, camera and screen share are untouched on every platform, and the picker still ships on desktop and Android. What's gone is a control that never worked on the one platform it was removed from.

**`backgroundConnection` — made reachable.** The service works and is wired into `MainWindow` and the `github` flavor's manifest; only the setter and the UI entry were missing. Added `setBackgroundConnection` and a "Stay connected in the background" switch, both gated on a new `isBackgroundConnectionAvailable` (Android && !store) that `BackgroundConnectionController` now uses too — so the toggle can't appear on a Play build whose manifest omits the service, and the two gates can't drift.

## Verification

Run from the repository root after the final edit:

- `flutter analyze --no-fatal-infos` — identical to master run back-to-back under the same conditions; no new issues.
- `flutter test` — **1233 passing**, 0 failing (1219 baseline + 14 new).
- `scripts/codegen.sh --check` — generated files match committed output, verified from a cold `.dart_tool/build`.

Docs updated: `docs/voice-and-video/voice-channels.md`, and `docs/complexity-audit.md`, whose B2 entry described a toggle that did not exist.

## Known gap

The hidden-servers icon has no dedicated widget test. `_SpaceIcon` and the sheet are private to the `accord_home.dart` `part` library, the repo has no harness that pumps the real rail (`mobile_pop_scope_test` and `drawer_swipe_area_test` both use hand-built replicas), and extracting the icon would ripple through five other call sites. The change removes a callback and adds no behaviour, so the only assertable property is the absence of a handler — which the nullable type enforces at the call site.

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)