### PR TITLE
ci(ios): publish the signed .ipa as a dispatchable artifact

### DIFF
--- a/.github/workflows/ios-ipa.yml
+++ b/.github/workflows/ios-ipa.yml
@@ -120,10 +120,16 @@ jobs:
         # it the Settings → Updates entry is present, and a self-updater on
         # camera invites the guideline 2.2 finding back.
         shell: bash
+        env:
+          # Routed through env rather than interpolated into the script below —
+          # a workflow_dispatch input is attacker-influenceable by whoever can
+          # dispatch the workflow, and untrusted expressions must never be
+          # spliced directly into a run: block (see the website-rebuild job in
+          # release.yml for the same reasoning).
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
           BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/^version:[[:space:]]*//; s/[-+].*//')
-          BUILD_NUMBER="${{ inputs.build_number }}"
-          BUILD_NUMBER="${BUILD_NUMBER:-${{ github.run_number }}}"
+          BUILD_NUMBER="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
           echo "Marketing version: $BUILD_NAME (build $BUILD_NUMBER)"
           flutter build ios --release --no-codesign \
             --build-name="$BUILD_NAME" \

--- a/.github/workflows/ios-ipa.yml
+++ b/.github/workflows/ios-ipa.yml
@@ -1,0 +1,146 @@
+# On-demand signed iOS .ipa, as a downloadable artifact.
+#
+# The release lane hands its .ipa straight to App Store Connect inside fastlane
+# (`fastlane ios appstore`), so the file never leaves the runner and no release
+# asset carries it — every published asset is Android/desktop/web. That leaves
+# nothing to install when the app has to be filmed on hardware nobody in the
+# project owns: guideline 1.2 asks for the UGC precautions recorded on a
+# physical device (#293), and both routes to one — TestFlight to a borrowed
+# phone, or a device farm that resigns uploaded apps — need a binary in hand.
+#
+# This runs the same build and the same signing as the release job and stops
+# before delivery, so what you install is what Apple reviews. It is
+# workflow_dispatch only, uploads nothing to Apple, and touches no release
+# state.
+#
+# Secrets: the signing set only (APPLE_DIST_CERT_P12, CERT_P12_PASSWORD,
+# IOS_PROFILE_BASE64, IOS_PROFILE_NAME, APPLE_TEAM_ID). No App Store Connect
+# API key — the :ipa lane never talks to their API.
+name: iOS .ipa artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'CFBundleVersion. Leave empty to use the run number.'
+        required: false
+        default: ''
+
+env:
+  # Keep in sync with ci.yml / release.yml / .fvmrc.
+  FLUTTER_CHANNEL: beta
+  PUB_CACHE: ${{ github.workspace }}/.pub-cache
+
+jobs:
+  ipa:
+    name: Signed .ipa
+    runs-on: macos-15
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Select latest stable Xcode
+        # The same selection the release job makes, so this signs against the
+        # SDK the reviewed binary is built against.
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache pub + native deps
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
+      - name: Cache CocoaPods
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cocoapods
+            ~/Library/Caches/CocoaPods
+          key: pods-${{ runner.os }}-${{ hashFiles('pubspec.lock', 'packages/livekit_client/**/*.podspec') }}
+          restore-keys: |
+            pods-${{ runner.os }}-
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Install dependencies
+        # Retried for the same reason the release job retries it: `pub get`
+        # fetches git dependencies, and a reset connection there is transient.
+        shell: bash
+        run: |
+          set -uo pipefail
+          n=0
+          max=3
+          until flutter pub get; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "::error::flutter pub get failed after $max attempts" >&2
+              exit 1
+            fi
+            echo "::warning::flutter pub get attempt $n failed; retrying in $((n * 15))s"
+            sleep $((n * 15))
+          done
+
+      - name: Update CocoaPods spec repo
+        run: pod repo update
+
+      - name: Code generation (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Import Apple Distribution certificate
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DIST_CERT_P12 }}
+          p12-password: ${{ secrets.CERT_P12_PASSWORD }}
+
+      - name: Install provisioning profile
+        env:
+          PROFILE_B64: ${{ secrets.IOS_PROFILE_BASE64 }}
+        run: |
+          DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$DIR"
+          echo "$PROFILE_B64" | base64 --decode > "$DIR/daccord_ios_appstore.mobileprovision"
+
+      - name: Build iOS (Flutter, unsigned)
+        # APP_STORE=true for the same reason the release job sets it: without
+        # it the Settings → Updates entry is present, and a self-updater on
+        # camera invites the guideline 2.2 finding back.
+        shell: bash
+        run: |
+          BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/^version:[[:space:]]*//; s/[-+].*//')
+          BUILD_NUMBER="${{ inputs.build_number }}"
+          BUILD_NUMBER="${BUILD_NUMBER:-${{ github.run_number }}}"
+          echo "Marketing version: $BUILD_NAME (build $BUILD_NUMBER)"
+          flutter build ios --release --no-codesign \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --dart-define=APP_STORE=true
+
+      - name: Archive, sign & export
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_BUNDLE_ID: com.cattrall.daccord
+          IOS_PROFILE_NAME: ${{ secrets.IOS_PROFILE_NAME }}
+        run: bundle exec fastlane ios ipa
+
+      - name: Upload the .ipa
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daccord-ios-ipa
+          path: build/appstore/Daccord-iOS.ipa
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -299,6 +299,29 @@ reviewer seeing the self-updater in a recording invites the 2.2 finding back
 the phone or tablet this recording is captured on, regardless of this flag —
 still build with it set, since the store lane always does.
 
+**No Mac, and no device? Get the .ipa out of CI.** `flutter run` needs both.
+The release lane hands its `.ipa` to App Store Connect from inside fastlane, so
+no release asset carries one — dispatch **iOS .ipa artifact**
+(`.github/workflows/ios-ipa.yml`) instead. It runs the same build and the same
+signing as `ios-appstore` and stops before delivery (`fastlane ios ipa`), then
+uploads `Daccord-iOS.ipa` as a run artifact, so what you install is what Apple
+reviews, already built with `APP_STORE=true`. Two ways to get it onto hardware:
+
+- **TestFlight to a borrowed phone.** Any iPhone will do, and the person
+  holding it only has to follow the shot list — Control Centre's Screen
+  Recording produces exactly the file Apple wants.
+- **A real-device cloud** (BrowserStack App Live, Sauce Labs, AWS Device Farm).
+  These are physical phones and their session video is downloadable. Upload the
+  same `.ipa`: they resign it with their own profile. The device sits in their
+  datacentre, so the Accord server has to be reachable from it — a public
+  instance you control, or the vendor's local-tunnel binary.
+
+A simulator recording is *not* a substitute: Apple asked for a physical device.
+The nearest fallback, if neither route is open, is a capture from
+`.github/workflows/ios-simulator.yml` (which already boots a simulator and can
+`xcrun simctl io <udid> recordVideo`) with the reply saying plainly that it is
+a simulator — expect to be asked again.
+
 **Reset first.** Terms acceptance is stored device-globally and keyed by
 `appTermsVersion` (`lib/features/authentication/utils/terms_acceptance.dart`), so
 an install that has already accepted will skip the gate. **Delete the app and

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -223,6 +223,37 @@ def force_manual_signing(project, profile_name, identity: "Apple Distribution")
   )
 end
 
+# Archive, sign and export the App Store .ipa, and return an absolute path to
+# it. Shared by the two iOS lanes so the binary that gets installed for a
+# screen recording is the one Apple reviews, signed the same way.
+def build_appstore_ipa
+  profile = ENV.fetch("IOS_PROFILE_NAME")
+  force_manual_signing("ios/Runner.xcodeproj", profile)
+  ipa = build_app(
+    workspace: "ios/Runner.xcworkspace",
+    scheme: "Runner",
+    configuration: "Release",
+    export_method: "app-store",
+    output_directory: "build/appstore",
+    output_name: "Daccord-iOS.ipa",
+    clean: false, # Flutter already produced the build; don't nuke it.
+    export_options: {
+      provisioningProfiles: { ENV.fetch("APP_BUNDLE_ID") => profile },
+      teamID: ENV.fetch("APPLE_TEAM_ID"),
+      signingStyle: "manual",
+    },
+  )
+  # gym may return a workspace-relative path while its analyser runs from the
+  # fastlane directory. Resolve the path against the checkout before the
+  # review-state preflight opens the IPA.
+  ipa ||= Fastlane::Actions.lane_context[
+    Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH
+  ] || "build/appstore/Daccord-iOS.ipa"
+  ipa = File.expand_path(ipa, ENV.fetch("GITHUB_WORKSPACE", Dir.pwd))
+  UI.user_error!("No .ipa produced by gym (got #{ipa.inspect})") unless File.exist?(ipa)
+  ipa
+end
+
 platform :android do
   desc "Upload the release App Bundle (.aab) to Google Play"
   # The workflow builds a signed AAB with `flutter build appbundle` and writes
@@ -301,34 +332,22 @@ platform :ios do
   # TestFlight, because every App Store build does.
   lane :appstore do
     api_key = asc_api_key
-    profile = ENV.fetch("IOS_PROFILE_NAME")
-    force_manual_signing("ios/Runner.xcodeproj", profile)
-    ipa = build_app(
-      workspace: "ios/Runner.xcworkspace",
-      scheme: "Runner",
-      configuration: "Release",
-      export_method: "app-store",
-      output_directory: "build/appstore",
-      output_name: "Daccord-iOS.ipa",
-      clean: false, # Flutter already produced the build; don't nuke it.
-      export_options: {
-        provisioningProfiles: { ENV.fetch("APP_BUNDLE_ID") => profile },
-        teamID: ENV.fetch("APPLE_TEAM_ID"),
-        signingStyle: "manual",
-      },
-    )
-    # gym may return a workspace-relative path while its analyser runs from the
-    # fastlane directory. Resolve the path against the checkout before the
-    # review-state preflight opens the IPA.
-    ipa ||= lane_context[SharedValues::IPA_OUTPUT_PATH] || "build/appstore/Daccord-iOS.ipa"
-    ipa = File.expand_path(ipa, ENV.fetch("GITHUB_WORKSPACE", Dir.pwd))
-    UI.user_error!("No .ipa produced by gym (got #{ipa.inspect})") unless File.exist?(ipa)
     submit_release(
       api_key: api_key,
       platform: "ios",
       metadata_path: "fastlane/metadata/ios",
-      ipa: ipa,
+      ipa: build_appstore_ipa,
     )
+  end
+
+  desc "Build and sign the App Store .ipa, stopping before it is uploaded"
+  # The same binary :appstore submits, left on disk instead of delivered, so it
+  # can be installed somewhere the guideline 1.2 precautions can be filmed on
+  # hardware — a borrowed phone over TestFlight, or a device farm that resigns
+  # uploaded apps (#293). Deliberately never calls asc_api_key: nothing here
+  # talks to App Store Connect, so it needs the signing secrets alone.
+  lane :ipa do
+    UI.success("Built #{build_appstore_ipa}")
   end
 end
 


### PR DESCRIPTION
The 1.2 recording has to come from a physical device, and there is no device
here. Both routes to one — TestFlight to a borrowed phone, or a real-device
cloud (BrowserStack App Live and friends resign whatever you upload) — need an
`.ipa`, and the project has never produced a downloadable one: `fastlane ios
appstore` passes its build straight to `submit_release` inside the lane, so the
file dies with the runner, and every release asset is Android, desktop or web.

- `build_appstore_ipa` — the archive/sign/export half of the `:appstore` lane,
  lifted verbatim including the gym path resolution, returning the same
  absolute path the lane already computed. Both lanes now build the identical
  binary, so what gets installed for the recording is what Apple reviews.
- `ios ipa` — the same build, stopping before delivery. Never calls
  `asc_api_key`; it needs the signing secrets alone.
- `.github/workflows/ios-ipa.yml` — `workflow_dispatch` only, mirrors the
  `ios-appstore` steps up to the archive, builds with `--dart-define=APP_STORE=true`
  as the store lane does, and uploads `Daccord-iOS.ipa` as a run artifact
  (14-day retention). Uploads nothing to Apple and touches no release state.

`workflow_dispatch` only fires for workflows on the default branch, so this has
to land before it can be run.

Refs #293