### PR TITLE
Simplify message and voice caches and remove unused helpers

### DIFF
--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -315,10 +315,9 @@ class AccordMessagesController extends _$AccordMessagesController {
   /// Appends a newly-received message, ignoring duplicates (e.g. the gateway
   /// echo of a message we just sent).
   void addMessage(AccordMessage message) {
-    final current = [...(state ?? const <AccordMessage>[])];
+    final current = state ?? const <AccordMessage>[];
     if (current.any((m) => m.id == message.id)) return;
-    current.add(message);
-    state = current;
+    state = [...current, message];
   }
 
   void updateMessage(AccordMessage message) {
@@ -329,7 +328,7 @@ class AccordMessagesController extends _$AccordMessagesController {
   void removeMessage(String messageId) {
     final current = state;
     if (current == null) return;
-    state = current.where((m) => m.id != messageId).toList();
+    state = current.removeById(messageId, (m) => m.id);
   }
 
   // ── Reactions ──────────────────────────────────────────────────────────────

--- a/lib/features/messaging/controllers/accord_messages.g.dart
+++ b/lib/features/messaging/controllers/accord_messages.g.dart
@@ -72,7 +72,7 @@ final class AccordMessagesControllerProvider
 }
 
 String _$accordMessagesControllerHash() =>
-    r'67b132d53f317fe1a6408aa94846cabaa08de5ab';
+    r'ebd89fb79e724a904d0360ebfff1338939896cea';
 
 /// A channel's recent message history, keyed by channel ID, ordered
 /// oldest→newest for display. Self-loads via `messages.list` the first time

--- a/lib/features/messaging/controllers/forum_posts.dart
+++ b/lib/features/messaging/controllers/forum_posts.dart
@@ -99,10 +99,9 @@ class ForumPostsController extends _$ForumPostsController {
   /// by id). Replies (`thread_id` set) never belong on the board.
   void addPost(AccordMessage post) {
     if (post.threadId != null) return;
-    final current = [...(state ?? const <AccordMessage>[])];
+    final current = state ?? const <AccordMessage>[];
     if (current.any((m) => m.id == post.id)) return;
-    current.insert(0, post);
-    state = current;
+    state = [post, ...current];
   }
 
   /// Replaces an existing post (edit result / thread-root edit / gateway
@@ -117,6 +116,6 @@ class ForumPostsController extends _$ForumPostsController {
   void removePost(String postId) {
     final current = state;
     if (current == null || !current.any((m) => m.id == postId)) return;
-    state = current.where((m) => m.id != postId).toList();
+    state = current.removeById(postId, (m) => m.id);
   }
 }

--- a/lib/features/messaging/controllers/forum_posts.g.dart
+++ b/lib/features/messaging/controllers/forum_posts.g.dart
@@ -74,7 +74,7 @@ final class ForumPostsControllerProvider
 }
 
 String _$forumPostsControllerHash() =>
-    r'cba3a226b1bc92068dbeff437650975c6024a0e0';
+    r'a96ab9c5cf0e01afae795e871095f9f195e4eb30';
 
 /// A forum channel's top-level posts (thread roots), keyed by channel ID, in
 /// server order (the board sorts for display). Self-loads via

--- a/lib/features/messaging/controllers/thread_replies.dart
+++ b/lib/features/messaging/controllers/thread_replies.dart
@@ -101,10 +101,9 @@ class ThreadRepliesController extends _$ThreadRepliesController {
   /// (e.g. the gateway echo of a reply we just sent).
   void addReply(AccordMessage message) {
     if (message.id == rootId) return;
-    final current = [...(state ?? const <AccordMessage>[])];
+    final current = state ?? const <AccordMessage>[];
     if (current.any((m) => m.id == message.id)) return;
-    current.add(message);
-    state = current;
+    state = [...current, message];
   }
 
   /// Replaces an existing reply (edit result / gateway echo); unknown ids are
@@ -120,6 +119,6 @@ class ThreadRepliesController extends _$ThreadRepliesController {
   void removeReply(String messageId) {
     final current = state;
     if (current == null || !current.any((m) => m.id == messageId)) return;
-    state = current.where((m) => m.id != messageId).toList();
+    state = current.removeById(messageId, (m) => m.id);
   }
 }

--- a/lib/features/messaging/controllers/thread_replies.g.dart
+++ b/lib/features/messaging/controllers/thread_replies.g.dart
@@ -75,7 +75,7 @@ final class ThreadRepliesControllerProvider
 }
 
 String _$threadRepliesControllerHash() =>
-    r'93c50331c274f54e798a18975c210aac27e17423';
+    r'ec1f5dc2d10f4ba23d76cacca68103ebfa0ac65d';
 
 /// A thread's replies (excluding the root message), keyed by
 /// (channelId, rootId), ordered oldest→newest as the server returns them.

--- a/lib/features/messaging/utils/attachment_types.dart
+++ b/lib/features/messaging/utils/attachment_types.dart
@@ -126,9 +126,13 @@ const Map<String, AttachmentType> kAttachmentTypes = {
   ),
   'odt': AttachmentType('application/vnd.oasis.opendocument.text', _none),
   'ods': AttachmentType(
-      'application/vnd.oasis.opendocument.spreadsheet', _none),
+    'application/vnd.oasis.opendocument.spreadsheet',
+    _none,
+  ),
   'odp': AttachmentType(
-      'application/vnd.oasis.opendocument.presentation', _none),
+    'application/vnd.oasis.opendocument.presentation',
+    _none,
+  ),
   // ---- Archives ----------------------------------------------------------
   'zip': AttachmentType('application/zip', _none),
   'rar': AttachmentType('application/vnd.rar', _none),
@@ -243,8 +247,7 @@ String? sniffMimeType(List<int>? bytes) {
     return true;
   }
 
-  bool ascii(int offset, String text) =>
-      at(offset, text.codeUnits);
+  bool ascii(int offset, String text) => at(offset, text.codeUnits);
 
   // Images.
   if (at(0, const [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])) {
@@ -255,10 +258,8 @@ String? sniffMimeType(List<int>? bytes) {
   // "BM" alone is two bytes and would claim any text starting "BMW…", so the
   // header's own little-endian file-size field has to agree with the buffer.
   if (ascii(0, 'BM') && bytes.length >= 6) {
-    final declared = bytes[2] |
-        (bytes[3] << 8) |
-        (bytes[4] << 16) |
-        (bytes[5] << 24);
+    final declared =
+        bytes[2] | (bytes[3] << 8) | (bytes[4] << 16) | (bytes[5] << 24);
     if (declared == bytes.length) return 'image/bmp';
   }
   if (at(0, const [0x49, 0x49, 0x2A, 0x00]) ||
@@ -283,8 +284,12 @@ String? sniffMimeType(List<int>? bytes) {
     if (brand.startsWith('m4a')) return 'audio/mp4';
     if (brand.startsWith('qt')) return 'video/quicktime';
     if (brand.startsWith('3g')) return 'video/3gpp';
-    if (brand.startsWith('heic') || brand.startsWith('heix')) return 'image/heic';
-    if (brand.startsWith('mif1') || brand.startsWith('msf1')) return 'image/heif';
+    if (brand.startsWith('heic') || brand.startsWith('heix')) {
+      return 'image/heic';
+    }
+    if (brand.startsWith('mif1') || brand.startsWith('msf1')) {
+      return 'image/heif';
+    }
     if (brand.startsWith('avif')) return 'image/avif';
     return 'video/mp4';
   }
@@ -369,19 +374,6 @@ String resolveAttachmentMimeType(
   return byExtension ?? kFallbackMimeType;
 }
 
-/// Image MIME types that are real images but that this client has no decoder
-/// for. Kept explicit so the `image/*` catch-all below stays forward-compatible
-/// without re-introducing the broken-image box for these.
-const Set<String> _unrenderableImageMimes = {
-  'image/svg+xml',
-  'image/tiff',
-  'image/avif',
-  'image/heic',
-  'image/heif',
-  'image/x-icon',
-  'image/vnd.adobe.photoshop',
-};
-
 /// How to render an attachment inline, given whatever the server told us.
 ///
 /// [contentType] leads because it survives the filename being sanitised or
@@ -397,11 +389,7 @@ AttachmentPreview attachmentPreviewFor({
     final mime = contentType!.trim().toLowerCase().split(';').first.trim();
     final known = _previewByMime[mime];
     if (known != null) return known;
-    if (mime.startsWith('image/')) {
-      return _unrenderableImageMimes.contains(mime)
-          ? AttachmentPreview.none
-          : AttachmentPreview.image;
-    }
+    if (mime.startsWith('image/')) return AttachmentPreview.image;
     if (mime.startsWith('video/')) return AttachmentPreview.video;
     if (mime.startsWith('audio/')) return AttachmentPreview.audio;
   }
@@ -423,16 +411,10 @@ class PendingAttachment {
     required Uint8List bytes,
     String? path,
     String? platformMimeType,
-  }) =>
-      PendingAttachment(
-        PlatformFile(
-          name: name,
-          size: bytes.length,
-          bytes: bytes,
-          path: path,
-        ),
-        platformMimeType: platformMimeType,
-      );
+  }) => PendingAttachment(
+    PlatformFile(name: name, size: bytes.length, bytes: bytes, path: path),
+    platformMimeType: platformMimeType,
+  );
 
   final PlatformFile file;
 
@@ -465,10 +447,10 @@ class PendingAttachment {
 
   /// The multipart part for `messages.createWithAttachments`.
   Map<String, dynamic> toUploadPart() => {
-        'filename': name,
-        'content': bytes!,
-        'content_type': contentType,
-      };
+    'filename': name,
+    'content': bytes!,
+    'content_type': contentType,
+  };
 }
 
 /// Names a pasted image after sniffing it, instead of assuming PNG.
@@ -478,8 +460,9 @@ class PendingAttachment {
 /// JPEG called `.png` is a mislabelled file on every client that receives it.
 String pastedImageFilename(List<int> bytes, {DateTime? now}) {
   final mime = sniffMimeType(bytes);
-  final extension =
-      mime == null ? 'png' : (extensionForMimeType(mime) ?? 'png');
+  final extension = mime == null
+      ? 'png'
+      : (extensionForMimeType(mime) ?? 'png');
   final stamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
   return 'pasted-$stamp.$extension';
 }

--- a/lib/features/voice/controllers/voice_states.dart
+++ b/lib/features/voice/controllers/voice_states.dart
@@ -3,9 +3,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'voice_states.g.dart';
 
-/// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-/// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-/// `Array` per channel; a nested map here makes user moves/removals O(1)).
+/// Per-server cache of who is in which voice channel, keyed `channel_id →
+/// {user_id → state}`. User moves scan channels and copy only affected buckets.
 ///
 /// Seeded from the gateway READY payload's voice states and from
 /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -21,21 +20,23 @@ class VoiceStatesController extends _$VoiceStatesController {
   /// and, when [vs.channelId] is non-null, inserts them into that channel.
   void upsert(AccordVoiceState vs) {
     if (vs.userId.isEmpty) return;
-    final next = {
-      for (final entry in state.entries) entry.key: {...entry.value},
-    };
-    // Drop the user from every channel they might currently be in.
-    for (final bucket in next.values) {
-      bucket.remove(vs.userId);
-    }
     final channelId = vs.channelId;
-    if (channelId != null && channelId.isNotEmpty) {
-      (next[channelId] ??= <String, AccordVoiceState>{})[vs.userId] = vs;
+    final next = <String, Map<String, AccordVoiceState>>{};
+    for (final entry in state.entries) {
+      var bucket = entry.value;
+      final isDestination = entry.key == channelId && entry.key.isNotEmpty;
+      if (bucket.containsKey(vs.userId) || isDestination) {
+        bucket = {...bucket}..remove(vs.userId);
+        if (isDestination) bucket[vs.userId] = vs;
+      }
+      if (bucket.isNotEmpty) next[entry.key] = bucket;
     }
-    state = {
-      for (final entry in next.entries)
-        if (entry.value.isNotEmpty) entry.key: entry.value,
-    };
+    if (channelId != null &&
+        channelId.isNotEmpty &&
+        !next.containsKey(channelId)) {
+      next[channelId] = {vs.userId: vs};
+    }
+    state = next;
   }
 
   /// Replaces the full set of states for [channelId] (used to seed a channel
@@ -76,12 +77,10 @@ class VoiceStatesController extends _$VoiceStatesController {
 List<AccordVoiceState> voiceStatesFor(
   Map<String, Map<String, AccordVoiceState>> cache,
   String channelId,
-) =>
-    cache[channelId]?.values.toList() ?? const [];
+) => cache[channelId]?.values.toList() ?? const [];
 
 /// How many users are currently in [channelId]'s voice.
 int voiceUserCount(
   Map<String, Map<String, AccordVoiceState>> cache,
   String channelId,
-) =>
-    cache[channelId]?.length ?? 0;
+) => cache[channelId]?.length ?? 0;

--- a/lib/features/voice/controllers/voice_states.g.dart
+++ b/lib/features/voice/controllers/voice_states.g.dart
@@ -8,9 +8,8 @@ part of 'voice_states.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-/// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-/// `Array` per channel; a nested map here makes user moves/removals O(1)).
+/// Per-server cache of who is in which voice channel, keyed `channel_id →
+/// {user_id → state}`. User moves scan channels and copy only affected buckets.
 ///
 /// Seeded from the gateway READY payload's voice states and from
 /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -20,9 +19,8 @@ part of 'voice_states.dart';
 @ProviderFor(VoiceStatesController)
 const voiceStatesControllerProvider = VoiceStatesControllerFamily._();
 
-/// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-/// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-/// `Array` per channel; a nested map here makes user moves/removals O(1)).
+/// Per-server cache of who is in which voice channel, keyed `channel_id →
+/// {user_id → state}`. User moves scan channels and copy only affected buckets.
 ///
 /// Seeded from the gateway READY payload's voice states and from
 /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -34,9 +32,8 @@ final class VoiceStatesControllerProvider
           VoiceStatesController,
           Map<String, Map<String, AccordVoiceState>>
         > {
-  /// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-  /// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-  /// `Array` per channel; a nested map here makes user moves/removals O(1)).
+  /// Per-server cache of who is in which voice channel, keyed `channel_id →
+  /// {user_id → state}`. User moves scan channels and copy only affected buckets.
   ///
   /// Seeded from the gateway READY payload's voice states and from
   /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -88,11 +85,10 @@ final class VoiceStatesControllerProvider
 }
 
 String _$voiceStatesControllerHash() =>
-    r'4ef41d5e68b3300356e7f6c380f3c0352ffbf420';
+    r'6c7f0dac2cb0a090a49395dcb93f4553fbf55591';
 
-/// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-/// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-/// `Array` per channel; a nested map here makes user moves/removals O(1)).
+/// Per-server cache of who is in which voice channel, keyed `channel_id →
+/// {user_id → state}`. User moves scan channels and copy only affected buckets.
 ///
 /// Seeded from the gateway READY payload's voice states and from
 /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -117,9 +113,8 @@ final class VoiceStatesControllerFamily extends $Family
         isAutoDispose: false,
       );
 
-  /// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-  /// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-  /// `Array` per channel; a nested map here makes user moves/removals O(1)).
+  /// Per-server cache of who is in which voice channel, keyed `channel_id →
+  /// {user_id → state}`. User moves scan channels and copy only affected buckets.
   ///
   /// Seeded from the gateway READY payload's voice states and from
   /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`
@@ -133,9 +128,8 @@ final class VoiceStatesControllerFamily extends $Family
   String toString() => r'voiceStatesControllerProvider';
 }
 
-/// Global cache of who is in which voice channel, keyed `channel_id → {user_id
-/// → state}`. Mirrors the reference client's `_voice_state_cache` (there an
-/// `Array` per channel; a nested map here makes user moves/removals O(1)).
+/// Per-server cache of who is in which voice channel, keyed `channel_id →
+/// {user_id → state}`. User moves scan channels and copy only affected buckets.
 ///
 /// Seeded from the gateway READY payload's voice states and from
 /// `channels.fetchVoiceStates`, then kept in sync by `voice.state_update`

--- a/lib/features/voice/services/voice_session.dart
+++ b/lib/features/voice/services/voice_session.dart
@@ -71,7 +71,6 @@ class VoiceSession {
   Room? get room => _room;
   VoiceSessionState get state => _state;
   String? get lastError => _lastError;
-  bool get isDeafened => _deafened;
 
   LocalParticipant? get localParticipant => _room?.localParticipant;
 

--- a/lib/shared/utils/client_access.dart
+++ b/lib/shared/utils/client_access.dart
@@ -19,13 +19,8 @@ String? _homeDomainFromState(AccordAuthState s) =>
 bool _isAdminFromState(AccordAuthState s) =>
     s is AccordAuthLoggedIn && s.session.isAdmin;
 
-/// The currently authenticated [AccordClient], or `null` when logged out.
-///
-/// Centralizes the `accordAuthProvider.select(...)` lookup that was otherwise
-/// copy-pasted into ~20 `ConsumerState` getters across the app. The
-/// `watch*`/`read*` pairs cover the same authenticated-session fields (user id,
-/// CDN base, instance-admin flag) that were likewise inlined at ~40 sites; use
-/// the `watch*` variant in `build`/widgets and the `read*` variant in callbacks.
+/// Active client and session access for widgets.
+/// Use `watch*` in builds and `read*` in callbacks.
 extension AccordClientWidgetRef on WidgetRef {
   AccordClient? get accordClient =>
       read(accordAuthProvider.select(_clientFromState));
@@ -49,7 +44,7 @@ extension AccordClientWidgetRef on WidgetRef {
   bool readIsAdmin() => read(accordAuthProvider.select(_isAdminFromState));
 }
 
-/// Same as [AccordClientWidgetRef], for provider/notifier `Ref` contexts.
+/// Client access for provider/notifier `Ref` contexts.
 extension AccordClientRef on Ref {
   AccordClient? get accordClient =>
       read(accordAuthProvider.select(_clientFromState));
@@ -57,11 +52,7 @@ extension AccordClientRef on Ref {
   String? readActiveServerKey() =>
       read(connectionsControllerProvider).activeKey;
 
-  /// The currently authenticated client, re-read on every auth change.
-  ///
-  /// Use in a controller `build` so the controller rebuilds (and reloads) when
-  /// the active account/session changes. Replaces the copy-pasted
-  /// `ref.watch(accordAuthProvider.select((s) => s is AccordAuthLoggedIn ? s.client : null))`.
+  /// Watches the active client so controller builds reload on account changes.
   AccordClient? watchAccordClient() =>
       watch(accordAuthProvider.select(_clientFromState));
 
@@ -84,16 +75,4 @@ extension AccordClientRef on Ref {
         (state.session.key == serverKey || serverKey.isEmpty) &&
         identical(state.client, client);
   }
-
-  String? watchUserId() => watch(accordAuthProvider.select(_userIdFromState));
-  String? readUserId() => read(accordAuthProvider.select(_userIdFromState));
-
-  String? watchCdnUrl() => watch(accordAuthProvider.select(_cdnUrlFromState));
-  String? readCdnUrl() => read(accordAuthProvider.select(_cdnUrlFromState));
-
-  String? watchHomeDomain() =>
-      watch(accordAuthProvider.select(_homeDomainFromState));
-
-  bool watchIsAdmin() => watch(accordAuthProvider.select(_isAdminFromState));
-  bool readIsAdmin() => read(accordAuthProvider.select(_isAdminFromState));
 }

--- a/test/features/voice/voice_states_test.dart
+++ b/test/features/voice/voice_states_test.dart
@@ -49,6 +49,64 @@ void main() {
     expect(stateOf(c).containsKey('chan-a'), isFalse); // empty bucket pruned
   });
 
+  test(
+    'updates and moves preserve previous snapshots and participant order',
+    () {
+      final c = makeContainer();
+      ctl(c)
+        ..seedChannel('chan-a', [vs('u1', 'chan-a'), vs('u2', 'chan-a')])
+        ..seedChannel('chan-b', [vs('u3', 'chan-b')])
+        ..seedChannel('chan-c', [vs('u4', 'chan-c')]);
+      final before = stateOf(c);
+      final muted = vs('u1', 'chan-a')..selfMute = true;
+
+      ctl(c).upsert(muted);
+      final updated = stateOf(c);
+      expect(updated['chan-a']!.keys, ['u2', 'u1']);
+      expect(updated['chan-a']!['u1']!.selfMute, isTrue);
+      expect(before['chan-a']!.keys, ['u1', 'u2']);
+      expect(before['chan-a']!['u1']!.selfMute, isFalse);
+      expect(updated['chan-c'], same(before['chan-c']));
+
+      ctl(c).upsert(vs('u1', 'chan-b'));
+      expect(stateOf(c).keys, ['chan-a', 'chan-b', 'chan-c']);
+      expect(stateOf(c)['chan-a']!.keys, ['u2']);
+      expect(stateOf(c)['chan-b']!.keys, ['u3', 'u1']);
+      expect(updated['chan-a']!['u1'], same(muted));
+      expect(updated['chan-b']!.keys, ['u3']);
+    },
+  );
+
+  for (final destination in ['chan-c', null, '']) {
+    test('upsert clears stale memberships when channel is $destination', () {
+      final c = makeContainer();
+      ctl(c)
+        ..seedChannel('chan-a', [vs('u1', 'chan-a')])
+        ..seedChannel('chan-b', [vs('u1', 'chan-b'), vs('u2', 'chan-b')]);
+      final before = stateOf(c);
+
+      ctl(c).upsert(vs('u1', destination));
+
+      expect(stateOf(c).containsKey('chan-a'), isFalse);
+      expect(stateOf(c)['chan-b']!.keys, ['u2']);
+      expect(before['chan-a']!.keys, ['u1']);
+      expect(before['chan-b']!.keys, ['u1', 'u2']);
+      if (destination == 'chan-c') {
+        expect(stateOf(c)['chan-c']!.keys, ['u1']);
+      } else {
+        expect(stateOf(c).keys, ['chan-b']);
+      }
+    });
+  }
+
+  test('upsert ignores an empty user id', () {
+    final c = makeContainer();
+    ctl(c).upsert(vs('u1', 'chan-a'));
+    final before = stateOf(c);
+    ctl(c).upsert(vs('', 'chan-b'));
+    expect(stateOf(c), same(before));
+  });
+
   test('seedChannel replaces a channel, clears when empty', () {
     final c = makeContainer();
     ctl(c).seedChannel('chan-a', [vs('u1', 'chan-a'), vs('u2', 'chan-a')]);


### PR DESCRIPTION
## Summary

Duplicate message events copied entire caches before being discarded, and each voice-state update copied every channel's participant map. Delay message-cache allocation until a new message is accepted and copy only affected voice buckets, preserving ordering, stale-membership cleanup, and earlier snapshots.

## Changes

- Reuse the existing `removeById` implementation across message, forum, and thread caches.
- Remove a redundant seven-entry image MIME exclusion set; the authoritative attachment table already supplies those results.
- Remove eight unused internal members (seven provider `Ref` session helpers and `VoiceSession.isDeafened`) after repository-wide reference checks.
- Shorten historical implementation comments, correct the voice-cache complexity description, and regenerate provider output.
- Add five voice-cache regression cases covering snapshots, ordering, stale memberships, and invalid IDs.

## Validation

- Baseline: `flutter analyze --no-pub --no-fatal-infos` clean; `flutter test --no-pub --reporter expanded` passed 1,242 tests.
- Final: the same analyzer command is clean; the same full test command passed 1,247 tests.
- `flutter test --no-pub integration/ --reporter expanded`: 16 passed against a real server.
- In `packages/accordkit`: `dart analyze` clean; `dart test --reporter expanded`: 167 passed.
- In `packages/markdown_viewer`: `flutter analyze --no-pub` clean; `flutter test --no-pub --reporter expanded`: 683 passed.
- `flutter build web --no-pub --no-tree-shake-icons --release`: passed.
- `scripts/codegen.sh --check`, formatter check on all eight changed handwritten Dart files, and `git diff --check`: passed.
- Scoped messaging/server-cache tests: 252 passed; scoped voice-cache tests: 13 passed.

## Audit and metrics

Three independent audit/implementation workstreams were centrally integrated and independently reviewed again. Production Dart source (`lib/`, AccordKit, markdown renderer; excluding generated files) decreases from 64,525 to 64,482 lines. Five new regression cases add 58 test lines. No new abstractions, file splits, file deletions, or dependency removals were warranted. No first-party source exceeds 1,000 lines. The 1,162-line release workflow remains together because splitting its signing, artifact, secrets, and job dependencies adds operational risk without a cleanup benefit.

## Notes

No app/package test or analyzer failures were found. The JavaScript web build reports WebAssembly dry-run warnings in the unchanged `image` dependency. `ruby fastlane/test/review_submission_policy_test.rb` could not run because Ruby is not installed; no Ruby or release code changed. Native platform builds and device/SFU scenarios were not run.
