### PR TITLE
chore: release 0.2.18

### DIFF
--- a/dist/release-notes.txt
+++ b/dist/release-notes.txt
@@ -1,9 +1,11 @@
-# Release version: 0.2.17
+# Release version: 0.2.18
 
-• Fixed a first-run issue that could show a blank screen shortly after signing
-  in.
-• Direct messages now include more of the conversation tools available in
-  channels, including replies, reactions, pins, search and improved call and
-  group controls.
-• Improved account security, connection reliability, media safety and
-  cross-server data isolation.
+• Improved message reporting and user blocking across conversations, threads
+  and forums.
+• Fixed requests that could leave screens loading indefinitely and added
+  clearer feedback when an action fails.
+• Improved iPad layouts and mobile channel navigation, including swiping to
+  open the channel drawer.
+• Made app and server terms clearer during sign-in and registration.
+• Fixed incomplete settings and conversation controls and improved message
+  and voice state handling.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: bonfire
 description: "A fast, cross-platform Flutter client for Daccord."
 publish_to: "none"
 
-version: 0.2.17+1
+version: 0.2.18+1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Prepare patch release v0.2.18 with the fixes merged since v0.2.17. Bump the app version to 0.2.18+1 and update the versioned App Store notes for reporting and blocking, request timeout and error feedback, iPad layouts, mobile navigation, terms, and completed controls.

Validation: all 10 release-note and release-workflow tests passed locally; the release-note generator accepted v0.2.18 and generated both Apple metadata files. Windows signing smoke run 34067149299 passed. Full CI must pass before merging and tagging.
