### PR TITLE
fix(read-state): ack our own messages so they stop re-lighting the channel

### DIFF
--- a/lib/features/events/services/accord_message_events.dart
+++ b/lib/features/events/services/accord_message_events.dart
@@ -144,7 +144,22 @@ void bindMessageEvents(
       // and the rail/channel indicators apply [UnreadIndicatorGate] when they
       // render (see `ReadStateSnapshot.spaceShowsUnread`), so unmuting a space
       // reveals what arrived while it was muted without waiting for a reconnect.
-      if (!isOwn && !isVisibleChannel) {
+      //
+      // Our own message is the one case that *clears* read state instead:
+      // posting into a channel reads it. The local badge alone isn't enough —
+      // without the `channels.ack` the server's read position stays behind our
+      // own message, so its `unread` array re-lights the channel on the next
+      // READY (a restart, or any reconnect that re-identifies). That is what
+      // made a channel highlight for messages the user wrote themselves. The
+      // ack also echoes to our other sessions via `read_state.update`.
+      if (isOwn) {
+        ref
+            .read(readStateControllerProvider(serverKey).notifier)
+            .markRead(message.channelId);
+        if (message.id.isNotEmpty) {
+          unawaited(client.channels.ack(message.channelId, message.id));
+        }
+      } else if (!isVisibleChannel) {
         ref
             .read(readStateControllerProvider(serverKey).notifier)
             .markUnread(

--- a/test/features/events/accord_event_handler_test.dart
+++ b/test/features/events/accord_event_handler_test.dart
@@ -137,9 +137,6 @@ void main() {
     final state = container.read(readStateControllerProvider(_serverKey));
     expect(state.isUnread('c1'), isFalse);
     // The ack is what stops READY's `unread` array from re-lighting the channel.
-    expect(
-      acked,
-      contains('POST /api/v1/channels/c1/ack {"message_id":"m7"}'),
-    );
+    expect(acked, contains('POST /api/v1/channels/c1/ack {"message_id":"m7"}'));
   });
 }

--- a/test/features/events/accord_event_handler_test.dart
+++ b/test/features/events/accord_event_handler_test.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/events/services/accord_event_handler.dart';
 import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 /// A [GatewayConnection] a test can push inbound frames through.
 class _FakeGatewayConnection implements GatewayConnection {
@@ -81,5 +84,62 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(container.read(provider)?.single.id, 'm1');
+  });
+
+  test('our own message reads the channel instead of highlighting it', () async {
+    final connection = _FakeGatewayConnection();
+    final acked = <String>[];
+    final client = AccordClient(
+      baseUrl: 'https://accord.example.test',
+      gatewayUrl: 'wss://accord.example.test/ws',
+      connectionFactory: (_) => connection,
+      httpClient: MockClient((request) async {
+        acked.add('${request.method} ${request.url.path} ${request.body}');
+        return http.Response('{}', 200);
+      }),
+    );
+    addTearDown(client.dispose);
+    final container = ProviderContainer(
+      overrides: [settingsControllerProvider.overrideWith(_QuietSettings.new)],
+    );
+    addTearDown(container.dispose);
+    // Unread from somebody else, in a channel that is not on screen.
+    container
+        .read(readStateControllerProvider(_serverKey).notifier)
+        .markUnread('c1', spaceId: 's1');
+    addTearDown(
+      handleAccordEvents(
+        container.read(_refProvider),
+        client,
+        serverKey: _serverKey,
+        currentUserId: 'u-self',
+        selfDomain: 'accord.example.test',
+        isActive: () => true,
+      ),
+    );
+    client.login();
+    await Future<void>.delayed(Duration.zero);
+
+    // Federation echoes our own message back qualified to our home domain.
+    connection.receive({
+      'op': GatewayOpcodes.event,
+      'type': 'message.create',
+      'data': {
+        'id': 'm7',
+        'channel_id': 'c1',
+        'space_id': 's1',
+        'author_id': 'u-self@accord.example.test',
+        'content': 'mine',
+      },
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(readStateControllerProvider(_serverKey));
+    expect(state.isUnread('c1'), isFalse);
+    // The ack is what stops READY's `unread` array from re-lighting the channel.
+    expect(
+      acked,
+      contains('POST /api/v1/channels/c1/ack {"message_id":"m7"}'),
+    );
   });
 }


### PR DESCRIPTION
## The bug

Channels highlight as unread for messages **you** wrote.

`channels.ack` is only POSTed when a channel is opened or explicitly marked read (`markChannelRead`). Nothing acks afterwards, so every message that lands while you sit in a channel — your own included — leaves the server's read position behind. The next `READY` then lists that channel in its `unread` array and `hydrateReadStateFromReady` re-lights it. Since the live handler already skips `markUnread` for own messages, the highlight only appears after a restart or a reconnect that re-identifies, which is what made it look arbitrary.

## The fix

In the `message.create` fan-out, our own message now *reads* the channel instead of being merely ignored: clear the local badge and ack the message. The ack is the half that matters — it's what stops READY from resurrecting the highlight — and it also echoes to our other sessions via `read_state.update`.

Self-authorship goes through the existing federation-aware `isSameUser`, so an own message echoed back qualified to our home domain (`<id>@<domain>`) counts too.

## Test

`test/features/events/accord_event_handler_test.dart` gains a case that seeds unread on a background channel, pushes a self-authored (domain-qualified) `message.create`, and asserts both halves: the badge clears and `POST /api/v1/channels/c1/ack {"message_id":"m7"}` is issued. Verified it fails without the change.

`flutter analyze --no-fatal-infos` clean; `flutter test` 1248 passing.

## Not covered here

Sitting in a channel while *other people* post still doesn't ack until you re-open it — the same root cause, but fixing it wants a debounced ack (one POST per incoming message otherwise). Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qna4WsEz8R1Nk7LqRkFgud