### PR TITLE
fix(channels): make the permission editor usable on narrow screens

### DIFF
--- a/lib/features/channels/views/channel_member_picker_dialog.dart
+++ b/lib/features/channels/views/channel_member_picker_dialog.dart
@@ -1,0 +1,88 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/member/utils/member_display.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+/// Search-and-pick dialog used to add a new member permission overwrite from
+/// [showChannelPermissionsDialog]. Pops the picked member's user ID, or `null`
+/// if dismissed.
+class ChannelMemberPickerDialog extends StatefulWidget {
+  const ChannelMemberPickerDialog({super.key, required this.members});
+
+  final List<AccordMember> members;
+
+  @override
+  State<ChannelMemberPickerDialog> createState() =>
+      _ChannelMemberPickerDialogState();
+}
+
+class _ChannelMemberPickerDialogState
+    extends State<ChannelMemberPickerDialog> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = BonfireThemeExtension.of(context);
+    final theme = Theme.of(context);
+    final q = _query.trim().toLowerCase();
+    final matches = widget.members
+        .where(
+          (m) => q.isEmpty || accordMemberName(m).toLowerCase().contains(q),
+        )
+        .sortedBy((m) => accordMemberName(m).toLowerCase());
+
+    return Dialog(
+      backgroundColor: colors.foreground,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 320, maxHeight: 420),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: TextField(
+                autofocus: true,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  prefixIcon: Icon(Icons.search, size: 18),
+                  hintText: 'Search members',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+            ),
+            Flexible(
+              child: matches.isEmpty
+                  ? Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        'No members',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    )
+                  : ListView(
+                      shrinkWrap: true,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      children: [
+                        for (final m in matches)
+                          ListTile(
+                            dense: true,
+                            leading: Icon(
+                              Icons.person_outline,
+                              color: colors.gray,
+                            ),
+                            title: Text(accordMemberName(m)),
+                            onTap: () => Navigator.of(context).pop(m.userId),
+                          ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/channels/views/channel_permissions.dart
+++ b/lib/features/channels/views/channel_permissions.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/views/channel_member_picker_dialog.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/shared/utils/confirm_dialog.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
@@ -329,7 +330,7 @@ class _ChannelPermissionsDialogState
   Future<void> _addMemberOverwrite() async {
     final picked = await showDialog<String>(
       context: context,
-      builder: (_) => _MemberPickerDialog(
+      builder: (_) => ChannelMemberPickerDialog(
         members: _members.values
             .where((m) => _types[m.userId] != 'user')
             .toList(),
@@ -591,6 +592,7 @@ class _EntityListPane extends StatelessWidget {
     final children = [
       for (final role in roles)
         _EntityRow(
+          key: ValueKey('role-${role.id}'),
           compact: compact,
           label: role.name,
           color: roleColor(role.id) ?? colors.dirtyWhite,
@@ -620,6 +622,7 @@ class _EntityListPane extends StatelessWidget {
         ),
       for (final id in memberIds)
         _EntityRow(
+          key: ValueKey('member-$id'),
           compact: compact,
           label: memberName(id),
           color: colors.dirtyWhite,
@@ -628,6 +631,7 @@ class _EntityListPane extends StatelessWidget {
           onTap: () => onSelectMember(id),
         ),
       _EntityRow(
+        key: const ValueKey('add-member'),
         compact: compact,
         label: '+ Add Member',
         color: colors.primary,
@@ -659,6 +663,7 @@ class _EntityListPane extends StatelessWidget {
 
 class _EntityRow extends StatefulWidget {
   const _EntityRow({
+    super.key,
     this.compact = false,
     required this.label,
     required this.color,
@@ -937,84 +942,6 @@ class _TriButton extends StatelessWidget {
           ),
         ),
         child: Icon(icon, size: 16, color: selected ? color : colors.gray),
-      ),
-    );
-  }
-}
-
-class _MemberPickerDialog extends StatefulWidget {
-  const _MemberPickerDialog({required this.members});
-
-  final List<AccordMember> members;
-
-  @override
-  State<_MemberPickerDialog> createState() => _MemberPickerDialogState();
-}
-
-class _MemberPickerDialogState extends State<_MemberPickerDialog> {
-  String _query = '';
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = BonfireThemeExtension.of(context);
-    final theme = Theme.of(context);
-    final q = _query.trim().toLowerCase();
-    final matches = widget.members
-        .where(
-          (m) => q.isEmpty || accordMemberName(m).toLowerCase().contains(q),
-        )
-        .sortedBy((m) => accordMemberName(m).toLowerCase());
-
-    return Dialog(
-      backgroundColor: colors.foreground,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 320, maxHeight: 420),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(12),
-              child: TextField(
-                autofocus: true,
-                decoration: const InputDecoration(
-                  isDense: true,
-                  prefixIcon: Icon(Icons.search, size: 18),
-                  hintText: 'Search members',
-                  border: OutlineInputBorder(),
-                ),
-                onChanged: (v) => setState(() => _query = v),
-              ),
-            ),
-            Flexible(
-              child: matches.isEmpty
-                  ? Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Text(
-                        'No members',
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    )
-                  : ListView(
-                      shrinkWrap: true,
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      children: [
-                        for (final m in matches)
-                          ListTile(
-                            dense: true,
-                            leading: Icon(
-                              Icons.person_outline,
-                              color: colors.gray,
-                            ),
-                            title: Text(accordMemberName(m)),
-                            onTap: () => Navigator.of(context).pop(m.userId),
-                          ),
-                      ],
-                    ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/features/channels/views/channel_permissions.dart
+++ b/lib/features/channels/views/channel_permissions.dart
@@ -24,13 +24,20 @@ Future<void> showChannelPermissionsDialog(
 }) {
   return showDialog<void>(
     context: context,
-    builder: (_) => _ChannelPermissionsDialog(spaceId: spaceId, channel: channel),
+    builder: (_) =>
+        _ChannelPermissionsDialog(spaceId: spaceId, channel: channel),
   );
 }
 
 /// The tri-state of a single permission within an overwrite: explicitly allowed,
 /// explicitly denied, or inherited (neither list contains it).
 enum _OverwriteState { allow, neutral, deny }
+
+/// Below this many logical pixels the dialog stacks the role/member selector
+/// above a full-width editor instead of placing them side by side (#328). Used
+/// both for the body layout (via [LayoutBuilder]) and, against the screen
+/// width, to let the dialog fill a phone instead of keeping desktop insets.
+const _compactBreakpoint = 560.0;
 
 /// Permissions only meaningful on voice channels — hidden for text/forum/etc.
 const _voiceOnlyPerms = <String>{
@@ -61,7 +68,10 @@ const _textOnlyPerms = <String>{
 };
 
 class _ChannelPermissionsDialog extends ConsumerStatefulWidget {
-  const _ChannelPermissionsDialog({required this.spaceId, required this.channel});
+  const _ChannelPermissionsDialog({
+    required this.spaceId,
+    required this.channel,
+  });
 
   final String spaceId;
   final AccordChannel channel;
@@ -108,7 +118,12 @@ class _ChannelPermissionsDialogState
   }
 
   Map<String, AccordMember> get _members =>
-      ref.read(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId)) ??
+      ref.read(
+        accordMembersControllerProvider(
+          ref.readActiveServerKey() ?? '',
+          widget.spaceId,
+        ),
+      ) ??
       const <String, AccordMember>{};
 
   Future<void> _load() async {
@@ -125,9 +140,8 @@ class _ChannelPermissionsDialogState
       final overwrite = item is AccordPermissionOverwrite
           ? item
           : item is Map
-              ? AccordPermissionOverwrite.fromJson(
-                  item.cast<String, dynamic>())
-              : null;
+          ? AccordPermissionOverwrite.fromJson(item.cast<String, dynamic>())
+          : null;
       if (overwrite == null || overwrite.id.isEmpty) continue;
       _originalIds.add(overwrite.id);
       _types[overwrite.id] = overwrite.type; // fromJson normalizes member→user
@@ -152,17 +166,20 @@ class _ChannelPermissionsDialogState
   }
 
   static Map<String, Map<String, _OverwriteState>> _deepCopy(
-          Map<String, Map<String, _OverwriteState>> src) =>
-      {for (final e in src.entries) e.key: Map.of(e.value)};
+    Map<String, Map<String, _OverwriteState>> src,
+  ) => {for (final e in src.entries) e.key: Map.of(e.value)};
 
   /// Materializes an all-inherit entry for [id] if it has none yet, so the
   /// editor can show rows for a role/member with no existing overwrite.
   void _ensureEntity(String? id, {String type = 'role'}) {
     if (id == null) return;
     _types.putIfAbsent(id, () => type);
-    _data.putIfAbsent(id, () => {
-          for (final p in AccordPermission.all()) p: _OverwriteState.neutral,
-        });
+    _data.putIfAbsent(
+      id,
+      () => {
+        for (final p in AccordPermission.all()) p: _OverwriteState.neutral,
+      },
+    );
   }
 
   void _select(String id, String type) {
@@ -234,7 +251,8 @@ class _ChannelPermissionsDialogState
     // Entities that still carry at least one allow/deny survive; the rest that
     // were originally present are deleted.
     final active = <String>[];
-    final payloads = <(String id, String type, List<String> allow, List<String> deny)>[];
+    final payloads =
+        <(String id, String type, List<String> allow, List<String> deny)>[];
     for (final entry in _data.entries) {
       final allow = <String>[];
       final deny = <String>[];
@@ -306,8 +324,7 @@ class _ChannelPermissionsDialogState
     return role == null ? null : accordRoleColor(role.color);
   }
 
-  String _memberName(String id) =>
-      accordMemberName(_members[id], fallback: id);
+  String _memberName(String id) => accordMemberName(_members[id], fallback: id);
 
   Future<void> _addMemberOverwrite() async {
     final picked = await showDialog<String>(
@@ -328,19 +345,31 @@ class _ChannelPermissionsDialogState
     // fresh `roles` list to the space (see SpacesController._mutateRoles), so
     // selecting the list identity catches all role changes without rebuilding
     // for unrelated spaces.
-    ref.watch(spacesControllerProvider.select((spaces) =>
-        spaces?.firstWhereOrNull((s) => s.id == widget.spaceId)?.roles));
+    ref.watch(
+      spacesControllerProvider.select(
+        (spaces) =>
+            spaces?.firstWhereOrNull((s) => s.id == widget.spaceId)?.roles,
+      ),
+    );
     // Rebuild when a rendered member-overwrite name changes (member update or
     // user backfill), joined so select() compares by value. The build reads
     // nothing else from the cache; the watch also keeps the self-loading
     // member controller alive for the read-at-tap member picker.
     final memberIds = _memberOverwriteIds;
-    ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId).select(
+    ref.watch(
+      accordMembersControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        widget.spaceId,
+      ).select(
         (members) => memberIds
             .map((id) => accordMemberName(members?[id], fallback: id))
-            .join('\u0000')));
+            .join('\u0000'),
+      ),
+    );
     final colors = BonfireThemeExtension.of(context);
-    final theme = Theme.of(context);
+    // On a phone the default 40px dialog insets and the 560px height cap would
+    // leave the stacked layout cramped; let it use (nearly) the whole screen.
+    final phone = MediaQuery.sizeOf(context).width < _compactBreakpoint;
 
     return PopScope(
       canPop: false,
@@ -349,53 +378,29 @@ class _ChannelPermissionsDialogState
       },
       child: Dialog(
         backgroundColor: colors.foreground,
+        insetPadding: phone ? const EdgeInsets.all(12) : null,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 760, maxHeight: 560),
+          constraints: BoxConstraints(
+            maxWidth: 760,
+            maxHeight: phone ? double.infinity : 560,
+          ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               _Header(
-                title: 'Permissions: #${widget.channel.name ?? widget.channel.id}',
+                title:
+                    'Permissions: #${widget.channel.name ?? widget.channel.id}',
                 onClose: _tryClose,
               ),
               Expanded(
                 child: _loading
                     ? const LoadingView()
-                    : Row(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          SizedBox(
-                            width: 200,
-                            child: _EntityListPane(
-                              roles: _roles,
-                              memberIds: _memberOverwriteIds,
-                              selectedId: _selectedId,
-                              roleColor: _roleColor,
-                              memberName: _memberName,
-                              onSelectRole: (id) => _select(id, 'role'),
-                              onSelectMember: (id) => _select(id, 'user'),
-                              onAddMember: _addMemberOverwrite,
-                            ),
-                          ),
-                          VerticalDivider(width: 1, color: colors.background),
-                          Expanded(
-                            child: _selectedId == null
-                                ? Center(
-                                    child: Text(
-                                      'Select a role or member',
-                                      style: theme.textTheme.bodyMedium,
-                                    ),
-                                  )
-                                : _OverwriteEditorPane(
-                                    key: ValueKey(_selectedId),
-                                    data: _data[_selectedId] ?? const {},
-                                    visiblePerms: _visiblePerms().toSet(),
-                                    enabled: !_saving,
-                                    onSet: _setPermission,
-                                  ),
-                          ),
-                        ],
+                    : LayoutBuilder(
+                        builder: (context, constraints) =>
+                            constraints.maxWidth < _compactBreakpoint
+                            ? _buildCompactBody(colors)
+                            : _buildWideBody(colors),
                       ),
               ),
               if (_error != null)
@@ -414,6 +419,64 @@ class _ChannelPermissionsDialogState
           ),
         ),
       ),
+    );
+  }
+
+  /// Desktop/tablet: fixed-width selector list beside the editor.
+  Widget _buildWideBody(BonfireThemeExtension colors) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SizedBox(width: 200, child: _buildEntityPane(compact: false)),
+        VerticalDivider(width: 1, color: colors.background),
+        Expanded(child: _buildEditorPane(compact: false)),
+      ],
+    );
+  }
+
+  /// Phones: a horizontally scrolling strip of role/member chips above a
+  /// full-width editor, so permission labels keep their room to wrap (#328).
+  Widget _buildCompactBody(BonfireThemeExtension colors) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildEntityPane(compact: true),
+        Divider(height: 1, color: colors.background),
+        Expanded(child: _buildEditorPane(compact: true)),
+      ],
+    );
+  }
+
+  Widget _buildEntityPane({required bool compact}) {
+    return _EntityListPane(
+      compact: compact,
+      roles: _roles,
+      memberIds: _memberOverwriteIds,
+      selectedId: _selectedId,
+      roleColor: _roleColor,
+      memberName: _memberName,
+      onSelectRole: (id) => _select(id, 'role'),
+      onSelectMember: (id) => _select(id, 'user'),
+      onAddMember: _addMemberOverwrite,
+    );
+  }
+
+  Widget _buildEditorPane({required bool compact}) {
+    if (_selectedId == null) {
+      return Center(
+        child: Text(
+          'Select a role or member',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+    return _OverwriteEditorPane(
+      key: ValueKey(_selectedId),
+      data: _data[_selectedId] ?? const {},
+      visiblePerms: _visiblePerms().toSet(),
+      enabled: !_saving,
+      compact: compact,
+      onSet: _setPermission,
     );
   }
 }
@@ -475,14 +538,18 @@ class _Footer extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border(top: BorderSide(color: colors.background, width: 1)),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
+      // OverflowBar wraps Reset/Save onto two lines when large text scale
+      // makes them too wide for a phone, instead of overflowing.
+      child: OverflowBar(
+        alignment: MainAxisAlignment.end,
+        overflowAlignment: OverflowBarAlignment.end,
+        spacing: 8,
+        overflowSpacing: 8,
         children: [
           TextButton(
             onPressed: (saving || !canReset) ? null : onReset,
             child: const Text('Reset'),
           ),
-          const SizedBox(width: 8),
           FilledButton(
             onPressed: saving ? null : onSave,
             child: Text(saving ? 'Saving…' : 'Save'),
@@ -495,6 +562,7 @@ class _Footer extends StatelessWidget {
 
 class _EntityListPane extends StatelessWidget {
   const _EntityListPane({
+    required this.compact,
     required this.roles,
     required this.memberIds,
     required this.selectedId,
@@ -505,6 +573,8 @@ class _EntityListPane extends StatelessWidget {
     required this.onAddMember,
   });
 
+  /// Horizontal chip strip (narrow screens) instead of a vertical list.
+  final bool compact;
   final List<AccordRole> roles;
   final List<String> memberIds;
   final String? selectedId;
@@ -518,47 +588,78 @@ class _EntityListPane extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
     final theme = Theme.of(context);
-    return ListView(
-      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-      children: [
-        for (final role in roles)
-          _EntityRow(
-            label: role.name,
-            color: roleColor(role.id) ?? colors.dirtyWhite,
-            icon: Icons.shield_outlined,
-            selected: role.id == selectedId,
-            onTap: () => onSelectRole(role.id),
-          ),
+    final children = [
+      for (final role in roles)
+        _EntityRow(
+          compact: compact,
+          label: role.name,
+          color: roleColor(role.id) ?? colors.dirtyWhite,
+          icon: Icons.shield_outlined,
+          selected: role.id == selectedId,
+          onTap: () => onSelectRole(role.id),
+        ),
+      if (compact)
+        // The strip has no room for a section header; a thin rule separates
+        // roles from members (the chip icons already tell them apart).
+        Container(
+          width: 1,
+          height: 24,
+          margin: const EdgeInsets.symmetric(horizontal: 6),
+          color: colors.darkGray,
+        )
+      else
         Padding(
           padding: const EdgeInsets.fromLTRB(10, 12, 10, 4),
           child: Text(
             'MEMBERS',
-            style: theme.textTheme.labelSmall!
-                .copyWith(color: colors.gray, letterSpacing: 0.6),
+            style: theme.textTheme.labelSmall!.copyWith(
+              color: colors.gray,
+              letterSpacing: 0.6,
+            ),
           ),
         ),
-        for (final id in memberIds)
-          _EntityRow(
-            label: memberName(id),
-            color: colors.dirtyWhite,
-            icon: Icons.person_outline,
-            selected: id == selectedId,
-            onTap: () => onSelectMember(id),
-          ),
+      for (final id in memberIds)
         _EntityRow(
-          label: '+ Add Member',
-          color: colors.primary,
-          icon: Icons.add,
-          selected: false,
-          onTap: onAddMember,
+          compact: compact,
+          label: memberName(id),
+          color: colors.dirtyWhite,
+          icon: Icons.person_outline,
+          selected: id == selectedId,
+          onTap: () => onSelectMember(id),
         ),
-      ],
+      _EntityRow(
+        compact: compact,
+        label: '+ Add Member',
+        color: colors.primary,
+        icon: Icons.add,
+        selected: false,
+        onTap: onAddMember,
+      ),
+    ];
+    if (compact) {
+      return SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+        child: Row(
+          children: [
+            for (var i = 0; i < children.length; i++) ...[
+              if (i > 0) const SizedBox(width: 6),
+              children[i],
+            ],
+          ],
+        ),
+      );
+    }
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      children: children,
     );
   }
 }
 
-class _EntityRow extends StatelessWidget {
+class _EntityRow extends StatefulWidget {
   const _EntityRow({
+    this.compact = false,
     required this.label,
     required this.color,
     required this.icon,
@@ -566,6 +667,9 @@ class _EntityRow extends StatelessWidget {
     required this.onTap,
   });
 
+  /// Renders as a self-sized chip (for the horizontal strip) instead of a
+  /// full-width list row.
+  final bool compact;
   final String label;
   final Color color;
   final IconData icon;
@@ -573,28 +677,78 @@ class _EntityRow extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
+  State<_EntityRow> createState() => _EntityRowState();
+}
+
+class _EntityRowState extends State<_EntityRow> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.selected) _reveal();
+  }
+
+  @override
+  void didUpdateWidget(_EntityRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selected && !oldWidget.selected) _reveal();
+  }
+
+  /// Scrolls this row into view once it becomes the selection — matters for
+  /// the compact strip, where "+ Add Member" appends the new chip off-screen.
+  /// Only on selection change, so it never fights the user's own scrolling.
+  void _reveal() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 150),
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = BonfireThemeExtension.of(context);
     final theme = Theme.of(context);
+    final compact = widget.compact;
+    final selected = widget.selected;
+    final color = widget.color;
+    final radius = BorderRadius.circular(compact ? 20 : 8);
+    final text = Text(
+      widget.label,
+      overflow: TextOverflow.ellipsis,
+      style: theme.textTheme.bodyMedium!.copyWith(color: color),
+    );
     return Material(
       color: selected ? colors.darkGray : Colors.transparent,
-      borderRadius: BorderRadius.circular(8),
+      shape: RoundedRectangleBorder(
+        borderRadius: radius,
+        // Unselected chips need an outline to read as tappable in the strip.
+        side: compact
+            ? BorderSide(color: selected ? color : colors.darkGray)
+            : BorderSide.none,
+      ),
       child: InkWell(
-        borderRadius: BorderRadius.circular(8),
-        onTap: onTap,
+        borderRadius: radius,
+        onTap: widget.onTap,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+          padding: compact
+              ? const EdgeInsets.symmetric(horizontal: 12, vertical: 10)
+              : const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
           child: Row(
+            mainAxisSize: compact ? MainAxisSize.min : MainAxisSize.max,
             children: [
-              Icon(icon, size: 16, color: color),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  label,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.bodyMedium!.copyWith(color: color),
-                ),
-              ),
+              Icon(widget.icon, size: 16, color: color),
+              SizedBox(width: compact ? 8 : 10),
+              if (compact)
+                // Long role names must not stretch the strip; cap the chip.
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 180),
+                  child: text,
+                )
+              else
+                Expanded(child: text),
             ],
           ),
         ),
@@ -609,12 +763,16 @@ class _OverwriteEditorPane extends StatelessWidget {
     required this.data,
     required this.visiblePerms,
     required this.enabled,
+    this.compact = false,
     required this.onSet,
   });
 
   final Map<String, _OverwriteState> data;
   final Set<String> visiblePerms;
   final bool enabled;
+
+  /// Tighter margins and finger-sized tri-state buttons (narrow screens).
+  final bool compact;
   final void Function(String perm, _OverwriteState state) onSet;
 
   @override
@@ -622,7 +780,9 @@ class _OverwriteEditorPane extends StatelessWidget {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
     return SingleChildScrollView(
-      padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+      padding: compact
+          ? const EdgeInsets.fromLTRB(12, 8, 12, 16)
+          : const EdgeInsets.fromLTRB(20, 16, 20, 20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -646,8 +806,10 @@ class _OverwriteEditorPane extends StatelessWidget {
         padding: const EdgeInsets.only(top: 14, bottom: 4),
         child: Text(
           group.label.toUpperCase(),
-          style: theme.textTheme.labelSmall!
-              .copyWith(color: colors.gray, letterSpacing: 0.6),
+          style: theme.textTheme.labelSmall!.copyWith(
+            color: colors.gray,
+            letterSpacing: 0.6,
+          ),
         ),
       ),
       for (final perm in perms)
@@ -656,6 +818,7 @@ class _OverwriteEditorPane extends StatelessWidget {
           description: AccordPermission.description(perm),
           state: data[perm] ?? _OverwriteState.neutral,
           enabled: enabled,
+          compact: compact,
           onChanged: (s) => onSet(perm, s),
         ),
     ];
@@ -668,6 +831,7 @@ class _PermissionRow extends StatelessWidget {
     required this.description,
     required this.state,
     required this.enabled,
+    this.compact = false,
     required this.onChanged,
   });
 
@@ -675,45 +839,58 @@ class _PermissionRow extends StatelessWidget {
   final String description;
   final _OverwriteState state;
   final bool enabled;
+
+  /// Finger-sized (40px) tri-state buttons for touch screens.
+  final bool compact;
   final ValueChanged<_OverwriteState> onChanged;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = BonfireThemeExtension.of(context);
+    final gap = SizedBox(width: compact ? 6 : 4);
+    // The label wraps freely while the three buttons keep their fixed size;
+    // the pane is full-width on phones so the text is never squeezed into a
+    // letter-per-line column (#328).
     final row = Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: EdgeInsets.symmetric(vertical: compact ? 6 : 4),
       child: Row(
         children: [
-          Expanded(
-            child: Text(label, style: theme.textTheme.bodyMedium),
-          ),
+          Expanded(child: Text(label, style: theme.textTheme.bodyMedium)),
+          SizedBox(width: compact ? 12 : 8),
           _TriButton(
             icon: Icons.check,
             color: colors.green,
+            compact: compact,
             selected: state == _OverwriteState.allow,
             onTap: enabled
-                ? () => onChanged(state == _OverwriteState.allow
-                    ? _OverwriteState.neutral
-                    : _OverwriteState.allow)
+                ? () => onChanged(
+                    state == _OverwriteState.allow
+                        ? _OverwriteState.neutral
+                        : _OverwriteState.allow,
+                  )
                 : null,
           ),
-          const SizedBox(width: 4),
+          gap,
           _TriButton(
             icon: Icons.remove,
             color: colors.gray,
+            compact: compact,
             selected: state == _OverwriteState.neutral,
             onTap: enabled ? () => onChanged(_OverwriteState.neutral) : null,
           ),
-          const SizedBox(width: 4),
+          gap,
           _TriButton(
             icon: Icons.close,
             color: colors.red,
+            compact: compact,
             selected: state == _OverwriteState.deny,
             onTap: enabled
-                ? () => onChanged(state == _OverwriteState.deny
-                    ? _OverwriteState.neutral
-                    : _OverwriteState.deny)
+                ? () => onChanged(
+                    state == _OverwriteState.deny
+                        ? _OverwriteState.neutral
+                        : _OverwriteState.deny,
+                  )
                 : null,
           ),
         ],
@@ -731,12 +908,16 @@ class _TriButton extends StatelessWidget {
     required this.color,
     required this.selected,
     required this.onTap,
+    this.compact = false,
   });
 
   final IconData icon;
   final Color color;
   final bool selected;
   final VoidCallback? onTap;
+
+  /// 40px touch target instead of the 30x28 desktop button.
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -745,8 +926,8 @@ class _TriButton extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(6),
       child: Container(
-        width: 30,
-        height: 28,
+        width: compact ? 40 : 30,
+        height: compact ? 40 : 28,
         decoration: BoxDecoration(
           color: selected ? color.withValues(alpha: 0.25) : Colors.transparent,
           borderRadius: BorderRadius.circular(6),
@@ -779,8 +960,9 @@ class _MemberPickerDialogState extends State<_MemberPickerDialog> {
     final theme = Theme.of(context);
     final q = _query.trim().toLowerCase();
     final matches = widget.members
-        .where((m) =>
-            q.isEmpty || accordMemberName(m).toLowerCase().contains(q))
+        .where(
+          (m) => q.isEmpty || accordMemberName(m).toLowerCase().contains(q),
+        )
         .sortedBy((m) => accordMemberName(m).toLowerCase());
 
     return Dialog(
@@ -809,8 +991,10 @@ class _MemberPickerDialogState extends State<_MemberPickerDialog> {
               child: matches.isEmpty
                   ? Padding(
                       padding: const EdgeInsets.all(16),
-                      child: Text('No members',
-                          style: theme.textTheme.bodyMedium),
+                      child: Text(
+                        'No members',
+                        style: theme.textTheme.bodyMedium,
+                      ),
                     )
                   : ListView(
                       shrinkWrap: true,
@@ -819,8 +1003,10 @@ class _MemberPickerDialogState extends State<_MemberPickerDialog> {
                         for (final m in matches)
                           ListTile(
                             dense: true,
-                            leading:
-                                Icon(Icons.person_outline, color: colors.gray),
+                            leading: Icon(
+                              Icons.person_outline,
+                              color: colors.gray,
+                            ),
                             title: Text(accordMemberName(m)),
                             onTap: () => Navigator.of(context).pop(m.userId),
                           ),

--- a/test/features/channels/channel_permissions_layout_test.dart
+++ b/test/features/channels/channel_permissions_layout_test.dart
@@ -28,6 +28,7 @@ const _spaceId = 'space1';
 const _channelId = 'c1';
 const _selfId = 'u1';
 const _memberId = 'u2';
+const _newMemberId = 'u3';
 
 const _phone = Size(390, 844);
 const _desktop = Size(1024, 768);
@@ -91,6 +92,13 @@ class _Harness {
             userId: _memberId,
             spaceId: _spaceId,
             user: AccordUser(id: _memberId, username: 'alice'),
+          ),
+          // No existing overwrite, so this member is the pickable candidate in
+          // the "+ Add Member" flow (alice is excluded — she already has one).
+          _newMemberId: AccordMember(
+            userId: _newMemberId,
+            spaceId: _spaceId,
+            user: AccordUser(id: _newMemberId, username: 'bob'),
           ),
         }),
       ],
@@ -275,6 +283,33 @@ void main() {
     await tester.tap(find.text('Discard'));
     await tester.pumpAndSettle();
     expect(find.text('Save'), findsNothing);
+  });
+
+  testWidgets('phone: adding a member scrolls the new chip into view', (
+    tester,
+  ) async {
+    await _open(tester, _phone);
+
+    // "+ Add Member" sits at the end of the strip and is off-screen until
+    // scrolled to, same as the trailing chips in the test above.
+    await tester.ensureVisible(find.text('+ Add Member'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('+ Add Member'));
+    await tester.pumpAndSettle();
+
+    // Pick "bob" — the only member without an existing overwrite — from the
+    // member picker dialog.
+    expect(find.text('bob'), findsOneWidget);
+    await tester.tap(find.text('bob'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    // The freshly added chip becomes the selection. Without any scrolling of
+    // our own here (contrast the manual `ensureVisible` calls above),
+    // `_EntityRowState._reveal` must have scrolled it into view on selection,
+    // as the PR describes — otherwise it would land off the trailing edge of
+    // the strip, same as "+ Add Member" did before this tap.
+    expect(find.text('bob').hitTestable(), findsOneWidget);
   });
 
   testWidgets('phone at large text scale neither overflows nor hides Save', (

--- a/test/features/channels/channel_permissions_layout_test.dart
+++ b/test/features/channels/channel_permissions_layout_test.dart
@@ -1,0 +1,298 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/channels/views/channel_permissions.dart';
+import 'package:bonfire/features/member/controllers/accord_members.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/spaces/controllers/spaces.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Responsive layout of the channel permission editor (#328).
+///
+/// On desktop the dialog keeps its two panes (200px selector list beside the
+/// editor). On a phone that left the editor a few dozen pixels wide, so labels
+/// wrapped letter-by-letter and the footer could end up off-screen. Below the
+/// breakpoint the selector becomes a horizontal chip strip and the editor gets
+/// the full width.
+
+const _spaceId = 'space1';
+const _channelId = 'c1';
+const _selfId = 'u1';
+const _memberId = 'u2';
+
+const _phone = Size(390, 844);
+const _desktop = Size(1024, 768);
+
+class _Harness {
+  _Harness() {
+    final responder = MockClient((request) async {
+      final path = request.url.path;
+      requests.add('${request.method} $path');
+      // One existing member overwrite, so the selector also lists a member
+      // (chips only exist for members that carry an overwrite).
+      final data = path.endsWith('/channels/$_channelId/permissions')
+          ? [
+              {
+                'id': _memberId,
+                'type': 'member',
+                'allow': ['view_channel'],
+                'deny': <String>[],
+              },
+            ]
+          : <Object>[];
+      return http.Response(
+        jsonEncode({'data': data}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+    final server = AccordServer.fromBaseUrl('https://accord.example.test');
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: server.baseUrl,
+      gatewayUrl: server.gatewayUrl,
+      cdnUrl: server.cdnUrl,
+      httpClient: responder,
+    );
+    final space = AccordSpace(
+      id: _spaceId,
+      ownerId: _selfId,
+      roles: [
+        AccordRole(id: 'everyone', name: '@everyone', position: 0),
+        AccordRole(id: 'mod', name: 'Moderator', position: 1),
+      ],
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(
+          AccordAuthLoggedIn(
+            client: client,
+            session: AccordSession(
+              server: server,
+              token: 'test-token',
+              userId: _selfId,
+              username: 'self',
+            ),
+          ),
+        ),
+        spacesControllerProvider.overrideWithValue([space]),
+        accordMembersControllerProvider('', _spaceId).overrideWithValue({
+          _memberId: AccordMember(
+            userId: _memberId,
+            spaceId: _spaceId,
+            user: AccordUser(id: _memberId, username: 'alice'),
+          ),
+        }),
+      ],
+    );
+  }
+
+  final List<String> requests = [];
+  late final AccordClient client;
+  late final ProviderContainer container;
+
+  Widget app({double textScale = 1}) => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showChannelPermissionsDialog(
+              context,
+              spaceId: _spaceId,
+              channel: AccordChannel(
+                id: _channelId,
+                spaceId: _spaceId,
+                name: 'general',
+              ),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  void dispose() => container.dispose();
+}
+
+void _useSurface(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.reset);
+}
+
+Future<_Harness> _open(
+  WidgetTester tester,
+  Size surface, {
+  double textScale = 1,
+}) async {
+  _useSurface(tester, surface);
+  final h = _Harness();
+  addTearDown(h.dispose);
+  await tester.pumpWidget(h.app(textScale: textScale));
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  expect(h.requests, contains('GET /api/v1/channels/$_channelId/permissions'));
+  return h;
+}
+
+/// The nearest [Row] holding a permission label and its three buttons.
+Finder _permissionRow(String label) =>
+    find.ancestor(of: find.text(label), matching: find.byType(Row)).first;
+
+/// The tri-state button box (the square [Container]) around [icon] in the
+/// permission row labelled [label].
+Finder _triButton(String label, IconData icon) => find
+    .ancestor(
+      of: find.descendant(
+        of: _permissionRow(label),
+        matching: find.byIcon(icon),
+      ),
+      matching: find.byType(Container),
+    )
+    .first;
+
+/// Asserts the permission label [label] has real room: a column of at least
+/// 180px and no more than [maxLines] rendered lines. Note the test font draws
+/// every glyph as a 14px square, so at 180-200px only ~13 glyphs fit per
+/// line — "View Channel" (12) is the single-line probe; longer labels are
+/// allowed a second line here even though a real font keeps them on one.
+void _expectLabelRoom(WidgetTester tester, String label, {int maxLines = 1}) {
+  final paragraph = tester.renderObject<RenderParagraph>(find.text(label));
+  expect(paragraph.didExceedMaxLines, isFalse, reason: '"$label" was clipped');
+  expect(
+    paragraph.constraints.maxWidth,
+    greaterThanOrEqualTo(180),
+    reason: '"$label" column is squeezed (${paragraph.constraints})',
+  );
+  final oneLine = TextPainter(
+    text: paragraph.text,
+    textDirection: TextDirection.ltr,
+    textScaler: paragraph.textScaler,
+  ).preferredLineHeight;
+  expect(
+    paragraph.size.height,
+    lessThan(oneLine * (maxLines + 0.5)),
+    reason:
+        '"$label" should fit on $maxLines line(s) '
+        '(size ${paragraph.size}, constraints ${paragraph.constraints})',
+  );
+}
+
+void main() {
+  // A tap that lands off-screen must fail, not silently no-op: every tap
+  // below is meant to prove the target is reachable on a phone.
+  setUp(() => WidgetController.hitTestWarningShouldBeFatal = true);
+  tearDown(() => WidgetController.hitTestWarningShouldBeFatal = false);
+
+  testWidgets('desktop keeps the two-pane layout', (tester) async {
+    await _open(tester, _desktop);
+
+    expect(tester.takeException(), isNull);
+    // Selector list beside the editor, separated by the vertical rule.
+    expect(find.byType(VerticalDivider), findsOneWidget);
+    expect(find.text('MEMBERS'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+    _expectLabelRoom(tester, 'View Channel');
+    expect(find.text('Save').hitTestable(), findsOneWidget);
+    // Desktop buttons keep their compact 30x28 size.
+    expect(tester.getSize(_triButton('View Channel', Icons.check)).width, 30);
+  });
+
+  testWidgets('phone stacks a chip strip above a full-width editor', (
+    tester,
+  ) async {
+    await _open(tester, _phone);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(VerticalDivider), findsNothing);
+    expect(find.text('MEMBERS'), findsNothing);
+    // Every selector entry is still reachable as a chip in the strip.
+    for (final label in ['@everyone', 'Moderator', 'alice', '+ Add Member']) {
+      expect(find.text(label), findsOneWidget, reason: label);
+    }
+    // Labels get real room now instead of a letter-per-line column.
+    _expectLabelRoom(tester, 'View Channel');
+    _expectLabelRoom(tester, 'Manage Channels', maxLines: 2);
+    // Footer stays on screen.
+    expect(find.text('Save').hitTestable(), findsOneWidget);
+    expect(find.text('Reset').hitTestable(), findsOneWidget);
+    // Finger-sized tri-state controls.
+    final allow = tester.getSize(_triButton('View Channel', Icons.check));
+    expect(allow.width, greaterThanOrEqualTo(40));
+    expect(allow.height, greaterThanOrEqualTo(40));
+    // The dialog uses the phone's width (default 40px insets would leave
+    // the 390px surface with a 310px dialog).
+    expect(tester.getSize(find.byType(Dialog)).width, greaterThan(340));
+  });
+
+  testWidgets('phone: selecting a chip and editing a permission works', (
+    tester,
+  ) async {
+    await _open(tester, _phone);
+
+    // Member chip (existing overwrite) and role chip are both selectable. The
+    // strip scrolls: the member chip starts off-screen at its end, and once
+    // selected it is scrolled into view, which pushes the roles off the left.
+    await tester.ensureVisible(find.text('alice'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('alice'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('alice').hitTestable(), findsOneWidget);
+    await tester.ensureVisible(find.text('Moderator'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Moderator'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(_triButton('View Channel', Icons.check));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    // The edit registered as a pending change: closing asks to discard.
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    expect(find.text('Unsaved Changes'), findsOneWidget);
+    await tester.tap(find.text('Discard'));
+    await tester.pumpAndSettle();
+    expect(find.text('Save'), findsNothing);
+  });
+
+  testWidgets('phone at large text scale neither overflows nor hides Save', (
+    tester,
+  ) async {
+    await _open(tester, _phone, textScale: 1.6);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Save').hitTestable(), findsOneWidget);
+    expect(find.text('Reset').hitTestable(), findsOneWidget);
+    // The longest label wraps onto extra lines instead of being clipped.
+    final long = tester.renderObject<RenderParagraph>(
+      find.text('Mention @everyone, @here, and all roles'),
+    );
+    expect(long.didExceedMaxLines, isFalse);
+    expect(
+      tester.getSize(_triButton('View Channel', Icons.check)).width,
+      greaterThanOrEqualTo(40),
+    );
+  });
+}


### PR DESCRIPTION
Closes #328

## Problem
The channel permission editor placed a fixed 200px role/member list beside the editor, so on a phone in portrait the permission column was a few dozen pixels wide: labels like "View Channel" wrapped almost letter-by-letter and the allow/inherit/deny controls crowded the text.

## Change
- A `LayoutBuilder` on the dialog body switches to a stacked layout below 560px: the role/member selector becomes a horizontally scrolling strip of chips above a full-width permission editor. The wide two-pane layout is unchanged where there is room.
- Compact rows use 40×40 tri-state buttons with a fixed gap so labels wrap normally and controls stay clearly associated.
- On phones the dialog uses small insets and drops the 560px height cap so the scrollable editor gets the screen; the footer uses `OverflowBar` so Reset/Save wrap instead of overflowing at large text scale.
- Selecting a chip (including a freshly added member) scrolls it into view.

## Tests
New `test/features/channels/channel_permissions_layout_test.dart` opens the real dialog against a mocked client at 1024×768 (two-pane), 390×844 (stacked, labels on one line, Save/Reset hit-testable, no overflow), 390×844 at 1.6× text scale, and drives select/toggle/close on the phone layout.

Not verified on a physical device; layout is covered by widget tests only. Part of the diff is `dart format` reflow of the previously unformatted file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)