### PR TITLE
fix(notifications): notify for direct messages without a mention

### DIFF
--- a/lib/features/events/services/accord_message_events.dart
+++ b/lib/features/events/services/accord_message_events.dart
@@ -61,8 +61,9 @@ void bindMessageEvents(
         mentionEveryone: message.mentionEveryone,
         suppressEveryone: settings.suppressEveryone,
       );
+      final isDirectMessage = message.spaceId == null;
       final spaceMuted =
-          message.spaceId != null &&
+          !isDirectMessage &&
           settings.isSpaceMuted(serverKey, message.spaceId!);
 
       // Channel cache: only touch channels the UI has actually opened (see
@@ -157,7 +158,9 @@ void bindMessageEvents(
       // Mention notifications: fire for *any* mentioning message, even in
       // channels the UI hasn't opened and on servers that aren't currently
       // active (so a message on server B still notifies while you're on server
-      // A). [currentUserId] is per-connection, so author matching is correct on
+      // A). Direct messages notify without a mention (#326) — the gate handles
+      // that, so an unread DM pings you while you're reading another channel.
+      // [currentUserId] is per-connection, so author matching is correct on
       // every server; only the *visible-channel* skip is active-connection
       // -scoped, since that pointer belongs to the on-screen session.
       final notify = MessageNotificationGate.shouldNotify(
@@ -172,16 +175,22 @@ void bindMessageEvents(
           serverKey,
           message.channelId,
         ),
+        isDirectMessage: isDirectMessage,
       );
       if (notify) {
         final author = ref
             .read(accordUsersControllerProvider(serverKey).notifier)
             .cached(message.authorId, client: client);
-        final name = accordUserName(author, fallback: 'New mention');
+        final name = accordUserName(
+          author,
+          fallback: isDirectMessage ? 'New message' : 'New mention',
+        );
         final body = message.content.trim();
         showMentionNotification(
           title: name,
-          body: body.isEmpty ? 'mentioned you' : body,
+          body: body.isEmpty
+              ? (isDirectMessage ? 'Sent you a message' : 'mentioned you')
+              : body,
         );
       }
 
@@ -190,9 +199,11 @@ void bindMessageEvents(
       // focus, and never chimes for our own messages, a muted space (which stays
       // silent like its suppressed banner), or the channel that's on screen
       // (only the active connection owns the visible-channel pointer).
+      // A DM chimes like a mention: it is addressed to you, so it should be
+      // heard even while the window is focused on something else (#326).
       if (settings.soundsEnabled && !spaceMuted && !isOwn) {
         soundManager.playForMessage(
-          isMention: countsAsMention,
+          isMention: countsAsMention || isDirectMessage,
           isVisibleChannel: isVisibleChannel,
           isMemberJoin: message.type == 'member_join',
         );

--- a/lib/features/events/services/accord_message_events.dart
+++ b/lib/features/events/services/accord_message_events.dart
@@ -83,7 +83,7 @@ void bindMessageEvents(
             )
             .addMessage(message);
       }
-      if (message.spaceId == null) {
+      if (isDirectMessage) {
         ref
             .read(dmChannelsControllerProvider(serverKey).notifier)
             .applyMessage(message);

--- a/lib/features/notifications/utils/notification_gate.dart
+++ b/lib/features/notifications/utils/notification_gate.dart
@@ -40,6 +40,10 @@ class MessageNotificationGate {
   /// [spaceMuted] mirrors a per-space mute (`AccordSettings.isSpaceMuted`): when
   /// true the message's space is muted and no notification is shown, regardless
   /// of mentions — matching the old client's "Mute Server" action.
+  /// [isDirectMessage] is true for a DM / group-DM message (no parent space).
+  /// A DM is addressed to you by definition, so it notifies without needing an
+  /// `@mention` (#326); an explicit per-channel `'mentions'` level still
+  /// narrows it back to mention-only, and `'nothing'` still silences it.
   static bool shouldNotify({
     required bool notificationsEnabled,
     required bool suppressEveryone,
@@ -49,6 +53,7 @@ class MessageNotificationGate {
     required bool mentionEveryone,
     bool spaceMuted = false,
     String? channelLevel,
+    bool isDirectMessage = false,
   }) {
     if (!notificationsEnabled) return false;
     if (isOwnMessage) return false;
@@ -60,6 +65,9 @@ class MessageNotificationGate {
     // explicitly-disabled stream.
     if (channelLevel == 'nothing') return false;
     if (channelLevel == 'all') return true;
+    // A direct message is inherently "for you": the default (unset) level
+    // notifies for every DM, not only mentioning ones.
+    if (isDirectMessage && channelLevel == null) return true;
     return countsAsMention(
       mentionsMe: mentionsMe,
       mentionEveryone: mentionEveryone,

--- a/test/features/notifications/notification_gate_test.dart
+++ b/test/features/notifications/notification_gate_test.dart
@@ -17,17 +17,18 @@ void main() {
     bool mentionEveryone = false,
     bool spaceMuted = false,
     String? channelLevel,
-  }) =>
-      MessageNotificationGate.shouldNotify(
-        notificationsEnabled: notificationsEnabled,
-        suppressEveryone: suppressEveryone,
-        isOwnMessage: isOwnMessage,
-        isVisibleChannel: isVisibleChannel,
-        mentionsMe: mentionsMe,
-        mentionEveryone: mentionEveryone,
-        spaceMuted: spaceMuted,
-        channelLevel: channelLevel,
-      );
+    bool isDirectMessage = false,
+  }) => MessageNotificationGate.shouldNotify(
+    notificationsEnabled: notificationsEnabled,
+    suppressEveryone: suppressEveryone,
+    isOwnMessage: isOwnMessage,
+    isVisibleChannel: isVisibleChannel,
+    mentionsMe: mentionsMe,
+    mentionEveryone: mentionEveryone,
+    spaceMuted: spaceMuted,
+    channelLevel: channelLevel,
+    isDirectMessage: isDirectMessage,
+  );
 
   group('MessageNotificationGate.shouldNotify', () {
     test('a direct mention notifies', () {
@@ -49,7 +50,11 @@ void main() {
 
       test('a direct mention still notifies even with suppressEveryone', () {
         expect(
-          notify(mentionsMe: true, mentionEveryone: true, suppressEveryone: true),
+          notify(
+            mentionsMe: true,
+            mentionEveryone: true,
+            suppressEveryone: true,
+          ),
           isTrue,
         );
       });
@@ -74,7 +79,45 @@ void main() {
         expect(notify(channelLevel: 'all', isOwnMessage: true), isFalse);
         expect(notify(channelLevel: 'all', isVisibleChannel: true), isFalse);
         expect(
-            notify(channelLevel: 'all', notificationsEnabled: false), isFalse);
+          notify(channelLevel: 'all', notificationsEnabled: false),
+          isFalse,
+        );
+      });
+    });
+
+    group('direct messages', () {
+      test('a DM notifies without any mention (#326)', () {
+        expect(notify(isDirectMessage: true), isTrue);
+      });
+
+      test('a DM still respects own/visible/disabled gates', () {
+        expect(notify(isDirectMessage: true, isOwnMessage: true), isFalse);
+        expect(notify(isDirectMessage: true, isVisibleChannel: true), isFalse);
+        expect(
+          notify(isDirectMessage: true, notificationsEnabled: false),
+          isFalse,
+        );
+      });
+
+      test('an explicit per-channel level still wins for a DM', () {
+        expect(notify(isDirectMessage: true, channelLevel: 'nothing'), isFalse);
+        expect(
+          notify(isDirectMessage: true, channelLevel: 'mentions'),
+          isFalse,
+        );
+        expect(
+          notify(
+            isDirectMessage: true,
+            channelLevel: 'mentions',
+            mentionsMe: true,
+          ),
+          isTrue,
+        );
+        expect(notify(isDirectMessage: true, channelLevel: 'all'), isTrue);
+      });
+
+      test('a space message without a mention still stays quiet', () {
+        expect(notify(isDirectMessage: false), isFalse);
       });
     });
 
@@ -118,15 +161,18 @@ void main() {
     /// Read state with one unread, 2-mention channel in [spaceId] (plus an
     /// unrelated unread channel in another space, which must never leak into
     /// [spaceId]'s roll-up).
-    const state = ReadStateSnapshot(entries: {
-      channelId: ReadEntry(channelId: channelId, spaceId: spaceId, mentions: 2),
-      'other': ReadEntry(channelId: 'other', spaceId: 's2', mentions: 5),
-    });
+    const state = ReadStateSnapshot(
+      entries: {
+        channelId: ReadEntry(
+          channelId: channelId,
+          spaceId: spaceId,
+          mentions: 2,
+        ),
+        'other': ReadEntry(channelId: 'other', spaceId: 's2', mentions: 5),
+      },
+    );
 
-    AccordSettings settings({
-      bool spaceMuted = false,
-      String? channelLevel,
-    }) =>
+    AccordSettings settings({bool spaceMuted = false, String? channelLevel}) =>
         AccordSettings(
           mutedSpaces: spaceMuted
               ? [ServerEntityKey(serverKey, spaceId).encoded]
@@ -138,26 +184,26 @@ void main() {
 
     /// What the UI would render for [spaceId] / [channelId] under [s].
     ({bool railDot, int railBadge, bool channelPip, int channelBadge})
-        indicators(AccordSettings s, {ReadStateSnapshot from = state}) => (
-              railDot: from.spaceShowsUnread(
-                spaceId,
-                spaceMuted: s.isSpaceMuted(serverKey, spaceId),
-                channelLevels: s.channelNotificationsFor(serverKey),
-              ),
-              railBadge: from.visibleMentionsInSpace(
-                spaceId,
-                spaceMuted: s.isSpaceMuted(serverKey, spaceId),
-                channelLevels: s.channelNotificationsFor(serverKey),
-              ),
-              channelPip: from.isUnreadVisible(
-                channelId,
-                channelLevels: s.channelNotificationsFor(serverKey),
-              ),
-              channelBadge: from.visibleMentionCount(
-                channelId,
-                channelLevels: s.channelNotificationsFor(serverKey),
-              ),
-            );
+    indicators(AccordSettings s, {ReadStateSnapshot from = state}) => (
+      railDot: from.spaceShowsUnread(
+        spaceId,
+        spaceMuted: s.isSpaceMuted(serverKey, spaceId),
+        channelLevels: s.channelNotificationsFor(serverKey),
+      ),
+      railBadge: from.visibleMentionsInSpace(
+        spaceId,
+        spaceMuted: s.isSpaceMuted(serverKey, spaceId),
+        channelLevels: s.channelNotificationsFor(serverKey),
+      ),
+      channelPip: from.isUnreadVisible(
+        channelId,
+        channelLevels: s.channelNotificationsFor(serverKey),
+      ),
+      channelBadge: from.visibleMentionCount(
+        channelId,
+        channelLevels: s.channelNotificationsFor(serverKey),
+      ),
+    );
 
     test('unmuted, default level: dot and badge both show', () {
       final i = indicators(settings());
@@ -218,25 +264,35 @@ void main() {
     });
 
     test('a silenced channel does not hide its space\'s other unread', () {
-      const mixed = ReadStateSnapshot(entries: {
-        channelId:
-            ReadEntry(channelId: channelId, spaceId: spaceId, mentions: 2),
-        otherChannelId:
-            ReadEntry(channelId: otherChannelId, spaceId: spaceId, mentions: 1),
-      });
+      const mixed = ReadStateSnapshot(
+        entries: {
+          channelId: ReadEntry(
+            channelId: channelId,
+            spaceId: spaceId,
+            mentions: 2,
+          ),
+          otherChannelId: ReadEntry(
+            channelId: otherChannelId,
+            spaceId: spaceId,
+            mentions: 1,
+          ),
+        },
+      );
       final i = indicators(settings(channelLevel: 'nothing'), from: mixed);
       expect(i.railDot, isTrue, reason: '$otherChannelId is still unread');
       expect(i.railBadge, 1, reason: 'only the silenced channel is excluded');
       expect(i.channelPip, isFalse);
     });
 
-    test('muting is a pure read-side filter: unmuting reveals prior unread',
-        () {
-      // Same snapshot, different settings — no new message, no reconnect.
-      expect(indicators(settings(spaceMuted: true)).railDot, isFalse);
-      expect(indicators(settings()).railDot, isTrue);
-      expect(indicators(settings()).railBadge, 2);
-    });
+    test(
+      'muting is a pure read-side filter: unmuting reveals prior unread',
+      () {
+        // Same snapshot, different settings — no new message, no reconnect.
+        expect(indicators(settings(spaceMuted: true)).railDot, isFalse);
+        expect(indicators(settings()).railDot, isTrue);
+        expect(indicators(settings()).railBadge, 2);
+      },
+    );
 
     test('the READY hydrate path yields the same mute-aware result', () {
       // The gateway seed is deliberately unfiltered, so verify the filter still
@@ -249,13 +305,21 @@ void main() {
       ]);
       final hydrated = container.read(readStateControllerProvider(key));
 
-      expect(indicators(settings(spaceMuted: true), from: hydrated).railDot,
-          isFalse);
-      expect(indicators(settings(spaceMuted: true), from: hydrated).railBadge,
-          0);
-      expect(indicators(settings(channelLevel: 'nothing'), from: hydrated)
-          .channelPip,
-          isFalse);
+      expect(
+        indicators(settings(spaceMuted: true), from: hydrated).railDot,
+        isFalse,
+      );
+      expect(
+        indicators(settings(spaceMuted: true), from: hydrated).railBadge,
+        0,
+      );
+      expect(
+        indicators(
+          settings(channelLevel: 'nothing'),
+          from: hydrated,
+        ).channelPip,
+        isFalse,
+      );
       expect(indicators(settings(), from: hydrated).railDot, isTrue);
       expect(indicators(settings(), from: hydrated).railBadge, 2);
     });
@@ -269,10 +333,15 @@ void main() {
           .markUnread(channelId, spaceId: spaceId, isMention: true);
       final live = container.read(readStateControllerProvider(key));
 
-      expect(live.isUnread(channelId), isTrue,
-          reason: 'the write path never filters');
-      expect(indicators(settings(spaceMuted: true), from: live).railDot,
-          isFalse);
+      expect(
+        live.isUnread(channelId),
+        isTrue,
+        reason: 'the write path never filters',
+      );
+      expect(
+        indicators(settings(spaceMuted: true), from: live).railDot,
+        isFalse,
+      );
       expect(indicators(settings(), from: live).railBadge, 1);
     });
   });


### PR DESCRIPTION
Closes #326

## Problem
Incoming DMs went through `MessageNotificationGate` with the default "mentions only" policy, so an ordinary DM produced no local notification while the app was in the foreground unless the sender @-mentioned you or the channel had an explicit `all` override.

## Change
- `MessageNotificationGate.shouldNotify` takes `isDirectMessage`; under the default (unset) channel level a DM notifies without a mention. An explicit per-channel `mentions`/`nothing` level, the own-message, visible-channel and notifications-disabled guards still apply.
- The message event handler passes the flag for space-less messages, chimes DMs like a mention, and uses "New message" / "Sent you a message" copy for attachment-only DMs instead of "mentioned you".

## Tests
Gate tests cover DM default, guards, explicit levels, and that space messages stay mention-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)