### PR TITLE
fix(spaces): open the space menu reliably on touch long-press

### DIFF
--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -40,6 +40,7 @@ import 'package:bonfire/features/spaces/views/accord_gates.dart';
 import 'package:bonfire/features/spaces/views/accord_channel_reorder.dart';
 import 'package:bonfire/features/spaces/views/accord_invites.dart';
 import 'package:bonfire/features/spaces/views/accord_search.dart';
+import 'package:bonfire/features/spaces/views/rail_draggable.dart';
 import 'package:bonfire/features/user/views/self_status_button.dart';
 import 'package:bonfire/features/user/views/accord_direct_messages.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
@@ -68,8 +69,6 @@ import 'package:bonfire/features/voice/views/voice_participants.dart';
 import 'package:bonfire/features/voice/views/voice_pip_overlay.dart';
 import 'package:bonfire/theme/theme.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show SchedulerPhase;
 import 'package:flutter/services.dart';
@@ -206,7 +205,12 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
       final channelId = args['channel_id'] as String;
       final messageId = args['message_id'] as String;
       final root = ref
-          .read(accordMessagesControllerProvider(ref.readActiveServerKey() ?? '', channelId))
+          .read(
+            accordMessagesControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              channelId,
+            ),
+          )
           ?.firstWhereOrNull((m) => m.id == messageId);
       if (root == null) return {'error': 'Message not loaded'};
       showAccordThread(context, channelId: channelId, root: root);
@@ -513,7 +517,12 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
 
     final channels = effectiveSpaceId == null
         ? null
-        : ref.watch(accordChannelsControllerProvider(ref.readActiveServerKey() ?? '', effectiveSpaceId));
+        : ref.watch(
+            accordChannelsControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              effectiveSpaceId,
+            ),
+          );
 
     final firstText = channels?.where((c) => c.type == 'text').firstOrNull;
 

--- a/lib/features/spaces/views/accord_home_rail.dart
+++ b/lib/features/spaces/views/accord_home_rail.dart
@@ -389,16 +389,17 @@ class _SpaceRail extends ConsumerWidget {
     ctl.setSpaceOrder([for (final id in rest) ServerEntityKey.tryDecode(id)!]);
   }
 
-  /// Context menu for a space (double-tap / right-click): server actions
-  /// (invite, settings, leave) above the folder-assignment actions. [serverKey]
-  /// is the owning connection's key, so actions hit the right server even when
-  /// it isn't the active one.
+  /// Context menu for a space (long-press on touch / right-click on desktop):
+  /// server actions (invite, settings, leave) above the folder-assignment
+  /// actions. [serverKey] is the owning connection's key, so actions hit the
+  /// right server even when it isn't the active one. [position] anchors the
+  /// menu on desktop; null presents the touch-friendly sheet.
   Future<void> _spaceMenu(
     BuildContext context,
     WidgetRef ref,
     AccordSpace space,
     String serverKey,
-    Offset position,
+    Offset? position,
   ) {
     final settings = ref.read(settingsControllerProvider);
     final ctl = ref.read(settingsControllerProvider.notifier);

--- a/lib/features/spaces/views/accord_home_rail_folders.dart
+++ b/lib/features/spaces/views/accord_home_rail_folders.dart
@@ -53,20 +53,17 @@ class _FolderTileState extends ConsumerState<_FolderTile> {
         ? Color(folder.color!)
         : colors.darkGray;
 
-    final folderIcon = Tooltip(
-      message: folder.name.isEmpty ? 'Folder' : folder.name,
-      child: Container(
-        width: 48,
-        height: 48,
-        decoration: BoxDecoration(
-          color: folderColor.withValues(alpha: 0.5),
-          borderRadius: BorderRadius.circular(16),
-        ),
-        alignment: Alignment.center,
-        child: Icon(
-          folder.collapsed ? Icons.folder : Icons.folder_open,
-          color: colors.dirtyWhite,
-        ),
+    final folderIcon = Container(
+      width: 48,
+      height: 48,
+      decoration: BoxDecoration(
+        color: folderColor.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        folder.collapsed ? Icons.folder : Icons.folder_open,
+        color: colors.dirtyWhite,
       ),
     );
 
@@ -88,19 +85,18 @@ class _FolderTileState extends ConsumerState<_FolderTile> {
             },
             builder: (context, candidate, _) {
               final highlight = candidate.isNotEmpty;
-              return _RailDraggable(
+              return RailDraggable<_RailDrag>(
                 data: _FolderDrag(folder.id),
+                tooltip: folder.name.isEmpty ? 'Folder' : folder.name,
                 feedback: Material(
                   color: Colors.transparent,
                   child: folderIcon,
                 ),
                 childWhenDragging: Opacity(opacity: 0.3, child: folderIcon),
-                onPressMenu: (pos) => _folderMenu(context, ref, pos),
+                onMenu: (pos) => _folderMenu(context, ref, pos),
                 child: GestureDetector(
                   onTap: () =>
                       ctl.setFolderCollapsed(folder.id, !folder.collapsed),
-                  onSecondaryTapUp: (d) =>
-                      _folderMenu(context, ref, d.globalPosition),
                   child: Container(
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(16),
@@ -139,12 +135,15 @@ class _FolderTileState extends ConsumerState<_FolderTile> {
     );
   }
 
+  /// Context menu for a folder member (long-press on touch / right-click on
+  /// desktop): the shared server actions above "remove from folder".
+  /// [position] anchors it on desktop; null presents the touch sheet.
   Future<void> _memberMenu(
     BuildContext context,
     WidgetRef ref,
     SettingsController ctl,
     _RailSpace railSpace,
-    Offset position,
+    Offset? position,
   ) {
     final space = railSpace.space;
     final entries = <AccordMenuEntry>[
@@ -174,7 +173,7 @@ class _FolderTileState extends ConsumerState<_FolderTile> {
   Future<void> _folderMenu(
     BuildContext context,
     WidgetRef ref,
-    Offset position,
+    Offset? position,
   ) {
     final ctl = ref.read(settingsControllerProvider.notifier);
     final entries = <AccordMenuEntry>[
@@ -278,7 +277,10 @@ class _FolderMemberTile extends StatelessWidget {
   /// A space [draggedSpaceId] was dropped on this member: place it before this
   /// member within the folder.
   final ValueChanged<String> onDropBefore;
-  final void Function(Offset position) onMenu;
+
+  /// Open the member's management menu: anchored at [position] (desktop
+  /// right-click) or as a sheet when it is null (touch long-press).
+  final void Function(Offset? position) onMenu;
 
   @override
   Widget build(BuildContext context) {
@@ -301,8 +303,9 @@ class _FolderMemberTile extends StatelessWidget {
       },
       builder: (context, candidate, _) => Opacity(
         opacity: candidate.isNotEmpty ? 0.5 : 1,
-        child: _RailDraggable(
+        child: RailDraggable<_RailDrag>(
           data: _SpaceDrag(entityKey),
+          tooltip: space.name,
           feedback: Material(
             color: Colors.transparent,
             child: _SpaceIcon(
@@ -314,11 +317,8 @@ class _FolderMemberTile extends StatelessWidget {
             ),
           ),
           childWhenDragging: Opacity(opacity: 0.3, child: icon),
-          onPressMenu: onMenu,
-          child: GestureDetector(
-            onSecondaryTapUp: (d) => onMenu(d.globalPosition),
-            child: icon,
-          ),
+          onMenu: onMenu,
+          child: icon,
         ),
       ),
     );

--- a/lib/features/spaces/views/accord_home_rail_tiles.dart
+++ b/lib/features/spaces/views/accord_home_rail_tiles.dart
@@ -17,87 +17,6 @@ class _FolderDrag extends _RailDrag {
   final String folderId;
 }
 
-/// Desktop pointers have no "long press" affordance and scroll via the wheel,
-/// so a drag should start immediately on click-drag. Touch platforms keep the
-/// long-press gesture so dragging doesn't fight finger-scrolling.
-bool get _immediateDrag => switch (defaultTargetPlatform) {
-  TargetPlatform.linux ||
-  TargetPlatform.macOS ||
-  TargetPlatform.windows => true,
-  _ => false,
-};
-
-/// The platform-appropriate draggable for a rail item: an immediate [Draggable]
-/// on desktop (click-drag), a [LongPressDraggable] on touch (press-and-hold to
-/// lift, with haptic, so dragging doesn't fight finger-scrolling).
-///
-/// On touch a long-press that is *released in place* (no drag) is treated as a
-/// context-menu request via [onPressMenu] — that's the menu's discoverable home
-/// there, since touch has no right-click and long-press is the platform's
-/// universal "show actions" gesture. Desktop opens the same menu on right-click
-/// instead (handled by the child), so [onPressMenu] never fires there.
-class _RailDraggable extends StatefulWidget {
-  const _RailDraggable({
-    required this.data,
-    required this.feedback,
-    required this.childWhenDragging,
-    required this.child,
-    this.onPressMenu,
-  });
-
-  final _RailDrag data;
-  final Widget feedback;
-  final Widget childWhenDragging;
-  final Widget child;
-
-  /// Touch only: the user long-pressed and released without dragging at this
-  /// global position — open the item's management menu there.
-  final ValueChanged<Offset>? onPressMenu;
-
-  @override
-  State<_RailDraggable> createState() => _RailDraggableState();
-}
-
-class _RailDraggableState extends State<_RailDraggable> {
-  // Captured on pointer-down so a release-in-place can anchor the menu where the
-  // finger landed (the drag callbacks don't carry the press origin).
-  Offset _downPos = Offset.zero;
-  bool _moved = false;
-
-  @override
-  Widget build(BuildContext context) {
-    if (_immediateDrag) {
-      return Draggable<_RailDrag>(
-        data: widget.data,
-        feedback: widget.feedback,
-        childWhenDragging: widget.childWhenDragging,
-        child: widget.child,
-      );
-    }
-    return Listener(
-      onPointerDown: (e) => _downPos = e.position,
-      child: LongPressDraggable<_RailDrag>(
-        data: widget.data,
-        feedback: widget.feedback,
-        childWhenDragging: widget.childWhenDragging,
-        onDragStarted: () {
-          _moved = false;
-          HapticFeedback.mediumImpact();
-        },
-        onDragUpdate: (d) {
-          if (!_moved && (d.globalPosition - _downPos).distance > 8) {
-            _moved = true;
-          }
-        },
-        onDragEnd: (d) {
-          if (!_moved && !d.wasAccepted) widget.onPressMenu?.call(_downPos);
-        },
-        child: widget.child,
-      ),
-    );
-  }
-}
-
 /// A drop zone occupying the track between two rail items, so a space or folder
 /// can be inserted *at* that position (e.g. between a space and a folder)
 /// instead of only onto an icon. Grows and shows an insertion bar while a
@@ -176,7 +95,10 @@ class _DraggableSpace extends StatelessWidget {
   /// A folder [folderId] was dropped on this tile: move the whole folder before
   /// this space.
   final ValueChanged<String> onDropFolderBefore;
-  final void Function(Offset position) onMenu;
+
+  /// Open the space's management menu: anchored at [position] (desktop
+  /// right-click) or as a sheet when it is null (touch long-press).
+  final void Function(Offset? position) onMenu;
   final String serverKey;
   final String entityKey;
 
@@ -204,8 +126,9 @@ class _DraggableSpace extends StatelessWidget {
       },
       builder: (context, candidate, _) => Opacity(
         opacity: candidate.isNotEmpty ? 0.5 : 1,
-        child: _RailDraggable(
+        child: RailDraggable<_RailDrag>(
           data: _SpaceDrag(entityKey),
+          tooltip: space.name,
           feedback: Material(
             color: Colors.transparent,
             child: _SpaceIcon(
@@ -220,11 +143,8 @@ class _DraggableSpace extends StatelessWidget {
           // Drag drives reorder / grouping; the management menu (new folder,
           // move/remove, leave) opens via long-press on touch and right-click on
           // desktop so it stays reachable everywhere.
-          onPressMenu: onMenu,
-          child: GestureDetector(
-            onSecondaryTapUp: (d) => onMenu(d.globalPosition),
-            child: icon,
-          ),
+          onMenu: onMenu,
+          child: icon,
         ),
       ),
     );
@@ -319,61 +239,61 @@ class _SpaceIcon extends ConsumerWidget {
         context,
       ).textTheme.titleSmall!.copyWith(color: Colors.white),
     );
+    // No Tooltip here: in the rail, [RailDraggable] owns the name tooltip (its
+    // long-press trigger must not compete with the drag / menu gesture), and
+    // the other host — the hidden-servers sheet — prints the name beside it.
     return Center(
-      child: Tooltip(
-        message: space.name,
-        child: GestureDetector(
-          onTap: onTap,
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: [
-              Opacity(
-                opacity: unreachable ? 0.4 : 1.0,
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 120),
-                  width: 48,
-                  height: 48,
-                  clipBehavior: Clip.antiAlias,
-                  decoration: BoxDecoration(
-                    color: selected ? colors.primary : colors.darkGray,
-                    borderRadius: radius,
-                  ),
-                  alignment: Alignment.center,
-                  child: iconUrl == null
-                      ? fallback
-                      : CachedNetworkImage(
-                          imageUrl: iconUrl,
-                          width: 48,
-                          height: 48,
-                          fit: BoxFit.cover,
-                          placeholder: (_, _) => fallback,
-                          errorWidget: (_, _, _) => fallback,
-                        ),
+      child: GestureDetector(
+        onTap: onTap,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Opacity(
+              opacity: unreachable ? 0.4 : 1.0,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                width: 48,
+                height: 48,
+                clipBehavior: Clip.antiAlias,
+                decoration: BoxDecoration(
+                  color: selected ? colors.primary : colors.darkGray,
+                  borderRadius: radius,
                 ),
-              ),
-              if (mentions > 0)
-                Positioned(
-                  right: -4,
-                  top: -2,
-                  child: _MentionBadge(count: mentions),
-                )
-              else if (hasUnread)
-                Positioned(
-                  left: -4,
-                  top: 18,
-                  child: Container(
-                    width: 8,
-                    height: 12,
-                    decoration: const BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.horizontal(
-                        right: Radius.circular(4),
+                alignment: Alignment.center,
+                child: iconUrl == null
+                    ? fallback
+                    : CachedNetworkImage(
+                        imageUrl: iconUrl,
+                        width: 48,
+                        height: 48,
+                        fit: BoxFit.cover,
+                        placeholder: (_, _) => fallback,
+                        errorWidget: (_, _, _) => fallback,
                       ),
+              ),
+            ),
+            if (mentions > 0)
+              Positioned(
+                right: -4,
+                top: -2,
+                child: _MentionBadge(count: mentions),
+              )
+            else if (hasUnread)
+              Positioned(
+                left: -4,
+                top: 18,
+                child: Container(
+                  width: 8,
+                  height: 12,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.horizontal(
+                      right: Radius.circular(4),
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/features/spaces/views/rail_draggable.dart
+++ b/lib/features/spaces/views/rail_draggable.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Desktop pointers have no "long press" affordance and scroll via the wheel,
+/// so a drag should start immediately on click-drag. Touch platforms keep the
+/// long-press gesture so dragging doesn't fight finger-scrolling.
+bool get railDragsImmediately => switch (defaultTargetPlatform) {
+  TargetPlatform.linux ||
+  TargetPlatform.macOS ||
+  TargetPlatform.windows => true,
+  _ => false,
+};
+
+/// The platform-appropriate draggable for a space-rail item (a space, a folder
+/// member or a folder): an immediate [Draggable] on desktop (click-drag), a
+/// [LongPressDraggable] on touch (press-and-hold to lift, with haptic, so
+/// dragging doesn't fight finger-scrolling).
+///
+/// It also owns the item's context-menu triggers and its [tooltip], because
+/// the three gestures share one arena and have to be reconciled here:
+///
+/// * Desktop: right-click opens the menu anchored at the pointer; the tooltip
+///   shows on hover as usual.
+/// * Touch: a long-press lifts the tile (haptic). Releasing it *in place* —
+///   without dragging and without a drop being accepted — opens the menu
+///   ([onMenu] with a null position, i.e. the touch-friendly bottom sheet);
+///   moving the finger instead reorders as before. Touch has no right-click,
+///   and long-press is the platform's universal "show actions" gesture.
+///
+/// On touch the tooltip's own long-press trigger is disabled
+/// ([TooltipTriggerMode.manual]; hover still works with a mouse). Left at the
+/// default, [Tooltip] adds a `LongPressGestureRecognizer` with the same
+/// timeout as [LongPressDraggable]'s delayed drag recogniser, and being the
+/// inner listener its timer fires first and *always* wins the arena — so a
+/// long press showed the space's name and the drag (and with it the menu)
+/// never started (#327). The name is shown as the sheet's title instead.
+class RailDraggable<T extends Object> extends StatefulWidget {
+  const RailDraggable({
+    super.key,
+    required this.data,
+    required this.tooltip,
+    required this.feedback,
+    required this.childWhenDragging,
+    required this.child,
+    this.onMenu,
+  });
+
+  final T data;
+
+  /// The item's name: a hover tooltip on desktop, the menu sheet's title on
+  /// touch (via the caller's [onMenu]).
+  final String tooltip;
+  final Widget feedback;
+  final Widget childWhenDragging;
+  final Widget child;
+
+  /// Open the item's management menu. [position] is the global right-click
+  /// position on desktop (anchor the menu there) and null for a touch
+  /// long-press (present it as a bottom sheet).
+  final void Function(Offset? position)? onMenu;
+
+  @override
+  State<RailDraggable<T>> createState() => _RailDraggableState<T>();
+}
+
+class _RailDraggableState<T extends Object> extends State<RailDraggable<T>> {
+  // Where the finger landed, and whether it has since travelled far enough to
+  // count as a drag rather than a hold. Tracked on the raw pointer stream (the
+  // drag callbacks don't carry the press origin) so a release-in-place can be
+  // told apart from a reorder that happened to miss every drop target.
+  Offset? _downPosition;
+  bool _moved = false;
+
+  void _onPointerDown(PointerDownEvent event) {
+    _downPosition = event.position;
+    _moved = false;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    final down = _downPosition;
+    if (_moved || down == null) return;
+    if ((event.position - down).distance > kTouchSlop) _moved = true;
+  }
+
+  // A system cancel (incoming call, notification shade) ends the drag without
+  // a release; that is not a request for the menu.
+  void _onPointerCancel(PointerCancelEvent event) => _moved = true;
+
+  void _onDragEnd(DraggableDetails details) {
+    if (!_moved && !details.wasAccepted) widget.onMenu?.call(null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final onMenu = widget.onMenu;
+    final desktop = railDragsImmediately;
+    final child = Tooltip(
+      message: widget.tooltip,
+      triggerMode: desktop ? null : TooltipTriggerMode.manual,
+      child: GestureDetector(
+        onSecondaryTapUp: onMenu == null
+            ? null
+            : (d) => onMenu(d.globalPosition),
+        child: widget.child,
+      ),
+    );
+    if (desktop) {
+      return Draggable<T>(
+        data: widget.data,
+        feedback: widget.feedback,
+        childWhenDragging: widget.childWhenDragging,
+        child: child,
+      );
+    }
+    return Listener(
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerCancel: _onPointerCancel,
+      child: LongPressDraggable<T>(
+        data: widget.data,
+        feedback: widget.feedback,
+        childWhenDragging: widget.childWhenDragging,
+        // One clear "lifted" pulse instead of the framework's selection click
+        // plus ours.
+        hapticFeedbackOnStart: false,
+        onDragStarted: HapticFeedback.mediumImpact,
+        onDragEnd: _onDragEnd,
+        child: child,
+      ),
+    );
+  }
+}

--- a/test/features/spaces/rail_draggable_test.dart
+++ b/test/features/spaces/rail_draggable_test.dart
@@ -203,6 +203,29 @@ void main() {
       expect(find.text('Mute server'), findsNothing);
     }, variant: touch);
 
+    testWidgets('a system pointer cancel after lifting opens no menu', (
+      tester,
+    ) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(_tile('space5')),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pump(_hold);
+      expect(_feedback('space5'), findsOneWidget, reason: 'lifted');
+
+      // An incoming call or notification shade cancels the pointer without
+      // a release — must not be read as "release in place" (#327).
+      await gesture.cancel();
+      await tester.pumpAndSettle();
+
+      expect(log, isEmpty);
+      expect(find.text('Mute server'), findsNothing);
+      expect(_feedback('space5'), findsNothing);
+    }, variant: touch);
+
     testWidgets('a quick finger-scroll still scrolls the rail', (tester) async {
       final log = <String>[];
       await tester.pumpWidget(_app(log));

--- a/test/features/spaces/rail_draggable_test.dart
+++ b/test/features/spaces/rail_draggable_test.dart
@@ -1,0 +1,277 @@
+import 'package:bonfire/features/spaces/views/rail_draggable.dart';
+import 'package:bonfire/shared/components/context_menu.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _theme = BonfireThemeExtension(
+  foreground: Colors.white,
+  background: Color(0xFF1e1f22),
+  dirtyWhite: Color(0xFFdcddde),
+  gray: Color(0xFF949ba4),
+  darkGray: Color(0xFF4e5058),
+  primary: Color(0xFF5865f2),
+  red: Color(0xFFed4245),
+  green: Color(0xFF23a55a),
+  yellow: Color(0xFFf0b232),
+);
+
+/// Replicates the space rail's gesture stack (#327): a scrollable column of
+/// [RailDraggable] tiles whose child — like `_SpaceIcon` — has its own tap
+/// detector, and whose menu is the real [showAccordContextMenu]. Stripped of
+/// Riverpod/network so the gesture arena can be exercised alone.
+class _Rail extends StatefulWidget {
+  const _Rail({required this.log});
+
+  final List<String> log;
+
+  @override
+  State<_Rail> createState() => _RailState();
+}
+
+class _RailState extends State<_Rail> {
+  final _scroll = ScrollController();
+  String? _dropped;
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  Widget _tile(BuildContext context, String name) => RailDraggable<String>(
+    key: ValueKey('tile-$name'),
+    data: name,
+    tooltip: name,
+    feedback: SizedBox(
+      key: ValueKey('feedback-$name'),
+      width: 48,
+      height: 48,
+      child: const ColoredBox(color: Colors.blue),
+    ),
+    childWhenDragging: const SizedBox(width: 48, height: 48),
+    onMenu: (position) {
+      widget.log.add('menu:$name:${position == null ? 'sheet' : 'anchored'}');
+      showAccordContextMenu(
+        context,
+        entries: [
+          AccordMenuEntry(
+            label: 'Mute server',
+            icon: Icons.notifications_off_outlined,
+            onSelected: () => widget.log.add('mute:$name'),
+          ),
+        ],
+        globalPosition: position,
+      );
+    },
+    child: GestureDetector(
+      onTap: () => widget.log.add('tap:$name'),
+      child: SizedBox(
+        width: 48,
+        height: 48,
+        child: ColoredBox(color: Colors.grey, child: Text('icon-$name')),
+      ),
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) => Row(
+    children: [
+      SizedBox(
+        width: 72,
+        child: ListView(
+          controller: _scroll,
+          children: [
+            for (var i = 0; i < 30; i++)
+              Padding(
+                padding: const EdgeInsets.all(6),
+                child: Center(
+                  child: Builder(builder: (ctx) => _tile(ctx, 'space$i')),
+                ),
+              ),
+          ],
+        ),
+      ),
+      Expanded(
+        child: DragTarget<String>(
+          onAcceptWithDetails: (d) => setState(() => _dropped = d.data),
+          builder: (_, _, _) => Center(
+            child: Text(_dropped == null ? 'drop here' : 'dropped:$_dropped'),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+Widget _app(List<String> log) => MaterialApp(
+  theme: ThemeData(extensions: const [_theme]),
+  home: Scaffold(body: _Rail(log: log)),
+);
+
+Finder _tile(String name) => find.byKey(ValueKey('tile-$name'));
+Finder _feedback(String name) => find.byKey(ValueKey('feedback-$name'));
+
+/// A hold long enough for [LongPressDraggable] to lift the tile.
+const _hold = Duration(milliseconds: 600);
+
+void main() {
+  const touch = TargetPlatformVariant({
+    TargetPlatform.android,
+    TargetPlatform.iOS,
+  });
+  const desktop = TargetPlatformVariant({TargetPlatform.linux});
+
+  group('RailDraggable on touch', () {
+    testWidgets('a long-press released in place opens the menu as a sheet', (
+      tester,
+    ) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      await tester.longPress(_tile('space1'), kind: PointerDeviceKind.touch);
+      await tester.pumpAndSettle();
+
+      expect(log, ['menu:space1:sheet']);
+      expect(find.text('Mute server'), findsOneWidget);
+      expect(find.byType(BottomSheet), findsOneWidget);
+      // The regression: the name tooltip must not have claimed the press.
+      expect(find.text('space1'), findsNothing);
+      expect(_feedback('space1'), findsNothing);
+
+      await tester.tap(find.text('Mute server'));
+      await tester.pumpAndSettle();
+      expect(log, ['menu:space1:sheet', 'mute:space1']);
+      expect(find.byType(BottomSheet), findsNothing);
+    }, variant: touch);
+
+    testWidgets('a plain tap selects the space without a menu', (tester) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      await tester.tap(_tile('space2'), kind: PointerDeviceKind.touch);
+      await tester.pumpAndSettle();
+
+      expect(log, ['tap:space2']);
+      expect(find.text('Mute server'), findsNothing);
+      expect(_feedback('space2'), findsNothing);
+    }, variant: touch);
+
+    testWidgets('a long-press then drag lifts the tile, and a drop opens '
+        'no menu', (tester) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(_tile('space3')),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pump(_hold);
+      expect(_feedback('space3'), findsOneWidget, reason: 'lifted');
+      expect(find.text('Mute server'), findsNothing);
+
+      await gesture.moveBy(const Offset(300, 0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text('dropped:space3'), findsOneWidget);
+      expect(log, isEmpty);
+      expect(find.text('Mute server'), findsNothing);
+    }, variant: touch);
+
+    testWidgets('a drag that misses every target opens no menu either', (
+      tester,
+    ) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(_tile('space3')),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pump(_hold);
+      // Down the rail, still over the list (no drop target) — a reorder
+      // attempt that fell through, not a request for actions.
+      await gesture.moveBy(const Offset(0, 120));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(log, isEmpty);
+      expect(find.text('Mute server'), findsNothing);
+    }, variant: touch);
+
+    testWidgets('a quick finger-scroll still scrolls the rail', (tester) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+      final scrollable = find.byType(Scrollable).first;
+      final state = tester.state<ScrollableState>(scrollable);
+      expect(state.position.pixels, 0);
+
+      await tester.drag(
+        _tile('space4'),
+        const Offset(0, -200),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pumpAndSettle();
+
+      expect(state.position.pixels, greaterThan(0));
+      expect(log, isEmpty);
+      expect(find.text('Mute server'), findsNothing);
+      expect(_feedback('space4'), findsNothing);
+    }, variant: touch);
+  });
+
+  group('RailDraggable on desktop', () {
+    testWidgets('right-click opens the menu anchored at the pointer', (
+      tester,
+    ) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      await tester.tap(
+        _tile('space1'),
+        kind: PointerDeviceKind.mouse,
+        buttons: kSecondaryButton,
+      );
+      await tester.pumpAndSettle();
+
+      expect(log, ['menu:space1:anchored']);
+      expect(find.text('Mute server'), findsOneWidget);
+      expect(find.byType(BottomSheet), findsNothing);
+    }, variant: desktop);
+
+    testWidgets('a click-drag starts immediately', (tester) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(_tile('space2')),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(300, 0));
+      await tester.pump();
+      expect(_feedback('space2'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text('dropped:space2'), findsOneWidget);
+      expect(log, isEmpty);
+    }, variant: desktop);
+
+    testWidgets('hovering shows the name tooltip', (tester) async {
+      final log = <String>[];
+      await tester.pumpWidget(_app(log));
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(_tile('space1')));
+      await tester.pump(const Duration(seconds: 2));
+
+      expect(find.text('space1'), findsOneWidget);
+    }, variant: desktop);
+  });
+}


### PR DESCRIPTION
Closes #327

## Root cause
Each rail tile wrapped itself in a `Tooltip`. On touch, `Tooltip` installs its own `LongPressGestureRecognizer` with the same timeout as `LongPressDraggable`'s delayed drag recogniser, and as the inner listener its timer fires first and always wins the gesture arena. A long press therefore only showed the space's name: the tile never lifted, so the release-in-place menu path and touch reorder/grouping were both unreachable.

## Change
- New `RailDraggable<T>` (`lib/features/spaces/views/rail_draggable.dart`) owns the tooltip, the drag and both menu triggers for spaces, folder members and folders. On touch the tooltip's long-press trigger is disabled (`TooltipTriggerMode.manual`; hover still works with a mouse), so a long press lifts the tile with a single haptic, releasing in place opens the menu, and moving the finger reorders as before. Movement is measured on the raw pointer stream with `kTouchSlop`, and a pointer cancel never opens the menu.
- Touch passes a null anchor so `showAccordContextMenu` uses its existing bottom-sheet presentation (large rows, in-viewport, scrollable) even in landscape; right-click keeps the anchored popup. Destructive actions keep their confirmations.

## Tests
`test/features/spaces/rail_draggable_test.dart`: touch long-press opens the menu, tap still selects, long-press-then-drag lifts without opening the menu, scroll before the timeout doesn't lift, pointer cancel doesn't open the menu (each on Android and iOS), plus desktop right-click and immediate drag. The long-press cases fail against the old tooltip trigger.

Haptic feel and the sheet on a physical phone are not verified without a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)