### PR TITLE
fix(voice): request the mic up front and keep SFX from breaking call audio on mobile

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,16 @@
         android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission
         android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- Voice calls over a Bluetooth headset: flutter_webrtc's AudioSwitch only
+         enumerates/routes to Bluetooth SCO devices when the app holds the
+         Bluetooth permission — BLUETOOTH up to Android 11 (a normal permission,
+         granted at install) and the runtime BLUETOOTH_CONNECT from Android 12.
+         Neither plugin declares these itself. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_CONNECT" />
     <!-- REQUEST_INSTALL_PACKAGES (in-app self-update) is declared only in the
          `github` flavor (src/github/AndroidManifest.xml). The Play build omits it
          and updates through Google Play. -->

--- a/lib/features/notifications/services/sound.dart
+++ b/lib/features/notifications/services/sound.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 // `dart:io` isn't available on web; universal_io's Platform reports an empty
 // environment there, which is the right answer for this check anyway.
@@ -50,8 +53,10 @@ class SoundManager {
   /// Lazy so a silent manager never builds a player. `audioplayers` reaches the
   /// platform on first use, not construction, but building four of them plus a
   /// ringtone player in a test process is pointless either way.
-  late final List<AudioPlayer> _pool =
-      List.generate(_poolSize, (_) => AudioPlayer());
+  late final List<AudioPlayer> _pool = List.generate(
+    _poolSize,
+    (_) => AudioPlayer(),
+  );
   int _next = 0;
   bool _initialized = false;
 
@@ -72,6 +77,16 @@ class SoundManager {
   /// Mirrors `AccordSettings.sfxVolume` (0.0–1.0).
   double volume = 1.0;
 
+  /// Whether a LiveKit voice session is live. `VoiceController` raises this
+  /// before the media session connects and clears it after it disconnects; see
+  /// [allowsOneShotInCall] for what it gates.
+  bool _voiceSessionActive = false;
+  bool get voiceSessionActive => _voiceSessionActive;
+
+  void setVoiceSessionActive(bool active) {
+    _voiceSessionActive = active;
+  }
+
   void init() {
     if (silent || _initialized) return;
     _initialized = true;
@@ -79,15 +94,120 @@ class SoundManager {
       player.setReleaseMode(ReleaseMode.stop);
     }
     _ringPlayer.setReleaseMode(ReleaseMode.loop);
+    _applyAudioContext();
     _lifecycle = AppLifecycleListener(
       onStateChange: (state) => focused = state == AppLifecycleState.resumed,
     );
   }
 
+  /// Configures how our players interact with the platform audio session, once
+  /// at startup, so nothing about a chime ever has to change while a voice
+  /// call is live. Mobile only — the desktop/web backends have no such context.
+  ///
+  /// Android: applied per player rather than through `AudioPlayer.global`,
+  /// because `audioplayers_android` bakes the global default into a player at
+  /// creation and our players already exist. (Both paths also write
+  /// `AudioManager.mode`/`isSpeakerphoneOn` — at startup that is harmless;
+  /// mid-call it would undo flutter_webrtc's `MODE_IN_COMMUNICATION`, which is
+  /// exactly why this is never called again later.)
+  ///
+  /// iOS: `audioplayers_darwin` has a single global `AVAudioSession` category,
+  /// so it is set once via the global scope.
+  void _applyAudioContext() {
+    if (kIsWeb) return;
+    final context = audioContextFor(defaultTargetPlatform);
+    if (context == null) return;
+    Future<void> apply(Future<void> Function() op, String what) async {
+      try {
+        await op();
+      } catch (e) {
+        debugPrint('SoundManager: $what audio context failed: $e');
+      }
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      unawaited(
+        apply(() => AudioPlayer.global.setAudioContext(context), 'global'),
+      );
+      return;
+    }
+    for (final player in _pool) {
+      unawaited(apply(() => player.setAudioContext(context), 'sfx'));
+    }
+    unawaited(apply(() => _ringPlayer.setAudioContext(context), 'ringtone'));
+  }
+
+  /// The audioplayers context for our SFX and ringtone players on [platform],
+  /// or null where the backend has none (desktop, web). Pure so the choice can
+  /// be unit-tested without the plugin.
+  ///
+  /// * **Android** — `audioFocus: none`: a chime must not request (and on
+  ///   completion abandon) audio focus while flutter_webrtc's `AudioSwitch`
+  ///   holds it for the call, and outside a call a 300 ms chime has no business
+  ///   pausing whatever is playing. Everything else stays at the plugin
+  ///   defaults so volume/routing semantics are unchanged (media stream,
+  ///   `MODE_NORMAL` — only ever written at startup, see [_applyAudioContext]).
+  /// * **iOS** — `playback` + `mixWithOthers`: the plugin default minus the
+  ///   "interrupt other apps" behaviour. The category itself is irrelevant to a
+  ///   call: LiveKit reconfigures the session to `playAndRecord`/`voiceChat`
+  ///   through `RTCAudioSession` when the first audio track appears
+  ///   (`packages/livekit_client/lib/src/track/audio_management.dart`).
+  static AudioContext? audioContextFor(TargetPlatform platform) {
+    switch (platform) {
+      case TargetPlatform.android:
+        return AudioContext(
+          android: const AudioContextAndroid(
+            contentType: AndroidContentType.sonification,
+            audioFocus: AndroidAudioFocus.none,
+          ),
+        );
+      case TargetPlatform.iOS:
+        return AudioContext(
+          iOS: AudioContextIOS(
+            category: AVAudioSessionCategory.playback,
+            options: const {AVAudioSessionOptions.mixWithOthers},
+          ),
+        );
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return null;
+    }
+  }
+
+  /// Whether a one-shot chime may play while a voice session is live.
+  ///
+  /// False only on iOS. There, `audioplayers_darwin` calls
+  /// `AVAudioSession.setActive(false)` on the shared session every time a
+  /// one-shot finishes and no other player is running
+  /// (`WrappedMediaPlayer.onSoundComplete` → `controlAudioSession` →
+  /// `AudioContext.activateAudioSession(active: false)`). That is the very
+  /// session WebRTC's `RTCAudioSession` is driving the call through, and
+  /// deactivating it underneath WebRTC stops capture and playback — the
+  /// "connected, permission granted, no audio either way" call (#323). No
+  /// `AudioContext` avoids that call, so in-call chimes are skipped on iOS.
+  /// The looping ringtone is unaffected: a loop resumes on completion, so the
+  /// session is only ever re-*activated*, and `stopRingtone` doesn't touch it.
+  ///
+  /// Android's backend only requests/abandons audio focus around playback,
+  /// which [audioContextFor] turns off, so chimes are safe there; web and
+  /// desktop have no shared session at all.
+  static bool allowsOneShotInCall({
+    required TargetPlatform platform,
+    required bool isWeb,
+  }) => isWeb || platform != TargetPlatform.iOS;
+
   /// Plays the named SFX from [_sounds]. No-ops when disabled, muted, or the
-  /// name is unknown.
+  /// name is unknown — and, while a voice session is live, on the platforms
+  /// where a one-shot would break the call's audio session
+  /// ([allowsOneShotInCall]).
   Future<void> play(String name) async {
     if (silent || !enabled || volume <= 0.0) return;
+    if (_voiceSessionActive &&
+        !allowsOneShotInCall(platform: defaultTargetPlatform, isWeb: kIsWeb)) {
+      return;
+    }
     final asset = _sounds[name];
     if (asset == null) return;
 

--- a/lib/features/voice/controllers/voice.dart
+++ b/lib/features/voice/controllers/voice.dart
@@ -188,6 +188,7 @@ class VoiceController extends _$VoiceController {
       _afkMonitor = null;
       _session?.dispose();
       _session = null;
+      soundManager.setVoiceSessionActive(false);
     });
     return const VoiceConnection();
   }
@@ -254,12 +255,16 @@ class VoiceController extends _$VoiceController {
     _session ??= _buildSession();
     _reconnectAttempted = false;
 
-    final result = await client.voice
-        .join(channelId, selfMute: state.selfMute, selfDeaf: state.selfDeaf);
+    final result = await client.voice.join(
+      channelId,
+      selfMute: state.selfMute,
+      selfDeaf: state.selfDeaf,
+    );
     final info = result.data;
     if (!result.ok || info is! AccordVoiceServerUpdate) {
       state = state.copyWith(
-          error: result.error?.message ?? 'Failed to join voice channel');
+        error: result.error?.message ?? 'Failed to join voice channel',
+      );
       return;
     }
     final url = info.livekitUrl;
@@ -267,7 +272,8 @@ class VoiceController extends _$VoiceController {
     if (url == null || url.isEmpty || token == null || token.isEmpty) {
       await client.voice.leave(channelId);
       state = state.copyWith(
-          error: 'Voice backend unavailable — server returned no credentials');
+        error: 'Voice backend unavailable — server returned no credentials',
+      );
       return;
     }
 
@@ -279,6 +285,9 @@ class VoiceController extends _$VoiceController {
       clearError: true,
     );
     final settings = ref.read(settingsControllerProvider);
+    // Flag the live call *before* the media session comes up, so no chime can
+    // reconfigure the platform audio session underneath it (#323).
+    soundManager.setVoiceSessionActive(true);
     await _session!.connect(
       url,
       token,
@@ -289,8 +298,21 @@ class VoiceController extends _$VoiceController {
       outputVolume: settings.outputVolume,
       inputVolume: settings.inputVolume,
     );
+    _applyMicOutcome();
     soundManager.play('voice_join');
     await _refreshVoiceStates(channelId);
+  }
+
+  /// After a (re)connect: if the microphone could not be captured or
+  /// published — the OS denied access, no input device, publish failure —
+  /// reflect that honestly. We stay in the channel (you can still listen) but
+  /// as *muted*, tell the server so, and surface the reason in the voice bar
+  /// rather than showing a live mic that sends nothing (#325).
+  void _applyMicOutcome() {
+    final micError = _session?.micError;
+    if (micError == null || !state.isConnected || state.selfMute) return;
+    state = state.copyWith(selfMute: true, error: micError);
+    _sendVoiceStateUpdate();
   }
 
   /// Leaves the current voice channel and tears the session down.
@@ -304,6 +326,7 @@ class VoiceController extends _$VoiceController {
     if (channelId == null) return;
     _reconnectAttempted = false;
     await _session?.disconnect();
+    soundManager.setVoiceSessionActive(false);
     await _client?.voice.leave(channelId);
     soundManager.play('voice_leave');
     state = const VoiceConnection();
@@ -314,9 +337,22 @@ class VoiceController extends _$VoiceController {
   void setMute(bool muted) {
     _afkMonitor?.markActivity();
     if (!state.isConnected) return;
-    _session?.setMicEnabled(!muted);
     state = state.copyWith(selfMute: muted);
     soundManager.play(muted ? 'mute' : 'unmute');
+    _sendVoiceStateUpdate();
+    final session = _session;
+    if (session != null) unawaited(_applyMic(session, enabled: !muted));
+  }
+
+  /// Applies a mute toggle to the media session. An *unmute* that fails (the
+  /// OS denied the mic, no capture device) is reverted so the bar doesn't show
+  /// a live mic that isn't, and the reason is surfaced.
+  Future<void> _applyMic(VoiceSession session, {required bool enabled}) async {
+    final error = await session.setMicEnabled(enabled);
+    if (error == null || !enabled || !state.isConnected || state.selfMute) {
+      return;
+    }
+    state = state.copyWith(selfMute: true, error: error);
     _sendVoiceStateUpdate();
   }
 
@@ -397,8 +433,13 @@ class VoiceController extends _$VoiceController {
     if (url == null || url.isEmpty || token == null || token.isEmpty) return;
     final sessionState = _session?.state;
     if (sessionState == null || !needsReconnect(sessionState)) return;
-    await _session?.connect(url, token,
-        selfMute: state.selfMute, selfDeaf: state.selfDeaf);
+    await _session?.connect(
+      url,
+      token,
+      selfMute: state.selfMute,
+      selfDeaf: state.selfDeaf,
+    );
+    _applyMicOutcome();
   }
 
   /// The server removed us from voice (our gateway state's channel went null).
@@ -418,6 +459,7 @@ class VoiceController extends _$VoiceController {
     if (leftChannel != null && state.channelId != leftChannel) return;
     _reconnectAttempted = false;
     await _session?.disconnect();
+    soundManager.setVoiceSessionActive(false);
     state = const VoiceConnection();
     _syncAfk();
   }
@@ -494,8 +536,11 @@ class VoiceController extends _$VoiceController {
     if (client == null) return;
     _reconnectAttempted = true;
 
-    final result = await client.voice
-        .join(channelId, selfMute: state.selfMute, selfDeaf: state.selfDeaf);
+    final result = await client.voice.join(
+      channelId,
+      selfMute: state.selfMute,
+      selfDeaf: state.selfDeaf,
+    );
     final info = result.data;
     if (!result.ok || info is! AccordVoiceServerUpdate) {
       state = state.copyWith(
@@ -524,6 +569,7 @@ class VoiceController extends _$VoiceController {
       outputVolume: settings.outputVolume,
       inputVolume: settings.inputVolume,
     );
+    _applyMicOutcome();
   }
 
   Future<void> _refreshVoiceStates(String channelId) async {
@@ -629,13 +675,15 @@ class VoiceController extends _$VoiceController {
     );
     ref
         .read(presenceControllerProvider(serverKey).notifier)
-        .upsert(AccordPresence(
-          userId: userId,
-          status: status,
-          activities: custom == null
-              ? []
-              : [AccordActivity(name: custom, type: 'custom')],
-        ));
+        .upsert(
+          AccordPresence(
+            userId: userId,
+            status: status,
+            activities: custom == null
+                ? []
+                : [AccordActivity(name: custom, type: 'custom')],
+          ),
+        );
   }
 
   /// Moves us into the space's designated AFK channel, when it has one.

--- a/lib/features/voice/controllers/voice.g.dart
+++ b/lib/features/voice/controllers/voice.g.dart
@@ -53,7 +53,7 @@ final class VoiceControllerProvider
   }
 }
 
-String _$voiceControllerHash() => r'e07d65e68046284c9f9a9a63f5e791b9cd51952f';
+String _$voiceControllerHash() => r'9ad5dd605a2b045e92724d20550bf8230eed1482';
 
 /// Orchestrates voice channel join/leave and media toggles, the Dart port of
 /// the reference `client_voice.gd` + the voice slice of its `AppState`. Owns a

--- a/lib/features/voice/services/voice_session.dart
+++ b/lib/features/voice/services/voice_session.dart
@@ -31,6 +31,20 @@ class VoiceSession {
   bool _deafened = false;
   bool _intentionalDisconnect = false;
 
+  /// Why the microphone is *not* live after the last [connect] (or the last
+  /// [setMicEnabled] `true`): the OS denied microphone access, no capture
+  /// device, or the publish itself failed. Null when the mic was published or
+  /// simply wasn't requested (joined muted). The controller reads this right
+  /// after `connect` to keep the UI honest — muted, with the reason — rather
+  /// than showing a live mic that isn't (#325).
+  String? _micError;
+
+  /// How long to wait for the local participant to exist after `Room.connect`
+  /// before giving up on the initial mic publish. Only ever waited on in the
+  /// rare case the join-response listener hasn't finished when `connect`
+  /// returns.
+  static const _localParticipantTimeout = Duration(seconds: 10);
+
   /// Output (remote-audio) gain as a 0–2 multiplier; applied to every remote
   /// audio track. The reference dropped to -80 dB for deafen; here LiveKit has
   /// no per-track volume so we lean on the WebRTC track volume.
@@ -71,6 +85,9 @@ class VoiceSession {
   Room? get room => _room;
   VoiceSessionState get state => _state;
   String? get lastError => _lastError;
+
+  /// See [_micError].
+  String? get micError => _micError;
 
   LocalParticipant? get localParticipant => _room?.localParticipant;
 
@@ -179,20 +196,40 @@ class VoiceSession {
 
     _setState(VoiceSessionState.connecting);
     _lastError = null;
+    _micError = null;
+
+    // Capture the microphone *before* joining the room. On mobile this is what
+    // raises the OS microphone prompt — flutter_webrtc's `getUserMedia` calls
+    // `AVCaptureDevice requestAccessForMediaType:` on iOS and requests
+    // RECORD_AUDIO on Android — so the user is asked up front, at join, rather
+    // than at whichever later toggle happens to be the first real capture. It
+    // also makes a denied/failed capture a *reported* outcome ([micError])
+    // instead of a silently skipped publish: the old path was a null-aware
+    // `localParticipant?.setMicrophoneEnabled` inside an error-swallowing
+    // guard, and when that did nothing the first `mute` was a no-op and the
+    // `unmute` created the track — and prompted — for the first time (#325).
+    LocalAudioTrack? micTrack;
+    if (!selfMute) {
+      try {
+        micTrack = await LocalAudioTrack.create(
+          AudioCaptureOptions(deviceId: captureDeviceId),
+        );
+      } catch (e) {
+        _micError = describeMicFailure(e);
+        debugPrint('LiveKit mic capture failed: $e');
+      }
+    }
+
     try {
       await room.connect(url, token);
       // The new connection is live — genuine drops from here are unintentional.
       _intentionalDisconnect = false;
-      // The SDK publishes the mic for us; honour the initial mute state and the
-      // chosen capture device (we no longer bake it into RoomOptions, since the
-      // Room outlives any single device selection).
-      await _guardMedia(
-        'mic',
-        () => room.localParticipant?.setMicrophoneEnabled(
-          !selfMute,
-          audioCaptureOptions: AudioCaptureOptions(deviceId: captureDeviceId),
-        ),
-      );
+      if (micTrack != null) {
+        // Ownership moves to the publication (or is released on failure).
+        final track = micTrack;
+        micTrack = null;
+        await _publishMic(room, track);
+      }
       if (selfDeaf) await _applyDeafen(true);
       await _applyOutputDevice(audioOutputDeviceId);
       await _applyOutputGain();
@@ -203,9 +240,57 @@ class VoiceSession {
       _lastError = '$e';
       debugPrint('LiveKit connect failed: $e');
       _setState(VoiceSessionState.failed);
+      await _releaseTrack(micTrack);
       // Soft cleanup — keep the Room so the next attempt can reuse it.
       await _softDisconnect();
     }
+  }
+
+  /// Publishes the pre-captured microphone [track]. Unlike the other media
+  /// toggles this is *not* fire-and-forget: a failure is recorded in
+  /// [micError] (and the track released) so the controller can show it.
+  Future<void> _publishMic(Room room, LocalAudioTrack track) async {
+    try {
+      final participant = await _awaitLocalParticipant(room);
+      await participant.publishAudioTrack(track);
+    } catch (e) {
+      _micError = describeMicFailure(e);
+      debugPrint('LiveKit mic publish failed: $e');
+      await _releaseTrack(track);
+    }
+  }
+
+  /// `Room.connect` resolves on the engine's join/ICE events, while the local
+  /// participant is created by an async listener on that same join response
+  /// and is only guaranteed once `RoomConnectedEvent` fires. Normally it exists
+  /// by the time `connect` returns; if not, wait for it rather than silently
+  /// skipping the publish.
+  Future<LocalParticipant> _awaitLocalParticipant(Room room) async {
+    final existing = room.localParticipant;
+    if (existing != null) return existing;
+    final listener = _listener;
+    if (listener != null) {
+      await listener.waitFor<RoomConnectedEvent>(
+        duration: _localParticipantTimeout,
+        onTimeout: () => throw TrackPublishException(
+          'Timed out waiting for the room to finish connecting',
+        ),
+      );
+    }
+    final participant = room.localParticipant;
+    if (participant == null) {
+      throw TrackPublishException('Room connected without a local participant');
+    }
+    return participant;
+  }
+
+  /// Stops and disposes a local track we created but never published.
+  Future<void> _releaseTrack(LocalTrack? track) async {
+    if (track == null) return;
+    await _guardMedia('release track', () async {
+      await track.stop();
+      await track.dispose();
+    });
   }
 
   /// Lazily creates the one [Room] this session uses for its entire lifetime,
@@ -259,11 +344,31 @@ class VoiceSession {
   /// auto-reconnect). The Room is only fully released in [dispose].
   Future<void> disconnect() => _softDisconnect();
 
-  Future<void> setMicEnabled(bool enabled) async {
-    await _guardMedia(
-      'mic',
-      () => _room?.localParticipant?.setMicrophoneEnabled(enabled),
-    );
+  /// Mutes or unmutes the microphone. An unmute with no published mic (the
+  /// initial capture failed, or we joined muted) creates and publishes the
+  /// track — on mobile that is where the OS permission prompt appears if it
+  /// hasn't yet.
+  ///
+  /// Returns null once the mic is in the requested state, or the user-facing
+  /// reason an *unmute* failed (permission denied, no capture device) so the
+  /// controller can revert to muted and say why. Muting never fails: stopping a
+  /// track the OS already tore down is harmless.
+  Future<String?> setMicEnabled(bool enabled) async {
+    final participant = _room?.localParticipant;
+    if (participant == null) return null;
+    try {
+      await participant.setMicrophoneEnabled(enabled);
+      if (enabled) {
+        _micError = null;
+        // Unmuting restarts the capture track, which drops the applied gain.
+        await _applyInputGain();
+      }
+      return null;
+    } catch (e) {
+      debugPrint('LiveKit mic toggle failed: $e');
+      if (!enabled) return null;
+      return _micError = describeMicFailure(e);
+    }
   }
 
   /// Silences (or restores) every remote participant's audio locally. LiveKit

--- a/lib/features/voice/utils/voice_logic.dart
+++ b/lib/features/voice/utils/voice_logic.dart
@@ -84,3 +84,36 @@ bool isVoiceDoubleTap(DateTime? lastTapAt, DateTime now) =>
     lastTapAt != null &&
     !now.isBefore(lastTapAt) &&
     now.difference(lastTapAt) <= voiceDoubleTapWindow;
+
+/// The voice-bar message shown when the microphone could not be captured
+/// because the OS denied (or has not granted) microphone access.
+const String micPermissionDeniedMessage =
+    'Microphone access is unavailable — enable it in Settings';
+
+/// Whether a failed microphone capture/publish was a *permission* failure, as
+/// opposed to a device/transport problem.
+///
+/// The error surfaces differently per platform: iOS and web reject
+/// `getUserMedia` with a DOMException named `NotAllowedError`
+/// (`FlutterRTCMediaStream.m`, "step 10 Permission Failure"), Android's
+/// `GetUserMediaImpl` fails with a `PermissionDenied`-style message, and
+/// flutter_webrtc's Dart layer wraps both in a plain
+/// `'Unable to getUserMedia: …'` string — so this matches on the message text
+/// rather than on a type.
+bool isMicPermissionError(Object error) {
+  final text = '$error'.toLowerCase();
+  return text.contains('notallowederror') ||
+      text.contains('permissiondenied') ||
+      text.contains('permission');
+}
+
+/// The user-facing message for a microphone that could not be published at
+/// join/unmute time. A permission failure gets the actionable Settings hint;
+/// anything else keeps the platform's reason so the voice bar says *why*.
+String describeMicFailure(Object error) {
+  if (isMicPermissionError(error)) return micPermissionDeniedMessage;
+  final reason = '$error'.replaceFirst('Unable to getUserMedia: ', '').trim();
+  return reason.isEmpty
+      ? 'Microphone unavailable'
+      : 'Microphone unavailable: $reason';
+}

--- a/test/features/notifications/sound_test.dart
+++ b/test/features/notifications/sound_test.dart
@@ -1,4 +1,6 @@
+import 'package:audioplayers/audioplayers.dart';
 import 'package:bonfire/features/notifications/services/sound.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -11,15 +13,14 @@ void main() {
     bool focused = true,
     bool enabled = true,
     double volume = 1.0,
-  }) =>
-      SoundManager.soundForMessage(
-        isMention: isMention,
-        isVisibleChannel: isVisibleChannel,
-        isMemberJoin: isMemberJoin,
-        focused: focused,
-        enabled: enabled,
-        volume: volume,
-      );
+  }) => SoundManager.soundForMessage(
+    isMention: isMention,
+    isVisibleChannel: isVisibleChannel,
+    isMemberJoin: isMemberJoin,
+    focused: focused,
+    enabled: enabled,
+    volume: volume,
+  );
 
   group('SoundManager.soundForMessage', () {
     test('a member join plays member_join', () {
@@ -78,15 +79,18 @@ void main() {
       expect(SoundManager.silent, isTrue);
     });
 
-    test('play is a no-op while silent, even when enabled and audible', () async {
-      soundManager.enabled = true;
-      soundManager.volume = 1.0;
+    test(
+      'play is a no-op while silent, even when enabled and audible',
+      () async {
+        soundManager.enabled = true;
+        soundManager.volume = 1.0;
 
-      // Reaching a real AudioPlayer here would throw rather than return.
-      await expectLater(soundManager.play('message_received'), completes);
-      await expectLater(soundManager.startRingtone(), completes);
-      await expectLater(soundManager.stopRingtone(), completes);
-    });
+        // Reaching a real AudioPlayer here would throw rather than return.
+        await expectLater(soundManager.play('message_received'), completes);
+        await expectLater(soundManager.startRingtone(), completes);
+        await expectLater(soundManager.stopRingtone(), completes);
+      },
+    );
 
     test('init is a no-op while silent', () {
       expect(soundManager.init, returnsNormally);
@@ -97,6 +101,92 @@ void main() {
       // existence just to tear them down — that construction reaches the
       // platform the same as `play` does.
       expect(soundManager.dispose, returnsNormally);
+    });
+  });
+
+  group('SoundManager during a voice call (#323)', () {
+    tearDown(() => soundManager.setVoiceSessionActive(false));
+
+    test('one-shot chimes are held back only on iOS', () {
+      // iOS: audioplayers deactivates the shared AVAudioSession when a one-shot
+      // finishes, which kills WebRTC's capture/playback mid-call.
+      expect(
+        SoundManager.allowsOneShotInCall(
+          platform: TargetPlatform.iOS,
+          isWeb: false,
+        ),
+        isFalse,
+      );
+      for (final platform in [
+        TargetPlatform.android,
+        TargetPlatform.macOS,
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      ]) {
+        expect(
+          SoundManager.allowsOneShotInCall(platform: platform, isWeb: false),
+          isTrue,
+          reason: '$platform has no shared session to break',
+        );
+      }
+      // A browser on an iPhone reports iOS but plays through the web backend.
+      expect(
+        SoundManager.allowsOneShotInCall(
+          platform: TargetPlatform.iOS,
+          isWeb: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('setVoiceSessionActive is plain, readable state', () {
+      expect(soundManager.voiceSessionActive, isFalse);
+      soundManager.setVoiceSessionActive(true);
+      expect(soundManager.voiceSessionActive, isTrue);
+      soundManager.setVoiceSessionActive(false);
+      expect(soundManager.voiceSessionActive, isFalse);
+    });
+
+    test(
+      'play and the ringtone stay no-ops while silent, in-call too',
+      () async {
+        soundManager.enabled = true;
+        soundManager.volume = 1.0;
+        soundManager.setVoiceSessionActive(true);
+        await expectLater(soundManager.play('mute'), completes);
+        await expectLater(
+          soundManager.startRingtone(outgoing: true),
+          completes,
+        );
+        await expectLater(soundManager.stopRingtone(), completes);
+      },
+    );
+
+    test('Android context never takes audio focus, leaves globals alone', () {
+      final context = SoundManager.audioContextFor(TargetPlatform.android)!;
+      expect(context.android.audioFocus, AndroidAudioFocus.none);
+      // These two are written straight to AudioManager when applied; keeping
+      // the plugin defaults means the startup-time write is a no-op and the
+      // call's MODE_IN_COMMUNICATION is never touched.
+      expect(context.android.audioMode, AndroidAudioMode.normal);
+      expect(context.android.isSpeakerphoneOn, isFalse);
+      // Volume/routing semantics unchanged from the plugin default.
+      expect(context.android.usageType, AndroidUsageType.media);
+    });
+
+    test('iOS context keeps playback but mixes with other audio', () {
+      final context = SoundManager.audioContextFor(TargetPlatform.iOS)!;
+      expect(context.iOS.category, AVAudioSessionCategory.playback);
+      expect(
+        context.iOS.options,
+        contains(AVAudioSessionOptions.mixWithOthers),
+      );
+    });
+
+    test('desktop has no audio context to configure', () {
+      expect(SoundManager.audioContextFor(TargetPlatform.linux), isNull);
+      expect(SoundManager.audioContextFor(TargetPlatform.macOS), isNull);
+      expect(SoundManager.audioContextFor(TargetPlatform.windows), isNull);
     });
   });
 }

--- a/test/features/voice/voice_logic_test.dart
+++ b/test/features/voice/voice_logic_test.dart
@@ -166,4 +166,54 @@ void main() {
       );
     });
   });
+
+  group('isMicPermissionError', () {
+    test('recognises each platform\'s denial', () {
+      // iOS / web: flutter_webrtc wraps the DOMException name in a string.
+      expect(
+        isMicPermissionError('Unable to getUserMedia: NotAllowedError'),
+        isTrue,
+      );
+      // Android: GetUserMediaImpl's message.
+      expect(isMicPermissionError(Exception('PermissionDenied')), isTrue);
+      expect(
+        isMicPermissionError('Unable to getUserMedia: permission denied'),
+        isTrue,
+      );
+    });
+
+    test('a device/transport failure is not a permission failure', () {
+      expect(
+        isMicPermissionError('Unable to getUserMedia: NotFoundError'),
+        isFalse,
+      );
+      expect(
+        isMicPermissionError(
+          'LiveKit Exception: [TrackPublishException] Failed to publish track',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('describeMicFailure', () {
+    test('a denied mic gets the actionable Settings hint', () {
+      expect(
+        describeMicFailure('Unable to getUserMedia: NotAllowedError'),
+        micPermissionDeniedMessage,
+      );
+      expect(micPermissionDeniedMessage, contains('Settings'));
+    });
+
+    test('any other failure keeps the platform reason', () {
+      expect(
+        describeMicFailure('Unable to getUserMedia: NotFoundError'),
+        'Microphone unavailable: NotFoundError',
+      );
+    });
+
+    test('an empty reason still reads as a mic failure', () {
+      expect(describeMicFailure(''), 'Microphone unavailable');
+    });
+  });
 }

--- a/test/features/voice/voice_mic_publish_test.dart
+++ b/test/features/voice/voice_mic_publish_test.dart
@@ -1,0 +1,226 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/notifications/services/sound.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:bonfire/features/voice/services/voice_session.dart';
+import 'package:bonfire/features/voice/utils/voice_logic.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// A [VoiceSession] stand-in that never touches LiveKit: `connect` just
+/// records the call and reports whatever mic outcome the test configured, and
+/// `setMicEnabled` answers an unmute with [unmuteError].
+class _FakeSession extends VoiceSession {
+  String? micErrorOnConnect;
+  String? unmuteError;
+  int connects = 0;
+  bool? connectedMuted;
+  final micToggles = <bool>[];
+
+  @override
+  String? get micError => micErrorOnConnect;
+
+  @override
+  Future<void> connect(
+    String url,
+    String token, {
+    bool selfMute = false,
+    bool selfDeaf = false,
+    String? audioInputDeviceId,
+    String? audioOutputDeviceId,
+    int outputVolume = 100,
+    int inputVolume = 100,
+  }) async {
+    connects++;
+    connectedMuted = selfMute;
+  }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<String?> setMicEnabled(bool enabled) async {
+    micToggles.add(enabled);
+    return enabled ? unmuteError : null;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _FakeAccordAuth extends AccordAuth {
+  _FakeAccordAuth(this._client);
+  final AccordClient _client;
+
+  @override
+  AccordAuthState build() => const AccordAuthLoggedOut();
+
+  @override
+  AccordClient? clientForKey(String key) =>
+      key == 'server-key' ? _client : null;
+}
+
+class _ActiveConnections extends ConnectionsController {
+  @override
+  ConnectionsState build() => const ConnectionsState(activeKey: 'server-key');
+}
+
+class _FixedSettingsController extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+/// A [VoiceController] already sitting muted in a channel, for the unmute
+/// cases.
+class _MutedInCallVoiceController extends VoiceController {
+  @override
+  VoiceConnection build() => const VoiceConnection(
+    channelId: 'c1',
+    spaceId: 's1',
+    serverKey: 'server-key',
+    selfMute: true,
+  );
+}
+
+/// Serves the REST voice join with LiveKit credentials and an empty list for
+/// everything else (voice status, leave).
+AccordClient _client() {
+  final responder = MockClient((request) async {
+    final isJoin =
+        request.method == 'POST' &&
+        request.url.path.endsWith('/channels/c1/voice/join');
+    final body = isJoin
+        ? jsonEncode({
+            'space_id': 's1',
+            'channel_id': 'c1',
+            'backend': 'livekit',
+            'livekit_url': 'wss://livekit.example',
+            'token': 'lk-token',
+          })
+        : '[]';
+    return http.Response(
+      body,
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+  return AccordClient(
+    token: 'test-token',
+    tokenType: 'Bearer',
+    baseUrl: 'https://accord.example',
+    gatewayUrl: 'wss://accord.example/ws',
+    httpClient: responder,
+  );
+}
+
+({ProviderContainer container, _FakeSession session}) _harness({
+  VoiceController Function()? voice,
+}) {
+  final client = _client();
+  addTearDown(client.dispose);
+  final container = ProviderContainer(
+    overrides: [
+      accordAuthProvider.overrideWith(() => _FakeAccordAuth(client)),
+      connectionsControllerProvider.overrideWith(_ActiveConnections.new),
+      settingsControllerProvider.overrideWith(_FixedSettingsController.new),
+      if (voice != null) voiceControllerProvider.overrideWith(voice),
+    ],
+  );
+  addTearDown(container.dispose);
+  final session = _FakeSession();
+  container.read(voiceControllerProvider.notifier).debugSession = session;
+  return (container: container, session: session);
+}
+
+Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  // join() arms the AFK monitor, which installs input hooks on the binding.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() => soundManager.setVoiceSessionActive(false));
+
+  group('initial mic publish (#325)', () {
+    test('a denied microphone joins muted with the reason surfaced', () async {
+      final h = _harness();
+      h.session.micErrorOnConnect = micPermissionDeniedMessage;
+
+      await h.container.read(voiceControllerProvider.notifier).join('c1', 's1');
+
+      final state = h.container.read(voiceControllerProvider);
+      expect(h.session.connects, 1);
+      expect(
+        h.session.connectedMuted,
+        isFalse,
+        reason: 'the mic was asked for',
+      );
+      expect(state.isConnected, isTrue, reason: 'still in the channel');
+      expect(state.selfMute, isTrue, reason: 'no live mic, so shown muted');
+      expect(state.error, micPermissionDeniedMessage);
+    });
+
+    test('a published microphone joins live with no error', () async {
+      final h = _harness();
+
+      await h.container.read(voiceControllerProvider.notifier).join('c1', 's1');
+
+      final state = h.container.read(voiceControllerProvider);
+      expect(state.isConnected, isTrue);
+      expect(state.selfMute, isFalse);
+      expect(state.error, isNull);
+    });
+  });
+
+  group('unmute', () {
+    test(
+      'an unmute the platform refuses reverts to muted and says why',
+      () async {
+        final h = _harness(voice: _MutedInCallVoiceController.new);
+        h.session.unmuteError = 'Microphone unavailable: NotFoundError';
+
+        h.container.read(voiceControllerProvider.notifier).setMute(false);
+        await pump();
+
+        final state = h.container.read(voiceControllerProvider);
+        expect(h.session.micToggles, [true]);
+        expect(state.selfMute, isTrue);
+        expect(state.error, 'Microphone unavailable: NotFoundError');
+      },
+    );
+
+    test('a successful unmute goes live', () async {
+      final h = _harness(voice: _MutedInCallVoiceController.new);
+
+      h.container.read(voiceControllerProvider.notifier).setMute(false);
+      await pump();
+
+      final state = h.container.read(voiceControllerProvider);
+      expect(h.session.micToggles, [true]);
+      expect(state.selfMute, isFalse);
+      expect(state.error, isNull);
+    });
+  });
+
+  group('sound manager call tracking (#323)', () {
+    test('the live-session flag wraps join and leave', () async {
+      final h = _harness();
+      final voice = h.container.read(voiceControllerProvider.notifier);
+      expect(soundManager.voiceSessionActive, isFalse);
+
+      await voice.join('c1', 's1');
+      expect(soundManager.voiceSessionActive, isTrue);
+
+      await voice.leave();
+      expect(soundManager.voiceSessionActive, isFalse);
+      expect(h.container.read(voiceControllerProvider).isConnected, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #325
Closes #323

## Root causes

**#325, permission prompt only after mute/unmute.** The initial publish was a null-aware `localParticipant?.setMicrophoneEnabled(...)` inside the error-swallowing media guard, so if it did nothing there was no signal. With no publication, LiveKit's `setSourceEnabled` makes `mute` a no-op and `unmute` the first `LocalAudioTrack.create` → `getUserMedia` → `AVCaptureDevice requestAccessForMediaType:` — which is exactly the reported timing.

**#323, no audio either direction.** `audioplayers_darwin` calls `AVAudioSession.setActive(false)` on the shared session every time a one-shot finishes and no other player is running (`WrappedMediaPlayer.onSoundComplete` → `AudioplayersDarwinPlugin.controlAudioSession` → `AudioContext.activateAudioSession`). That is the session WebRTC drives the call through, so every join/mute/unmute/message chime deactivates it underneath `RTCAudioSession` and capture and playback stop. On Android the per-play audio-focus request and release fight flutter_webrtc's `AudioSwitch`.

## Change
- The mic track is created before `Room.connect`, so the OS prompt appears at join, then published explicitly once the local participant exists. A denied or failed capture keeps the user in the channel but muted, tells the server, and surfaces "Microphone access is unavailable — enable it in Settings" in the voice bar instead of showing a live mic that sends nothing. A failed unmute reverts to muted with the reason.
- `SoundManager` learns whether a voice session is live. One-shot chimes are skipped on iOS while a call is up (the looping ringtone is unaffected, since a loop re-activates rather than deactivates). Audio contexts are applied once at startup only, with audio focus off on Android, so nothing reconfigures the session mid-call. No-ops on web, desktop and under the test silencer.
- Android manifest declares the Bluetooth permissions needed for headset routing.

## Tests
`flutter test test/features/voice test/features/notifications` → 209 passed. New `voice_mic_publish_test.dart` covers the join-muted/denied/failed-unmute paths; `sound_test.dart` covers the in-call gating and per-platform contexts; `voice_logic_test.dart` covers the error classification.

## Not verified without a device
That the iOS prompt now appears at join, and that skipping in-call chimes is sufficient in practice; both are derived from plugin source rather than observed. `BLUETOOTH_CONNECT` is declared but not requested at runtime, so Android 12+ SCO headsets still need that wiring (would need a new dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)