### PR TITLE
fix(voice): render the DM call screen and deliver incoming rings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ android/ ios/ web/ windows/ linux/ macos/   # all platform targets present
 
 Cross-cutting startup features wired in `lib/main.dart`:
 - **Server config:** `lib/features/server/models/accord_server.dart` defines `AccordServer` (`baseUrl`/`gatewayUrl`/`cdnUrl`, derived from a base URL). The live per-server `AccordClient` instances are owned by `AccordAuth` (`lib/features/authentication/repositories/accord_auth.dart`, exposed as `accordAuthProvider`); `lib/features/server/controllers/connections.dart` holds the rail's per-connection UI state (session + status + cached spaces), not the clients.
-- **Multi-profile:** the app is wrapped in `ProfileGate`/`AppRestart` for switching between accounts.
+- **Multi-profile:** the app is wrapped in `AppRestart` for switching between accounts, and `ProfileGate` (the PIN lock) is hosted from the router app's `MaterialApp.builder` via `buildAppShell` (`lib/shared/components/app_shell.dart`) together with the incoming-call banner. Do not wrap `MainWindow` in another `MaterialApp`/Navigator: go_router's navigator must stay the root navigator (#324).
 - **Deep links:** `daccord://` URLs (navigate / connect / invite) are parsed via `ServerUri.parseDeepLink()`. Qualified navigation is held by `pendingDeepLinkProvider` until authentication and the owning connection's live space cache are ready; the `/spaces` route then hands channel/message targeting to `AccordHomeScreen`.
 - **Developer mode:** an MCP server (`mcpServerControllerProvider`) for in-app tooling.
 

--- a/lib/features/profiles/views/profile_gate.dart
+++ b/lib/features/profiles/views/profile_gate.dart
@@ -20,6 +20,11 @@ final profileUnlockedProvider = NotifierProvider<ProfileUnlocked, bool>(
 
 /// Gates [child] behind the active profile's PIN. When the active profile has no
 /// PIN, or once the correct PIN is entered, [child] is shown.
+///
+/// Hosted from the router app's `MaterialApp.builder` (see `buildAppShell`),
+/// where [child] is the app's root Navigator. The gate therefore has no
+/// Navigator — and no [Overlay] — above it, so the lock screen brings its own:
+/// Material text fields need one for their selection handles and toolbar.
 class ProfileGate extends ConsumerWidget {
   const ProfileGate({super.key, required this.child});
 
@@ -33,8 +38,31 @@ class ProfileGate extends ConsumerWidget {
     final unlocked = ref.watch(profileUnlockedProvider);
 
     if (active == null || !active.hasPin || unlocked) return child;
-    return _PinLockScreen(profileName: active.name);
+    return _PinLockHost(profileName: active.name);
   }
+}
+
+/// Wraps the lock screen in an [Overlay] of its own. Built once: an Overlay
+/// only reads [Overlay.initialEntries] on first build, and the host is
+/// discarded as a whole once the profile unlocks.
+class _PinLockHost extends StatefulWidget {
+  const _PinLockHost({required this.profileName});
+
+  final String profileName;
+
+  @override
+  State<_PinLockHost> createState() => _PinLockHostState();
+}
+
+class _PinLockHostState extends State<_PinLockHost> {
+  late final List<OverlayEntry> _entries = [
+    OverlayEntry(
+      builder: (_) => _PinLockScreen(profileName: widget.profileName),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) => Overlay(initialEntries: _entries);
 }
 
 class _PinLockScreen extends ConsumerStatefulWidget {

--- a/lib/features/user/views/accord_direct_messages_conversations.dart
+++ b/lib/features/user/views/accord_direct_messages_conversations.dart
@@ -568,13 +568,21 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
   /// Places an outgoing DM call: rings the other participant(s) and opens the
   /// full-screen call view. The callee gets a `call.ring` and can accept/decline.
   Future<void> _startCall({required bool video}) async {
+    // The app's root navigator is go_router's (see `buildAppShell`): the call
+    // view goes above this dialog, under the incoming-call banner host.
     final navigator = Navigator.of(context, rootNavigator: true);
     await ref
         .read(callControllerProvider.notifier)
         .startCall(_channel, video: video);
     if (!mounted) return;
-    // Bail if the underlying voice join failed (an error is surfaced elsewhere).
-    if (ref.read(voiceControllerProvider).channelId != _channel.id) return;
+    // Bail if the underlying voice join failed. The voice bar shows the error
+    // too, but it isn't on screen behind this dialog — say it here, where the
+    // call was placed, rather than silently doing nothing (#324).
+    if (ref.read(voiceControllerProvider).channelId != _channel.id) {
+      final error = ref.read(voiceControllerProvider).error;
+      if (error != null) showInfoSnack(context, error);
+      return;
+    }
     await showFullScreenVoice(
       navigator.context,
       channelId: _channel.id,

--- a/lib/features/voice/controllers/call.dart
+++ b/lib/features/voice/controllers/call.dart
@@ -55,11 +55,7 @@ CallRingtone callRingtone(Ref ref) => const CallRingtone();
 /// caller, the channel we're currently ringing (before the callee answers).
 @immutable
 class CallState {
-  const CallState({
-    this.incoming,
-    this.outgoingChannelId,
-    this.endedMessage,
-  });
+  const CallState({this.incoming, this.outgoingChannelId, this.endedMessage});
 
   /// A ring we've received and not yet answered or dismissed.
   final IncomingCall? incoming;
@@ -84,8 +80,9 @@ class CallState {
   }) {
     return CallState(
       incoming: clearIncoming ? null : (incoming ?? this.incoming),
-      outgoingChannelId:
-          clearOutgoing ? null : (outgoingChannelId ?? this.outgoingChannelId),
+      outgoingChannelId: clearOutgoing
+          ? null
+          : (outgoingChannelId ?? this.outgoingChannelId),
       endedMessage: clearEnded ? null : (endedMessage ?? this.endedMessage),
     );
   }
@@ -121,7 +118,9 @@ class CallController extends _$CallController {
 
   /// Logs [call] as an unanswered incoming call (see [MissedCallsController]).
   void _recordMissed(IncomingCall call) {
-    ref.read(missedCallsControllerProvider.notifier).record(
+    ref
+        .read(missedCallsControllerProvider.notifier)
+        .record(
           channelId: call.channelId,
           callerId: call.callerId,
           serverKey: call.serverKey,
@@ -138,6 +137,12 @@ class CallController extends _$CallController {
 
   /// Places an outgoing call on a DM/group-DM [channel]: joins voice, then rings
   /// the other participant(s). [video] starts the camera and hints the callee.
+  ///
+  /// Strictly join-then-ring, matching the server's model of a DM call as
+  /// "voice join + signaling": `POST /channels/{id}/voice/join` must succeed
+  /// before `call/ring` goes out. When the join is rejected the voice controller
+  /// leaves [VoiceConnection.error] set and we clear the outgoing state so the
+  /// caller's screen can report it instead of opening an empty call view.
   Future<void> startCall(AccordChannel channel, {bool video = false}) async {
     // Guard against concurrent taps: set outgoingChannelId synchronously so a
     // second tap that arrives before the first await sees hasOutgoing == true.
@@ -145,24 +150,45 @@ class CallController extends _$CallController {
     if (ref.read(voiceControllerProvider).channelId == channel.id) return;
     state = state.copyWith(outgoingChannelId: channel.id, clearEnded: true);
 
-    final serverKey = ref.read(connectionsControllerProvider).activeKey;
-    final client = _clientFor(serverKey);
-    if (client == null) {
+    final voice = ref.read(voiceControllerProvider.notifier);
+    await voice.join(channel.id, null);
+    // Bail if the join failed (the voice controller surfaces its own error).
+    final connection = ref.read(voiceControllerProvider);
+    if (connection.channelId != channel.id) {
       state = state.copyWith(clearOutgoing: true);
       return;
     }
 
-    final voice = ref.read(voiceControllerProvider.notifier);
-    await voice.join(channel.id, null);
-    // Bail if the join failed (the voice controller surfaces its own error).
-    if (ref.read(voiceControllerProvider).channelId != channel.id) {
-      state = state.copyWith(clearOutgoing: true);
+    // Ring through the connection the join was pinned to (which the voice
+    // controller resolved from the active server at join time), not whatever
+    // is active by the time the join resolves.
+    final client = _clientFor(connection.serverKey);
+    if (client == null) {
+      state = state.copyWith(
+        clearOutgoing: true,
+        endedMessage: 'Could not start the call — no connection',
+      );
+      await voice.leave();
       return;
     }
 
     if (video) await voice.toggleVideo();
     _ringtone.start(outgoing: true);
-    await client.voice.ring(channel.id, metadata: {'video': video});
+    final result = await client.voice.ring(
+      channel.id,
+      metadata: {'video': video},
+    );
+    if (result.ok) return;
+    // Nobody is being rung, so the call can never connect: hang up rather than
+    // leave the caller on a "Calling…" screen that nothing will answer, and
+    // say why (the server's reason when it gave one).
+    final reason = (result.error?.message ?? '').trim();
+    _ringtone.stop();
+    state = state.copyWith(
+      clearOutgoing: true,
+      endedMessage: reason.isEmpty ? 'Could not ring the call' : reason,
+    );
+    await voice.leave();
   }
 
   /// Accepts the pending incoming call by joining its voice channel (the server

--- a/lib/features/voice/controllers/call.g.dart
+++ b/lib/features/voice/controllers/call.g.dart
@@ -101,7 +101,7 @@ final class CallControllerProvider
   }
 }
 
-String _$callControllerHash() => r'91b94d8aa746fad76d61b42b5f590267c579df22';
+String _$callControllerHash() => r'52cc869408abbea2679ecddebca982a9f53df7c7';
 
 /// Orchestrates DM voice/video calls: placing an outgoing call (join voice +
 /// `call/ring`), reacting to the `call.*` gateway events, and accepting or

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ import 'package:bonfire/features/notifications/services/taskbar_badge.dart';
 import 'package:bonfire/features/onboarding/views/onboarding_tour.dart';
 import 'package:bonfire/features/updates/views/release_notes_dialog.dart';
 import 'package:bonfire/features/profiles/views/app_restart.dart';
-import 'package:bonfire/features/profiles/views/profile_gate.dart';
 import 'package:bonfire/features/profiles/services/profile_store.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:bonfire/features/server/services/deep_link_navigation.dart';
@@ -22,11 +21,10 @@ import 'package:bonfire/features/server/services/federation_join.dart';
 import 'package:bonfire/features/server/views/federation_join_confirmation.dart';
 import 'package:bonfire/features/developer/controllers/mcp_server_controller.dart';
 import 'package:bonfire/features/settings/controllers/settings.dart';
-import 'package:bonfire/features/settings/models/accord_settings.dart';
-import 'package:bonfire/features/voice/views/incoming_call_overlay.dart';
 import 'package:bonfire/router/controller.dart';
 import 'package:bonfire/shared/app_info.dart';
 import 'package:bonfire/shared/components/app_lifecycle_ticker_mode.dart';
+import 'package:bonfire/shared/components/app_shell.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:bonfire/shared/utils/desktop_window.dart';
 import 'package:bonfire/theme/app_theme.dart';
@@ -106,13 +104,15 @@ void main() async {
     debugPrint('setupDesktopWindow failed during startup: $e\n$st');
   }
 
+  // No bootstrap `MaterialApp` around [MainWindow]: the device-profile PIN gate
+  // lives inside the router app's builder (see `buildAppShell`), so go_router's
+  // navigator is the app's *root* navigator. A second Navigator out here is
+  // where `rootNavigator: true` lookups end up, and it has neither the app
+  // theme nor the incoming-call banner — the DM call view pushed into it
+  // blanked and rings were hidden under dialogs (#324).
   runApp(
     const AppRestart(
-      child: ProviderScope(
-        child: AppLifecycleTickerMode(
-          child: MaterialApp(home: ProfileGate(child: MainWindow())),
-        ),
-      ),
+      child: ProviderScope(child: AppLifecycleTickerMode(child: MainWindow())),
     ),
   );
 
@@ -176,13 +176,6 @@ void _silenceLiveKitAsyncErrors() {
     return previous?.call(error, stack) ?? false;
   };
 }
-
-/// Upper bound on the combined (system × in-app) text scale. The OS can ask
-/// for far more than this at the top accessibility sizes; past roughly 2× the
-/// app's fixed-height rows (channel tiles, the member list, voice tiles) start
-/// clipping instead of growing, so honour the user's preference up to here and
-/// no further.
-const double _maxEffectiveTextScale = 2.0;
 
 class MainWindow extends ConsumerStatefulWidget {
   const MainWindow({super.key});
@@ -269,16 +262,13 @@ class _MainWindowState extends ConsumerState<MainWindow> {
           final session = authState.session;
           final outcome = await confirmFederatedDeepLinkJoin(
             ctx,
-            activeAccount: '${session.username} (${session.userId}) on '
+            activeAccount:
+                '${session.username} (${session.userId}) on '
                 '${session.server.homeDomain}',
             domain: domain,
             spaceId: spaceId,
-            join: () => joinFederatedSpace(
-              ref,
-              authState.client,
-              domain,
-              spaceId,
-            ),
+            join: () =>
+                joinFederatedSpace(ref, authState.client, domain, spaceId),
           );
           if (outcome == null) break;
           if (outcome.error == null) {
@@ -410,33 +400,16 @@ class _MainWindowState extends ConsumerState<MainWindow> {
       theme: theme,
       darkTheme: theme,
       routerConfig: routerController,
-      // Apply accessibility prefs app-wide: scale all text by the UI scale and
-      // honour reduced-motion. Done in the router app's builder so the
-      // override sits above every route.
-      // The incoming-call banner is hosted here too, above every route, so a
-      // ring stays answerable from inside a dialog or the full-screen call
-      // view (#139).
-      builder: (context, child) {
-        // Compose the in-app UI scale with the platform's own text scale (iOS
-        // Dynamic Type, Android font size) instead of replacing it. Passing
-        // `TextScaler.linear(uiScale)` straight through discarded whatever the
-        // user had set at the OS level, so iOS "Larger Text" did nothing here —
-        // the app always rendered at its own scale. Capped at
-        // [_maxEffectiveTextScale] so the largest accessibility sizes can't
-        // burst fixed-height rows.
-        final systemScale = MediaQuery.textScalerOf(context).scale(1);
-        final combined = (systemScale * settings.uiScale).clamp(
-          AccordSettings.minUiScale,
-          _maxEffectiveTextScale,
-        );
-        return MediaQuery(
-          data: MediaQuery.of(context).copyWith(
-            textScaler: TextScaler.linear(combined),
-            disableAnimations: settings.reducedMotion,
-          ),
-          child: withIncomingCallOverlay(child),
-        );
-      },
+      // Accessibility prefs (UI scale, reduced motion), the device-profile PIN
+      // gate and the incoming-call banner all sit in the builder, above every
+      // route. See [buildAppShell] for why the gate must live *here* rather
+      // than in a wrapping MaterialApp (#324).
+      builder: (context, child) => buildAppShell(
+        context,
+        child,
+        uiScale: settings.uiScale,
+        reducedMotion: settings.reducedMotion,
+      ),
     );
   }
 }

--- a/lib/shared/components/app_shell.dart
+++ b/lib/shared/components/app_shell.dart
@@ -1,0 +1,61 @@
+import 'package:bonfire/features/profiles/views/profile_gate.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/voice/views/incoming_call_overlay.dart';
+import 'package:flutter/material.dart';
+
+/// Upper bound on the combined (system × in-app) text scale. The OS can ask
+/// for far more than this at the top accessibility sizes; past roughly 2× the
+/// app's fixed-height rows (channel tiles, the member list, voice tiles) start
+/// clipping instead of growing, so honour the user's preference up to here and
+/// no further.
+const double maxEffectiveTextScale = 2.0;
+
+/// Everything the app's `MaterialApp.router` layers between its chrome (theme,
+/// localizations, media query) and the router's Navigator — [child] — via
+/// `MaterialApp.builder`:
+///
+/// 1. the accessibility overrides (UI scale composed with the platform text
+///    scale, reduced motion), so they apply to every route;
+/// 2. the device-profile PIN gate, which replaces the Navigator with the lock
+///    screen until the active profile is unlocked;
+/// 3. the incoming-call banner host, above every route so a ring stays
+///    answerable from inside a dialog or the full-screen call view (#139).
+///
+/// This must be the *only* Navigator ancestry the app has. `main.dart` used to
+/// boot a second, bare `MaterialApp(home: ProfileGate(...))` around the router
+/// app to host the gate; that bootstrap app had its own Navigator (and no
+/// [BonfireThemeExtension]), so every `rootNavigator: true` lookup from inside
+/// the app — `showDialog`, the DM call's `showFullScreenVoice`, the incoming
+/// call's accept — climbed past the themed router into it. Dialogs survived
+/// because `showDialog` captures inherited themes; the DM call view did not,
+/// blanking on `BonfireThemeExtension.of`, and every dialog pushed there sat
+/// *above* the ring banner host (#324). Hosting the gate here keeps go_router's
+/// navigator as the root.
+Widget buildAppShell(
+  BuildContext context,
+  Widget? child, {
+  required double uiScale,
+  required bool reducedMotion,
+}) {
+  // Compose the in-app UI scale with the platform's own text scale (iOS
+  // Dynamic Type, Android font size) instead of replacing it. Passing
+  // `TextScaler.linear(uiScale)` straight through discarded whatever the
+  // user had set at the OS level, so iOS "Larger Text" did nothing here —
+  // the app always rendered at its own scale. Capped at
+  // [maxEffectiveTextScale] so the largest accessibility sizes can't burst
+  // fixed-height rows.
+  final systemScale = MediaQuery.textScalerOf(context).scale(1);
+  final combined = (systemScale * uiScale).clamp(
+    AccordSettings.minUiScale,
+    maxEffectiveTextScale,
+  );
+  return MediaQuery(
+    data: MediaQuery.of(context).copyWith(
+      textScaler: TextScaler.linear(combined),
+      disableAnimations: reducedMotion,
+    ),
+    // The gate wraps the banner host too: a locked profile shows neither the
+    // app nor who is calling it.
+    child: ProfileGate(child: withIncomingCallOverlay(child)),
+  );
+}

--- a/packages/accordkit/test/gateway_test.dart
+++ b/packages/accordkit/test/gateway_test.dart
@@ -226,6 +226,35 @@ void main() {
       await socket.dispose();
     });
 
+    test('call.ring with a null metadata (no ring body) still parses',
+        () async {
+      // accordserver echoes `"metadata": null` when the caller sent no body.
+      final factory = FakeConnectionFactory();
+      final socket = makeSocket(factory);
+      final rings = <AccordCallSignal>[];
+      socket.onCallRing.listen(rings.add);
+
+      socket.connectToGateway('wss://x');
+      await pump();
+
+      factory.last.receive(jsonEncode({
+        'op': GatewayOpcodes.event,
+        'type': 'call.ring',
+        'data': {
+          'channel_id': '5',
+          'caller_id': '9',
+          'participants': ['9', '2'],
+          'metadata': null,
+        },
+      }));
+      await pump();
+
+      expect(rings.single.channelId, '5');
+      expect(rings.single.callerId, '9');
+      expect(rings.single.metadata, isNull);
+      await socket.dispose();
+    });
+
     test('call.decline / cancel / end emit typed signals', () async {
       final factory = FakeConnectionFactory();
       final socket = makeSocket(factory);
@@ -247,7 +276,8 @@ void main() {
       await pump();
 
       expect(events.map((e) => e.type), ['decline', 'cancel', 'end']);
-      expect(events.every((e) => e.channelId == '5' && e.userId == '2'), isTrue);
+      expect(
+          events.every((e) => e.channelId == '5' && e.userId == '2'), isTrue);
       await socket.dispose();
     });
 
@@ -585,8 +615,7 @@ void main() {
       await socket.dispose();
     });
 
-    test('revives a dead socket even after reconnects are exhausted',
-        () async {
+    test('revives a dead socket even after reconnects are exhausted', () async {
       final factory = FakeConnectionFactory();
       final socket = makeExhaustedSocket(factory);
       socket.connectToGateway('wss://x');
@@ -635,8 +664,7 @@ void main() {
       await socket.dispose();
     });
 
-    test('force-closes a stale connection that misses the probe ack',
-        () async {
+    test('force-closes a stale connection that misses the probe ack', () async {
       final factory = FakeConnectionFactory();
       final socket = makeSocket(factory);
       socket.connectToGateway('wss://x');
@@ -648,8 +676,8 @@ void main() {
 
       // The probe heartbeat went out, was never acked, and the dead socket was
       // closed and reopened through the normal reconnect path.
-      final probe =
-          jsonDecode(factory.connections.first.sent.last) as Map<String, dynamic>;
+      final probe = jsonDecode(factory.connections.first.sent.last)
+          as Map<String, dynamic>;
       expect(probe['op'], GatewayOpcodes.heartbeat);
       expect(factory.connections.first.closeCode, 4000);
       expect(factory.connections, hasLength(2));
@@ -685,7 +713,8 @@ void main() {
       await socket.dispose();
     });
 
-    test('heartbeat timer does not race with probe during ack window', () async {
+    test('heartbeat timer does not race with probe during ack window',
+        () async {
       // Verify that the probe stops the heartbeat timer before sending its OOB
       // heartbeat, so a timer tick mid-probe can't close a live connection that
       // hasn't had time to ACK yet.

--- a/test/features/profiles/profile_gate_test.dart
+++ b/test/features/profiles/profile_gate_test.dart
@@ -52,4 +52,40 @@ void main() {
     expect(find.text(profilePinSecurityNotice), findsOneWidget);
     expect(find.text('Profile contents'), findsNothing);
   });
+
+  testWidgets('hosted in MaterialApp.builder (no Navigator above it) the lock '
+      'screen still takes a PIN and unlocks', (tester) async {
+    // This is where main.dart mounts the gate (#324): above the router's
+    // Navigator, so it has no Overlay of the app's to lean on — the PIN field's
+    // selection handles need one. Focusing and typing must not assert.
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData(extensions: const [_theme]),
+          builder: (context, child) =>
+              ProfileGate(child: child ?? const SizedBox.shrink()),
+          home: const Text('Profile contents'),
+        ),
+      ),
+    );
+
+    expect(find.text('Profile contents'), findsNothing);
+    expect(find.byType(TextField), findsOneWidget);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), '0000');
+    await tester.tap(find.text('Unlock'));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+    expect(find.text('Incorrect PIN'), findsOneWidget);
+    expect(find.text('Profile contents'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '1234');
+    await tester.tap(find.text('Unlock'));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+    expect(find.text('Profile contents'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+  });
 }

--- a/test/features/voice/dm_call_screen_test.dart
+++ b/test/features/voice/dm_call_screen_test.dart
@@ -76,8 +76,8 @@ class _StubVoice extends VoiceController {
   _StubVoice({
     this.initial = const VoiceConnection(),
     this.failJoinWith,
-    this.joinServerKey = _serverKey,
-  });
+    String? joinServerKey,
+  }) : joinServerKey = joinServerKey ?? _serverKey;
 
   final VoiceConnection initial;
   final String? failJoinWith;

--- a/test/features/voice/dm_call_screen_test.dart
+++ b/test/features/voice/dm_call_screen_test.dart
@@ -1,0 +1,407 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/channels/controllers/dm_channels.dart';
+import 'package:bonfire/features/messaging/views/message_pane/message_pane.dart';
+import 'package:bonfire/features/profiles/controllers/profiles_controller.dart';
+import 'package:bonfire/features/profiles/models/device_profile.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/user/views/accord_direct_messages.dart';
+import 'package:bonfire/features/voice/controllers/call.dart';
+import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:bonfire/features/voice/controllers/voice_states.dart';
+import 'package:bonfire/features/voice/views/incoming_call_overlay.dart';
+import 'package:bonfire/features/voice/views/voice_view.dart';
+import 'package:bonfire/shared/components/app_shell.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// The caller's side of a DM call (#324).
+///
+/// Placing a call used to leave the caller on a white screen. `main.dart`
+/// booted a bare bootstrap `MaterialApp(home: ProfileGate(...))` *around* the
+/// themed router app, so the DM conversation's `rootNavigator: true` lookup
+/// climbed past the router into that outer navigator and `showFullScreenVoice`
+/// pushed the call view there — where `BonfireThemeExtension.of` finds no
+/// extension and throws (a blank error widget in release). These tests drive
+/// the real conversation header through the real [CallController] inside the
+/// production app shell ([buildAppShell]), logged in against a [MockClient].
+
+const _selfId = 'u1';
+final _server = AccordServer.fromBaseUrl('https://accord.example.test');
+final _session = AccordSession(
+  server: _server,
+  token: 'test-token',
+  userId: _selfId,
+  username: 'self',
+);
+final _serverKey = _session.key;
+final _dm = AccordChannel(
+  id: 'dm1',
+  type: 'dm',
+  recipients: [AccordUser(id: 'u2', username: 'alice', displayName: 'Alice')],
+);
+
+class _FakeAuth extends AccordAuth {
+  _FakeAuth(this._client);
+
+  final AccordClient _client;
+
+  @override
+  AccordAuthState build() =>
+      AccordAuthLoggedIn(client: _client, session: _session);
+
+  @override
+  AccordClient? clientForKey(String key) => key == _serverKey ? _client : null;
+}
+
+class _ActiveConnections extends ConnectionsController {
+  @override
+  ConnectionsState build() => ConnectionsState(activeKey: _serverKey);
+}
+
+/// A [VoiceController] that never touches LiveKit: joining pins the connection
+/// exactly as the real one does, or fails with [failJoinWith] the way a
+/// rejected `POST /channels/{id}/voice/join` does.
+class _StubVoice extends VoiceController {
+  _StubVoice({this.initial = const VoiceConnection(), this.failJoinWith});
+
+  final VoiceConnection initial;
+  final String? failJoinWith;
+  int leaves = 0;
+
+  @override
+  VoiceConnection build() => initial;
+
+  @override
+  Future<void> join(String channelId, String? spaceId) async {
+    final error = failJoinWith;
+    if (error != null) {
+      state = state.copyWith(error: error);
+      return;
+    }
+    state = state.copyWith(
+      channelId: channelId,
+      spaceId: spaceId,
+      serverKey: _serverKey,
+      clearError: true,
+    );
+  }
+
+  @override
+  Future<void> leave() async {
+    leaves++;
+    state = const VoiceConnection();
+  }
+
+  @override
+  Future<void> toggleVideo() async {}
+}
+
+/// Both participants already in the DM call, so the connected body renders
+/// tiles rather than "Connecting…".
+class _SeededVoiceStates extends VoiceStatesController {
+  @override
+  Map<String, Map<String, AccordVoiceState>> build(String serverKey) => {
+    'dm1': {
+      'u1': AccordVoiceState(userId: 'u1', channelId: 'dm1'),
+      'u2': AccordVoiceState(userId: 'u2', channelId: 'dm1'),
+    },
+  };
+}
+
+class _FakeDmChannels extends DmChannelsController {
+  @override
+  List<AccordChannel>? build(String serverKey) => [_dm];
+}
+
+/// The chat panel is the real [MessagePane], whose rows read local preferences
+/// from a Hive box only `setupHive()` opens; in-memory defaults keep the tests
+/// off disk.
+class _FakeSettings extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+/// The production shell hosts the device-profile gate; keep it off Hive too.
+class _NoProfiles extends ProfilesController {
+  @override
+  List<DeviceProfile> build() => const [];
+
+  @override
+  DeviceProfile? get active => null;
+}
+
+class _SilentRingtone implements CallRingtone {
+  @override
+  void start({bool outgoing = false}) {}
+
+  @override
+  void stop() {}
+}
+
+class _Harness {
+  _Harness({
+    _StubVoice? voice,
+    this.ringStatus = 200,
+    this.ringBody = '{"data":{"ok":true}}',
+  }) : voice = voice ?? _StubVoice() {
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: _server.baseUrl,
+      gatewayUrl: _server.gatewayUrl,
+      cdnUrl: _server.cdnUrl,
+      httpClient: MockClient((request) async {
+        requests.add('${request.method} ${request.url.path}');
+        const json = {'content-type': 'application/json'};
+        if (request.url.path.endsWith('/call/ring')) {
+          return http.Response(ringBody, ringStatus, headers: json);
+        }
+        final body = request.method == 'GET' ? '[]' : '{}';
+        return http.Response(body, 200, headers: json);
+      }),
+    );
+  }
+
+  final _StubVoice voice;
+  final int ringStatus;
+  final String ringBody;
+  final List<String> requests = [];
+  late final AccordClient client;
+
+  /// The app exactly as `main.dart` composes it: one themed [MaterialApp]
+  /// whose builder is [buildAppShell], and nothing above it.
+  Widget app(Widget home) => ProviderScope(
+    overrides: [
+      accordAuthProvider.overrideWith(() => _FakeAuth(client)),
+      connectionsControllerProvider.overrideWith(_ActiveConnections.new),
+      settingsControllerProvider.overrideWith(_FakeSettings.new),
+      profilesControllerProvider.overrideWith(_NoProfiles.new),
+      voiceControllerProvider.overrideWith(() => voice),
+      voiceStatesControllerProvider(
+        _serverKey,
+      ).overrideWith(_SeededVoiceStates.new),
+      dmChannelsControllerProvider(
+        _serverKey,
+      ).overrideWith(_FakeDmChannels.new),
+      callRingtoneProvider.overrideWithValue(_SilentRingtone()),
+    ],
+    child: MaterialApp(
+      theme: buildAppTheme(AppThemePreset.dark),
+      builder: (context, child) =>
+          buildAppShell(context, child, uiScale: 1, reducedMotion: false),
+      home: home,
+    ),
+  );
+
+  /// A home screen with a button that opens the DM conversation the way the
+  /// rail does — a dialog on the root navigator.
+  Widget dmHome() => Scaffold(
+    body: Builder(
+      builder: (context) => TextButton(
+        onPressed: () => showAccordDirectMessages(context, initialChannel: _dm),
+        child: const Text('open dm'),
+      ),
+    ),
+  );
+}
+
+/// The call view holds a progress indicator while ringing, so it never
+/// settles; fixed pumps stand in for `pumpAndSettle`.
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+Future<void> _openConversation(WidgetTester tester, _Harness h) async {
+  tester.view.physicalSize = const Size(1200, 800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  addTearDown(h.client.dispose);
+  await tester.pumpWidget(h.app(h.dmHome()));
+  await tester.tap(find.text('open dm'));
+  await tester.pumpAndSettle();
+  expect(find.byTooltip('Start voice call'), findsOneWidget);
+}
+
+/// The in-call control bar's hang-up button, scoped to the call view because
+/// the incoming-call banner's decline button shares the icon.
+final _hangUp = find.descendant(
+  of: find.byType(VoiceChannelView),
+  matching: find.byIcon(Icons.call_end),
+);
+
+final _decline = find.descendant(
+  of: find.byType(IncomingCallOverlay),
+  matching: find.byTooltip('Decline'),
+);
+
+void main() {
+  testWidgets('placing a DM call opens the themed call view over the '
+      'conversation, then returns to it on hang-up', (tester) async {
+    final h = _Harness();
+    await _openConversation(tester, h);
+
+    await tester.tap(find.byTooltip('Start voice call'));
+    await _settle(tester);
+
+    // The white screen: the call view threw building on the bootstrap app's
+    // extension-less theme.
+    expect(tester.takeException(), isNull);
+    final view = find.byType(VoiceChannelView);
+    expect(view, findsOneWidget);
+    expect(
+      Theme.of(tester.element(view)).extension<BonfireThemeExtension>(),
+      isNotNull,
+      reason: 'the call view must be pushed inside the themed app',
+    );
+
+    // Joined, then rung — and the view reflects both.
+    expect(h.requests, contains('POST /api/v1/channels/dm1/call/ring'));
+    expect(find.text('Calling Alice…'), findsOneWidget);
+    expect(_hangUp, findsOneWidget);
+    // Full-screen opens with the chat panel, which is the real message pane.
+    expect(find.byType(MessagePane), findsWidgets);
+
+    // Hanging up while still ringing cancels the call, and ending the call
+    // pops the view back to the conversation it was placed from.
+    await tester.tap(_hangUp);
+    // Once the call view has popped nothing is left animating, so the route's
+    // exit transition can be waited out rather than pumped by hand.
+    await tester.pumpAndSettle();
+    expect(h.requests, contains('POST /api/v1/channels/dm1/call/cancel'));
+    expect(h.voice.leaves, 1);
+    expect(find.byType(VoiceChannelView), findsNothing);
+    expect(find.byTooltip('Start voice call'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a second call ringing in stays answerable above the call view '
+      'and the conversation dialog', (tester) async {
+    final h = _Harness();
+    await _openConversation(tester, h);
+    await tester.tap(find.byTooltip('Start voice call'));
+    await _settle(tester);
+    expect(find.byType(VoiceChannelView), findsOneWidget);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(VoiceChannelView)),
+    );
+    container
+        .read(callControllerProvider.notifier)
+        .handleRing(
+          const AccordCallSignal(
+            type: 'ring',
+            channelId: 'dm2',
+            callerId: 'u3',
+            participants: ['u1', 'u3'],
+          ),
+          _serverKey,
+          _selfId,
+        );
+    await _settle(tester);
+
+    // Both the dialog route and the call route are pages on the app's root
+    // navigator; the banner host sits above that navigator, so it is on top.
+    expect(_decline, findsOneWidget);
+    expect(_decline.hitTestable(), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the full-screen DM call view renders with its chat panel open', (
+    tester,
+  ) async {
+    // The second shape of the report: the view itself, presented full-screen
+    // for a DM (no space) — its chat panel builds a MessagePane with no
+    // channel object and no space, which must not be a problem.
+    final h = _Harness(
+      voice: _StubVoice(
+        initial: VoiceConnection(channelId: 'dm1', serverKey: _serverKey),
+      ),
+    );
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    addTearDown(h.client.dispose);
+
+    await tester.pumpWidget(
+      h.app(
+        const Scaffold(
+          body: SafeArea(
+            child: VoiceChannelView(
+              channelId: 'dm1',
+              spaceId: null,
+              channelName: 'Alice',
+              fullScreen: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await _settle(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(MessagePane), findsOneWidget);
+    expect(find.byTooltip('Close chat'), findsOneWidget);
+    expect(_hangUp, findsOneWidget);
+    // Connected but not ringing: no "Calling…" banner.
+    expect(find.textContaining('Calling'), findsNothing);
+    // Both participants have a tile.
+    expect(find.text('Alice'), findsWidgets);
+  });
+
+  testWidgets('a rejected voice join is reported on the conversation and '
+      'never rings', (tester) async {
+    final h = _Harness(
+      voice: _StubVoice(failJoinWith: 'Voice backend unavailable'),
+    );
+    await _openConversation(tester, h);
+
+    await tester.tap(find.byTooltip('Start voice call'));
+    await _settle(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(VoiceChannelView), findsNothing);
+    // Join must succeed before the ring goes out.
+    expect(h.requests, isNot(contains('POST /api/v1/channels/dm1/call/ring')));
+    expect(find.text('Voice backend unavailable'), findsOneWidget);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byTooltip('Start voice call')),
+    );
+    expect(container.read(callControllerProvider).hasOutgoing, isFalse);
+  });
+
+  testWidgets('a rejected ring hangs the call up and says why', (tester) async {
+    final h = _Harness(
+      ringStatus: 400,
+      ringBody:
+          '{"error":{"code":"channel_not_dm","message":"Not a DM channel"}}',
+    );
+    await _openConversation(tester, h);
+
+    await tester.tap(find.byTooltip('Start voice call'));
+    await _settle(tester);
+
+    expect(tester.takeException(), isNull);
+    // Nobody is being rung, so there is no call to show.
+    expect(find.byType(VoiceChannelView), findsNothing);
+    expect(h.voice.leaves, 1);
+    expect(find.text('Not a DM channel'), findsOneWidget);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byTooltip('Start voice call')),
+    );
+    expect(container.read(callControllerProvider).hasOutgoing, isFalse);
+    expect(container.read(voiceControllerProvider).channelId, isNull);
+  });
+}

--- a/test/features/voice/dm_call_screen_test.dart
+++ b/test/features/voice/dm_call_screen_test.dart
@@ -73,10 +73,20 @@ class _ActiveConnections extends ConnectionsController {
 /// exactly as the real one does, or fails with [failJoinWith] the way a
 /// rejected `POST /channels/{id}/voice/join` does.
 class _StubVoice extends VoiceController {
-  _StubVoice({this.initial = const VoiceConnection(), this.failJoinWith});
+  _StubVoice({
+    this.initial = const VoiceConnection(),
+    this.failJoinWith,
+    this.joinServerKey = _serverKey,
+  });
 
   final VoiceConnection initial;
   final String? failJoinWith;
+
+  /// The connection the join pins to. Defaults to the harness's own server;
+  /// set to something [_FakeAuth] doesn't recognise to simulate the
+  /// connection disappearing between the join resolving and the ring going
+  /// out (`_clientFor` then finds no client for it).
+  final String joinServerKey;
   int leaves = 0;
 
   @override
@@ -92,7 +102,7 @@ class _StubVoice extends VoiceController {
     state = state.copyWith(
       channelId: channelId,
       spaceId: spaceId,
-      serverKey: _serverKey,
+      serverKey: joinServerKey,
       clearError: true,
     );
   }
@@ -404,4 +414,36 @@ void main() {
     expect(container.read(callControllerProvider).hasOutgoing, isFalse);
     expect(container.read(voiceControllerProvider).channelId, isNull);
   });
+
+  testWidgets(
+    'a connection that vanishes right after a successful join hangs the '
+    'call up instead of ringing',
+    (tester) async {
+      // The join is pinned to a serverKey no client exists for by the time it
+      // resolves — the connection was dropped mid-join. `_clientFor` then
+      // returns null and `startCall` must not fall through to ringing on
+      // whatever connection happens to be active now.
+      final h = _Harness(voice: _StubVoice(joinServerKey: 'gone@nowhere'));
+      await _openConversation(tester, h);
+
+      await tester.tap(find.byTooltip('Start voice call'));
+      await _settle(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(VoiceChannelView), findsNothing);
+      expect(
+        h.requests,
+        isNot(contains('POST /api/v1/channels/dm1/call/ring')),
+      );
+      expect(h.voice.leaves, 1);
+      expect(
+        find.text('Could not start the call — no connection'),
+        findsOneWidget,
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byTooltip('Start voice call')),
+      );
+      expect(container.read(callControllerProvider).hasOutgoing, isFalse);
+    },
+  );
 }

--- a/test/features/voice/incoming_ring_delivery_test.dart
+++ b/test/features/voice/incoming_ring_delivery_test.dart
@@ -1,0 +1,393 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/events/services/accord_event_handler.dart';
+import 'package:bonfire/features/profiles/controllers/profiles_controller.dart';
+import 'package:bonfire/features/profiles/models/device_profile.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/features/voice/controllers/call.dart';
+import 'package:bonfire/features/voice/controllers/voice.dart';
+import 'package:bonfire/features/voice/controllers/voice_states.dart';
+import 'package:bonfire/features/voice/views/incoming_call_overlay.dart';
+import 'package:bonfire/features/voice/views/voice_view.dart';
+import 'package:bonfire/router/controller.dart' show rootNavigatorKey;
+import 'package:bonfire/shared/components/app_shell.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:bonfire/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// The callee's side of a DM call (#324): a `call.ring` frame shaped exactly
+/// like accordserver's (`routes/voice.rs` `ring_call`, broadcast under the
+/// `voice_states` intent) travels through the real [AccordClient] gateway, the
+/// app's event handler and [CallController] to the banner hosted by the
+/// production app shell — and accepting it opens the themed call view.
+
+const _selfId = 'u1';
+const _callerId = 'u2';
+final _server = AccordServer.fromBaseUrl('https://accord.example.test');
+final _session = AccordSession(
+  server: _server,
+  token: 'test-token',
+  userId: _selfId,
+  username: 'self',
+);
+final _serverKey = _session.key;
+final _refProvider = Provider<Ref>((ref) => ref);
+
+/// A [GatewayConnection] a test can push inbound frames through.
+class _FakeGatewayConnection implements GatewayConnection {
+  final _messages = StreamController<String>();
+  void receive(Map<String, dynamic> frame) => _messages.add(jsonEncode(frame));
+  @override
+  Future<void> get ready => Future.value();
+  @override
+  Stream<String> get messages => _messages.stream;
+  @override
+  void sendText(String text) {}
+  @override
+  Future<void> close([int? code, String? reason]) => _messages.close();
+  @override
+  int? closeCode;
+  @override
+  String? closeReason;
+}
+
+class _FakeAuth extends AccordAuth {
+  _FakeAuth(this._client);
+
+  final AccordClient _client;
+
+  @override
+  AccordAuthState build() =>
+      AccordAuthLoggedIn(client: _client, session: _session);
+
+  @override
+  AccordClient? clientForKey(String key) => key == _serverKey ? _client : null;
+}
+
+class _Connections extends ConnectionsController {
+  _Connections(this.activeKey);
+
+  final String activeKey;
+
+  @override
+  ConnectionsState build() => ConnectionsState(activeKey: activeKey);
+}
+
+class _StubVoice extends VoiceController {
+  _StubVoice([this.initial = const VoiceConnection()]);
+
+  final VoiceConnection initial;
+
+  @override
+  VoiceConnection build() => initial;
+
+  @override
+  Future<void> join(String channelId, String? spaceId) async {
+    state = state.copyWith(
+      channelId: channelId,
+      spaceId: spaceId,
+      serverKey: _serverKey,
+    );
+  }
+
+  @override
+  Future<void> leave() async => state = const VoiceConnection();
+}
+
+class _NoVoiceStates extends VoiceStatesController {
+  @override
+  Map<String, Map<String, AccordVoiceState>> build(String serverKey) =>
+      const {};
+}
+
+class _FakeSettings extends SettingsController {
+  @override
+  AccordSettings build() =>
+      const AccordSettings(notificationsEnabled: false, soundsEnabled: false);
+}
+
+class _NoProfiles extends ProfilesController {
+  @override
+  List<DeviceProfile> build() => const [];
+
+  @override
+  DeviceProfile? get active => null;
+}
+
+class _SilentRingtone implements CallRingtone {
+  @override
+  void start({bool outgoing = false}) {}
+
+  @override
+  void stop() {}
+}
+
+/// The frame accordserver broadcasts to every DM participant (caller included)
+/// when someone rings: `{op: 0, type: "call.ring", data: {...}}`, with a null
+/// `metadata` when the caller sent no body.
+Map<String, dynamic> _ringFrame({
+  String channelId = 'dm1',
+  String callerId = _callerId,
+  Object? metadata = const {'video': false},
+}) => {
+  'op': GatewayOpcodes.event,
+  'type': 'call.ring',
+  'data': {
+    'channel_id': channelId,
+    'caller_id': callerId,
+    'participants': [_selfId, callerId],
+    'metadata': metadata,
+  },
+};
+
+class _Harness {
+  _Harness({
+    String? activeKey,
+    bool isActive = true,
+    VoiceConnection voice = const VoiceConnection(),
+  }) {
+    client = AccordClient(
+      token: 'test-token',
+      tokenType: 'Bearer',
+      baseUrl: _server.baseUrl,
+      gatewayUrl: _server.gatewayUrl,
+      cdnUrl: _server.cdnUrl,
+      connectionFactory: (_) => connection,
+      httpClient: MockClient((request) async {
+        const json = {'content-type': 'application/json'};
+        if (request.url.path.endsWith('/users/$_callerId')) {
+          return http.Response(
+            jsonEncode({
+              'id': _callerId,
+              'username': 'alice',
+              'display_name': 'Alice',
+            }),
+            200,
+            headers: json,
+          );
+        }
+        final body = request.method == 'GET' ? '[]' : '{}';
+        return http.Response(body, 200, headers: json);
+      }),
+    );
+    container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWith(() => _FakeAuth(client)),
+        connectionsControllerProvider.overrideWith(
+          () => _Connections(activeKey ?? _serverKey),
+        ),
+        settingsControllerProvider.overrideWith(_FakeSettings.new),
+        profilesControllerProvider.overrideWith(_NoProfiles.new),
+        voiceControllerProvider.overrideWith(() => _StubVoice(voice)),
+        voiceStatesControllerProvider(
+          _serverKey,
+        ).overrideWith(_NoVoiceStates.new),
+        callRingtoneProvider.overrideWithValue(_SilentRingtone()),
+      ],
+    );
+    // Wired exactly as AccordAuth wires each connection.
+    dispose = handleAccordEvents(
+      container.read(_refProvider),
+      client,
+      serverKey: _serverKey,
+      currentUserId: _selfId,
+      selfDomain: _server.homeDomain,
+      isActive: () => isActive,
+    );
+  }
+
+  final connection = _FakeGatewayConnection();
+  late final AccordClient client;
+  late final ProviderContainer container;
+  late final VoidCallback dispose;
+
+  CallState get callState => container.read(callControllerProvider);
+
+  Future<void> login() async {
+    client.login();
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  void tearDown() {
+    dispose();
+    container.dispose();
+    client.dispose();
+  }
+
+  /// The app as `main.dart` composes it, keyed with the router's root
+  /// navigator so the banner's accept can open the call view.
+  Widget app(Widget home) => UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      navigatorKey: rootNavigatorKey,
+      theme: buildAppTheme(AppThemePreset.dark),
+      builder: (context, child) =>
+          buildAppShell(context, child, uiScale: 1, reducedMotion: false),
+      home: home,
+    ),
+  );
+}
+
+Future<void> _pump(WidgetTester tester) async {
+  for (var i = 0; i < 6; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+final _accept = find.descendant(
+  of: find.byType(IncomingCallOverlay),
+  matching: find.byTooltip('Accept'),
+);
+final _decline = find.descendant(
+  of: find.byType(IncomingCallOverlay),
+  matching: find.byTooltip('Decline'),
+);
+
+void main() {
+  test('a server-shaped call.ring lands in the call state', () async {
+    final h = _Harness();
+    addTearDown(h.tearDown);
+    await h.login();
+
+    h.connection.receive(_ringFrame());
+    await Future<void>.delayed(Duration.zero);
+
+    final incoming = h.callState.incoming;
+    expect(incoming, isNotNull);
+    expect(incoming!.channelId, 'dm1');
+    expect(incoming.callerId, _callerId);
+    expect(incoming.participants, [_selfId, _callerId]);
+    expect(incoming.video, isFalse);
+    // Accept/decline must route back through the connection it rang on.
+    expect(incoming.serverKey, _serverKey);
+  });
+
+  test('a ring without metadata (no request body) still rings', () async {
+    final h = _Harness();
+    addTearDown(h.tearDown);
+    await h.login();
+
+    h.connection.receive(_ringFrame(metadata: null));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(h.callState.incoming?.channelId, 'dm1');
+    expect(h.callState.incoming?.video, isFalse);
+  });
+
+  test('a ring on a background connection still rings', () async {
+    // The user is browsing another server; the DM lives on this one. The
+    // server targets DM participants directly, so the ring must not be
+    // gated on which connection is active.
+    final h = _Harness(
+      activeKey: 'someone@https://other.example',
+      isActive: false,
+    );
+    addTearDown(h.tearDown);
+    await h.login();
+
+    h.connection.receive(_ringFrame());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(h.callState.incoming?.channelId, 'dm1');
+    expect(h.callState.incoming?.serverKey, _serverKey);
+  });
+
+  test('the caller\'s own echo of the ring is ignored', () async {
+    // accordserver broadcasts call.ring to every participant, the caller too.
+    final h = _Harness(
+      voice: VoiceConnection(channelId: 'dm1', serverKey: _serverKey),
+    );
+    addTearDown(h.tearDown);
+    await h.login();
+
+    h.connection.receive(_ringFrame(callerId: _selfId));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(h.callState.incoming, isNull);
+  });
+
+  test('a ring for the call we are already in is ignored', () async {
+    final h = _Harness(
+      voice: VoiceConnection(channelId: 'dm1', serverKey: _serverKey),
+    );
+    addTearDown(h.tearDown);
+    await h.login();
+
+    // Another participant of a group DM we already joined rings it again.
+    h.connection.receive(_ringFrame(callerId: 'u3'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(h.callState.incoming, isNull);
+  });
+
+  testWidgets('the ring shows the banner in the app shell, over a dialog, and '
+      'accepting opens the themed call view', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final h = _Harness();
+    addTearDown(h.tearDown);
+    // Inside testWidgets' fake-async zone the gateway handshake advances on
+    // pumps, not on a real `Future.delayed`.
+    h.client.login();
+    await tester.pump();
+
+    await tester.pumpWidget(
+      h.app(
+        Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) =>
+                    const AlertDialog(title: Text('Direct messages')),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    // The callee is sitting in a dialog (on mobile the DM conversation *is*
+    // one) — the case the outer bootstrap navigator used to hide the banner in.
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Direct messages'), findsOneWidget);
+
+    h.connection.receive(_ringFrame());
+    await _pump(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Incoming call'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
+    expect(_decline.hitTestable(), findsOneWidget);
+    expect(_accept.hitTestable(), findsOneWidget);
+
+    await tester.tap(_accept);
+    await _pump(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(h.callState.incoming, isNull);
+    expect(h.container.read(voiceControllerProvider).channelId, 'dm1');
+    final view = find.byType(VoiceChannelView);
+    expect(view, findsOneWidget);
+    expect(
+      Theme.of(tester.element(view)).extension<BonfireThemeExtension>(),
+      isNotNull,
+      reason: 'the call view must open inside the themed app',
+    );
+    expect(find.byIcon(Icons.call_end), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #324

## Root causes
**Caller's blank screen.** `main.dart` booted a bare `MaterialApp(home: ProfileGate(child: MainWindow()))` around the themed `MaterialApp.router`. `Navigator.of(context, rootNavigator: true)` resolves to that outer navigator, so `showFullScreenVoice` pushed the DM call view into an app with no `BonfireThemeExtension`. `BonfireThemeExtension.of` is a bare null-check, so the view threw during build; in release the error box paints as a blank panel. A test reproducing the old nesting fails with exactly that `_TypeError` from `voice_view.dart`. Dialogs survived because `DialogRoute` captures inherited themes; a plain `MaterialPageRoute` does not.

**Callee's missing ring.** The same outer navigator is where every `showDialog` landed, including the DM conversation on mobile, so dialogs sat above the incoming-call banner host that #139 placed in the router app's builder. The ring played but the banner was hidden, and accepting would have pushed the call view into the same unthemed navigator. The gateway path itself was fine: the server maps `call.ring` to the `voice_states` intent, which the client subscribes to.

## Change
- Drop the bootstrap `MaterialApp`. The router builder now calls `buildAppShell` (`lib/shared/components/app_shell.dart`), which layers the accessibility overrides, `ProfileGate` and the ring banner host, so go_router's navigator is the app's root navigator.
- The PIN lock screen brings its own `Overlay` since no navigator sits above it any more.
- `CallController.startCall` rings through the connection the join was pinned to, and a rejected ring stops the ringtone, leaves voice and surfaces the server's message instead of leaving the caller on "Calling…". A rejected join shows the voice error in a snackbar from the DM view.
- CLAUDE.md multi-profile note updated: do not wrap `MainWindow` in another navigator.

## Tests
- `test/features/voice/dm_call_screen_test.dart`: real DM dialog → real `CallController` in the production shell → themed call view with control bar, ringing banner and message pane; hang-up cancels and pops; a second ring is answerable above the call view; full-screen DM view with chat open; rejected join and rejected ring paths.
- `test/features/voice/incoming_ring_delivery_test.dart`: server-shaped `call.ring` frame through the real gateway → event handler → `CallState.incoming`; null metadata; background connection; own echo and already-in-call ignored; banner over a dialog, accept opens the themed view.
- Profile gate PIN unlock under the builder; accordkit `call.ring` with null metadata.
- `flutter test test/features/voice test/features/user test/features/profiles test/features/spaces` → 266 pass; accordkit → 168 pass; codegen check clean.

Not verified on a device: real LiveKit media after the view opens, and the shell restructure on a real launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)