### PR TITLE
Complete AutoMod configuration and moderator review controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,3 +170,13 @@ When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SD
   volatile dependency versions or test counts.
 - Keep changes minimal and reuse-first; this is a port, not a rewrite.
 - Don't reintroduce Discord endpoints, Discord branding, or Firebase push without explicit instruction.
+
+## AutoMod
+
+`lib/features/automod/` owns the policy/review UI and block-before-delete flow.
+Keep configuration (`manage_space`), review (`moderate_members`), and stored-file
+blocking (effective channel `manage_messages`) separate; instance scope requires
+an administrator. `docs/automod.md` documents the client contract. Private
+evidence must use the authenticated SDK endpoint and must be cleared on account
+changes. Moderator mutations opt out of automatic 429 retry. Tests live in
+`test/features/automod/` and `packages/accordkit/test/automod_management_test.dart`.

--- a/README.md
+++ b/README.md
@@ -352,3 +352,9 @@ Every contribution — however small — goes straight into maintaining and impr
 ## 📄 License
 
 Licensed under the **[GNU General Public License v3.0](LICENSE)** (GPLv3), inherited from Bonfire. AccordKit-Dart is MIT-licensed; GPLv3 may incorporate MIT-licensed code, so depending on `accordkit` is fine.
+
+### Automatic moderation
+
+Configure server and space rules, review held uploads, and block repeated file
+uploads through the AutoMod controls. See [the client AutoMod guide](docs/automod.md)
+for permissions, video sampling, private evidence, and cooldown behavior.

--- a/docs/automod.md
+++ b/docs/automod.md
@@ -1,0 +1,50 @@
+# AutoMod in the client
+
+The server's AutoMod protocol is documented in
+[DaccordProject/accordserver](https://github.com/DaccordProject/accordserver/blob/master/docs/automod.md).
+
+Instance administrators open **Admin panel → AutoMod**. Space managers open
+**Space settings → AutoMod** to configure a complete override or restore the
+inherited instance policy. Members with `moderate_members` can open the same
+space screen to review uploads without gaining configuration access.
+
+Rules run in order. Configure explicit detector categories and thresholds,
+channel scope, policy-wide role/permission exemptions, evidence retention, and
+quarantine/reject/flag actions. Timeout is available only for hash or trust
+rules. Saving replaces the full policy. Enabling scanning does not install a
+model: instance health shows detector/video status and queue counts so the
+operator can complete server setup.
+
+Videos stay ordinary uploads. The server samples five frames at 10%, 30%, 50%,
+70%, and 90% and applies the highest score per category. This does not inspect
+every frame. The review screen displays available category scores and sample
+timestamps.
+
+The Review tab filters pending, quarantined, rejected, published, and removed
+uploads. Release, quarantine, reject, retry, and removal require a reason.
+Evidence is downloaded through the authenticated private API, with a 64 MiB
+in-memory limit and no redirect following or public CDN fallback. Image previews
+are evicted when closed; switching accounts disposes the review surface and
+closes its evidence dialog. Downloaded originals remain on the user's device.
+Expired evidence and deleted messages remain subject to server checks; release
+cannot restore a deleted message.
+
+**Block files and delete** is available beside message deletion to channel
+message managers; only instance administrators can select a global block,
+including DMs. Select files and enter a reason. The client blocks each selected
+attachment before deleting the message. If a block fails, the message stays; if
+deletion fails, successful blocks remain and the UI reports that partial result.
+No client download or hashing is necessary. The Blocked files tab also allows
+configurators to add known SHA-256 digests, inspect reasons/actors/timestamps,
+and remove blocks. Exact hash blocks operate independently of model scanning;
+modified copies can have different hashes.
+
+Pending uploads remain associated with their server/account across reconnects.
+Rejected uploads can still be released during retention and are reconciled too.
+Gateway withdrawal events remove attachments from caches and viewers. Older
+servers without the optional AutoMod endpoints show an update message while
+ordinary chat remains usable.
+
+The main composer shows configured slowmode and upload budgets. Thread replies
+and forum posts also preserve a rejected draft and show the server's 429 retry
+countdown; none of these send paths automatically resend a failed message.

--- a/lib/features/admin/views/accord_admin_panel.dart
+++ b/lib/features/admin/views/accord_admin_panel.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/features/automod/views/automod_panel.dart';
 import 'package:bonfire/features/admin/views/admin_reports_tab.dart';
 import 'package:bonfire/features/admin/views/admin_settings_tab.dart';
 import 'package:bonfire/features/admin/views/admin_spaces_tab.dart';
@@ -10,8 +11,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 /// Instance-level (server-wide) administration panel — visible only to instance
-/// admins (`session.isAdmin`). Four tabs mirroring the reference client's
-/// `server_management_panel`: Spaces, Users, Reports, Settings. Non-admins are
+/// admins (`session.isAdmin`). Five tabs extending the reference client's
+/// `server_management_panel`: Spaces, Users, Reports, Settings, AutoMod. Non-admins are
 /// shown an access-denied placeholder rather than the tabs.
 class AccordAdminPanel extends ConsumerWidget {
   const AccordAdminPanel({super.key});
@@ -20,8 +21,9 @@ class AccordAdminPanel extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = BonfireThemeExtension.of(context);
     final session = ref.watch(
-      accordAuthProvider
-          .select((s) => s is AccordAuthLoggedIn ? s.session : null),
+      accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.session : null,
+      ),
     );
     final isAdmin = session?.isAdmin ?? false;
 
@@ -58,7 +60,7 @@ class AccordAdminPanel extends ConsumerWidget {
     }
 
     return DefaultTabController(
-      length: 4,
+      length: 5,
       child: Scaffold(
         backgroundColor: colors.background,
         appBar: AppBar(
@@ -76,6 +78,7 @@ class AccordAdminPanel extends ConsumerWidget {
               Tab(text: 'Users'),
               Tab(text: 'Reports'),
               Tab(text: 'Settings'),
+              Tab(text: 'AutoMod'),
             ],
           ),
         ),
@@ -85,6 +88,7 @@ class AccordAdminPanel extends ConsumerWidget {
             AdminUsersTab(),
             AdminReportsTab(),
             AdminSettingsTab(),
+            AutomodPanel(),
           ],
         ),
       ),

--- a/lib/features/automod/utils/automod_policy.dart
+++ b/lib/features/automod/utils/automod_policy.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+Map<String, dynamic> copyAutomodJson(Map<String, dynamic> value) =>
+    (jsonDecode(jsonEncode(value)) as Map).cast<String, dynamic>();
+
+const automodTriggers = {
+  'media': 'Image/video content',
+  'hash_denylist': 'Blocked file',
+  'low_trust': 'New or untrusted member',
+  'non_nsfw_attachment': 'Attachment outside an NSFW channel',
+};
+const automodActions = {
+  'quarantine': 'Hold for review',
+  'reject': 'Reject',
+  'flag': 'Publish and report',
+  'timeout': 'Hold and time out member',
+};
+bool automodAllowsTimeout(String trigger) =>
+    trigger == 'hash_denylist' || trigger == 'low_trust';
+
+/// Validate the editable policy before sending its complete replacement.
+String? validateAutomodPolicy(Map<String, dynamic> policy) {
+  final retention = policy['retention_days'];
+  if (retention is! int || retention < 1 || retention > 90) {
+    return 'Keep evidence for between 1 and 90 days.';
+  }
+  final rules = policy['rules'];
+  if (rules is! List || rules.length > 32) return 'Use at most 32 rules.';
+  final ids = <String>{};
+  for (final rule in rules) {
+    if (rule is! Map) return 'Invalid rule. Update the client before editing.';
+    final id = rule['id'];
+    if (id is! String ||
+        id.isEmpty ||
+        utf8.encode(id).length > 64 ||
+        !ids.add(id)) {
+      return 'Each rule needs a unique name of at most 64 bytes.';
+    }
+    final trigger = automodMap(rule['trigger']);
+    final action = automodMap(rule['action']);
+    final scope = automodMap(rule['scope']);
+    if (!['all', 'non_nsfw', 'channels'].contains(scope['type'])) {
+      return 'Unsupported channel scope.';
+    }
+    if (!automodTriggers.containsKey(trigger['type']) ||
+        !automodActions.containsKey(action['type'])) {
+      return 'This policy uses a rule type this client cannot edit. Update the client first.';
+    }
+    if (trigger['type'] == 'media') {
+      final threshold = trigger['threshold'];
+      final categories = trigger['categories'];
+      if (threshold is! num ||
+          !threshold.isFinite ||
+          threshold < 0 ||
+          threshold > 1 ||
+          categories is! List ||
+          categories.isEmpty ||
+          categories.length > 64 ||
+          categories.any(
+            (c) => c is! String || c.isEmpty || utf8.encode(c).length > 64,
+          )) {
+        return 'Content rules need detector categories and a threshold between 0 and 1.';
+      }
+    }
+    if (scope['type'] == 'channels' &&
+        (automodList(scope['ids']).isEmpty ||
+            automodList(scope['ids']).length > 100)) {
+      return 'Choose between 1 and 100 channels for a channel-specific rule.';
+    }
+    if (action['type'] == 'timeout') {
+      final seconds = action['seconds'];
+      if (!automodAllowsTimeout(trigger['type'] as String) ||
+          seconds is! int ||
+          seconds < 1 ||
+          seconds > 86400) {
+        return 'Timeouts require a blocked-file or trust rule and a duration of 1–86400 seconds.';
+      }
+    }
+  }
+  return null;
+}
+
+Map<String, dynamic> automodMap(Object? value) =>
+    value is Map ? value.cast<String, dynamic>() : <String, dynamic>{};
+List<dynamic> automodList(Object? value) =>
+    value is List ? List<dynamic>.of(value) : <dynamic>[];

--- a/lib/features/automod/views/automod_panel.dart
+++ b/lib/features/automod/views/automod_panel.dart
@@ -1,0 +1,847 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/automod/utils/automod_policy.dart';
+import 'package:bonfire/features/automod/views/automod_rule_editor.dart';
+import 'package:bonfire/features/channels/controllers/accord_channels.dart';
+import 'package:bonfire/features/member/utils/permissions.dart';
+import 'package:bonfire/features/spaces/controllers/spaces.dart';
+import 'package:bonfire/shared/utils/client_access.dart';
+import 'package:bonfire/shared/utils/confirm_dialog.dart';
+import 'package:bonfire/shared/utils/download_attachment.dart';
+import 'package:bonfire/shared/utils/text_prompt_dialog.dart';
+import 'package:collection/collection.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showAutomodPanel(BuildContext context, String scope) =>
+    Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => Scaffold(
+          appBar: AppBar(title: const Text('AutoMod')),
+          body: AutomodPanel(scope: scope),
+        ),
+      ),
+    );
+
+/// Rebuild the workbench when its account or permissions change so old evidence
+/// and late HTTP responses cannot bleed into a different session.
+class AutomodPanel extends ConsumerWidget {
+  const AutomodPanel({super.key, this.scope = '*'});
+  final String scope;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(accordAuthProvider);
+    if (auth is! AccordAuthLoggedIn) {
+      return const Center(child: Text('Connect to a server first.'));
+    }
+    final spaces = ref.watch(spacesControllerProvider) ?? <AccordSpace>[];
+    final space = spaces.firstWhereOrNull((s) => s.id == scope);
+    final perms = scope == '*'
+        ? <String>{}
+        : ref.watchAccordPermissions(space, scope);
+    final configure =
+        auth.session.isAdmin ||
+        (scope != '*' &&
+            accordHasPermission(perms, AccordPermission.manageSpace));
+    final review =
+        auth.session.isAdmin ||
+        (scope != '*' &&
+            accordHasPermission(perms, AccordPermission.moderateMembers));
+    if (!configure && !review) {
+      return const Center(
+        child: Text('You do not have permission to manage AutoMod.'),
+      );
+    }
+    final channels = scope == '*'
+        ? [
+            for (final s in spaces)
+              ...?ref.watch(
+                accordChannelsControllerProvider(
+                  ref.watchActiveServerKey() ?? '',
+                  s.id,
+                ),
+              ),
+          ]
+        : ref.watch(
+                accordChannelsControllerProvider(
+                  ref.watchActiveServerKey() ?? '',
+                  scope,
+                ),
+              ) ??
+              <AccordChannel>[];
+    return AutomodWorkbench(
+      key: ValueKey((auth.client, scope, configure, review)),
+      client: auth.client,
+      scope: scope,
+      canConfigure: configure,
+      canReview: review,
+      roles: scope == '*'
+          ? [for (final s in spaces) ...s.roles]
+          : space?.roles ?? const [],
+      channels: channels,
+    );
+  }
+}
+
+class AutomodWorkbench extends StatefulWidget {
+  const AutomodWorkbench({
+    super.key,
+    required this.client,
+    required this.scope,
+    required this.canConfigure,
+    required this.canReview,
+    this.roles = const [],
+    this.channels = const [],
+  });
+  final AccordClient client;
+  final String scope;
+  final bool canConfigure, canReview;
+  final List<AccordRole> roles;
+  final List<AccordChannel> channels;
+  @override
+  State<AutomodWorkbench> createState() => _AutomodWorkbenchState();
+}
+
+class _AutomodWorkbenchState extends State<AutomodWorkbench> {
+  Map<String, dynamic>? _policy, _health;
+  List<Map<String, dynamic>> _uploads = [], _hashes = [], _events = [];
+  bool _inherited = false, _loading = true, _busy = false, _dirty = false;
+  String? _error;
+  String _status = 'quarantined';
+  int _generation = 0;
+  StreamSubscription<AccordAutomodUploadStatus>? _subscription;
+  Timer? _refreshTimer;
+  DialogRoute<void>? _evidenceRoute;
+  NavigatorState? _evidenceNavigator;
+  AutomodApi get _api => widget.client.automod;
+  @override
+  void initState() {
+    super.initState();
+    _subscription = widget.client.onAutomodUploadUpdate.listen((event) {
+      if (widget.scope != '*' && event.spaceId != widget.scope) return;
+      _refreshTimer?.cancel();
+      _refreshTimer = Timer(const Duration(milliseconds: 500), () {
+        if (mounted && !_busy && !_loading) _load();
+      });
+    });
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _refreshTimer?.cancel();
+    _generation++;
+    final route = _evidenceRoute;
+    final navigator = _evidenceNavigator;
+    if (route != null && navigator != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (route.isActive) navigator.removeRoute(route);
+      });
+    }
+    super.dispose();
+  }
+
+  List<Map<String, dynamic>> _rows(Object? data) => data is List
+      ? data.whereType<Map>().map((r) => r.cast<String, dynamic>()).toList()
+      : [];
+  String _failure(RestResult result) =>
+      result.statusCode == 404 ||
+          result.statusCode == 405 ||
+          result.statusCode == 501
+      ? 'This server does not support this AutoMod operation. Update the server.'
+      : result.statusCode == 403
+      ? 'Your server permissions do not allow this operation.'
+      : result.error?.message ?? 'The request failed. Try again.';
+  Future<void> _load() async {
+    final generation = ++_generation;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    final requests = <String, Future<RestResult>>{
+      if (widget.canConfigure) 'policy': _api.getPolicy(widget.scope),
+      if (widget.canConfigure) 'hashes': _api.listHashes(widget.scope),
+      if (widget.canReview)
+        'uploads': _api.listUploads(widget.scope, status: _status),
+      if (widget.canReview) 'events': _api.events(widget.scope),
+      if (widget.scope == '*') 'health': _api.health(),
+    };
+    final values = await Future.wait(requests.values);
+    if (!mounted || generation != _generation) return;
+    setState(() {
+      for (var i = 0; i < values.length; i++) {
+        final result = values[i], key = requests.keys.elementAt(i);
+        if (!result.ok) {
+          _error ??= _failure(result);
+          continue;
+        }
+        switch (key) {
+          case 'policy':
+            if (!_dirty) {
+              final envelope = automodMap(result.data);
+              _policy = copyAutomodJson(automodMap(envelope['policy']));
+              _inherited = envelope['inherited'] == true;
+            }
+          case 'hashes':
+            _hashes = _rows(result.data);
+          case 'uploads':
+            _uploads = _rows(result.data);
+          case 'events':
+            _events = _rows(result.data);
+          case 'health':
+            _health = automodMap(result.data);
+        }
+      }
+      _loading = false;
+    });
+  }
+
+  Future<void> _mutate(
+    Future<RestResult> Function() request, {
+    bool policy = false,
+  }) async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final result = await request();
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      if (!result.ok) {
+        _error = _failure(result);
+      } else if (policy) {
+        _dirty = false;
+      }
+    });
+    if (result.ok) await _load();
+  }
+
+  void _edit(VoidCallback update) => setState(() {
+    update();
+    _dirty = true;
+  });
+  Future<void> _rule([int? index]) async {
+    final rules = automodList(_policy?['rules']);
+    final edited = await editAutomodRule(
+      context,
+      rule: index == null ? null : automodMap(rules[index]),
+      channels: widget.channels,
+    );
+    if (!mounted || edited == null) return;
+    _edit(() {
+      if (index == null) {
+        rules.add(edited);
+      } else {
+        rules[index] = edited;
+      }
+      _policy!['rules'] = rules;
+    });
+  }
+
+  Future<String?> _reason(String title) async {
+    final reason = await showTextPromptDialog(
+      context,
+      title: title,
+      label: 'Reason',
+      confirmLabel: 'Continue',
+    );
+    if (!mounted || reason == null) return null;
+    if (reason.trim().isEmpty || utf8.encode(reason.trim()).length > 2000) {
+      setState(() => _error = 'Enter a reason of 1–2000 UTF-8 bytes.');
+      return null;
+    }
+    return reason.trim();
+  }
+
+  Future<void> _blockDigest() async {
+    final hash = await showTextPromptDialog(
+      context,
+      title: 'Block file digest',
+      label: 'SHA-256 digest',
+      helperText: '64 hexadecimal characters from a known file hash.',
+    );
+    if (!mounted || hash == null) return;
+    final digest = hash.trim().toLowerCase();
+    if (!RegExp(r'^[0-9a-f]{64}$').hasMatch(digest)) {
+      setState(() => _error = 'Enter a valid 64-character SHA-256 digest.');
+      return;
+    }
+    final reason = await _reason('Why block this file?');
+    if (!mounted || reason == null) return;
+    await _mutate(() => _api.blockHash(widget.scope, digest, reason));
+  }
+
+  Future<void> _review(Map<String, dynamic> upload, String action) async {
+    final reason = await _reason(
+      '${action[0].toUpperCase()}${action.substring(1)} attachment',
+    );
+    if (!mounted || reason == null || reason.trim().isEmpty) return;
+    await _mutate(
+      () => _api.review(asString(upload['id']), action, reason.trim()),
+    );
+  }
+
+  Future<void> _content(Map<String, dynamic> upload) async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final result = await _api.getContent(asString(upload['id']));
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (!result.ok || result.data is! Uint8List) {
+      setState(
+        () => _error = result.statusCode == 404 || result.statusCode == 410
+            ? 'This evidence has expired or is no longer available.'
+            : _failure(result),
+      );
+      return;
+    }
+    final bytes = result.data as Uint8List;
+    final filename = sanitizeAttachmentFilename(
+      asString(upload['filename'], 'evidence.bin'),
+    );
+    // The private API authenticates the download. Never hand its URL/token to
+    // an unauthenticated browser, CDN widget, external viewer or persistent cache.
+    final navigator = Navigator.of(context, rootNavigator: true);
+    final route = DialogRoute<void>(
+      context: context,
+      builder: (context) => !mounted
+          ? const SizedBox.shrink()
+          : AlertDialog(
+              title: Text(filename),
+              content: SizedBox(
+                width: 520,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (asString(upload['content_type']).startsWith('image/'))
+                      Flexible(
+                        child: Image.memory(
+                          bytes,
+                          cacheWidth: 800,
+                          errorBuilder: (_, _, _) => const Text(
+                            'No image preview available. Download to review.',
+                          ),
+                        ),
+                      )
+                    else
+                      const Text(
+                        'Download this private original to review it. Saved copies remain on your device.',
+                      ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Close'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    if (!mounted) return;
+                    try {
+                      await FilePicker.platform.saveFile(
+                        fileName: filename,
+                        bytes: bytes,
+                      );
+                    } catch (_) {
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Could not save the evidence.'),
+                          ),
+                        );
+                      }
+                    }
+                  },
+                  child: const Text('Download original'),
+                ),
+              ],
+            ),
+    );
+    _evidenceRoute = route;
+    _evidenceNavigator = navigator;
+    await navigator.push(route);
+    _evidenceRoute = null;
+    _evidenceNavigator = null;
+    await ResizeImage.resizeIfNeeded(800, null, MemoryImage(bytes)).evict();
+  }
+
+  Future<void> _more(String kind) async {
+    if (_busy) return;
+    final rows = kind == 'uploads'
+        ? _uploads
+        : kind == 'hashes'
+        ? _hashes
+        : _events;
+    if (rows.isEmpty) return;
+    setState(() => _busy = true);
+    final before = asString(rows.last[kind == 'hashes' ? 'hash' : 'id']);
+    final result = await (kind == 'uploads'
+        ? _api.listUploads(widget.scope, status: _status, before: before)
+        : kind == 'hashes'
+        ? _api.listHashes(widget.scope, before: before)
+        : _api.events(widget.scope, before: before));
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      if (result.ok) {
+        rows.addAll(_rows(result.data));
+      } else {
+        _error = _failure(result);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = [
+      if (widget.canConfigure) 'Rules',
+      if (widget.canReview) 'Review',
+      if (widget.canConfigure) 'Blocked files',
+      if (widget.canReview) 'Activity',
+    ];
+    return DefaultTabController(
+      length: tabs.length,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TabBar(
+                  isScrollable: true,
+                  tabs: [for (final title in tabs) Tab(text: title)],
+                ),
+              ),
+              IconButton(
+                tooltip: 'Refresh AutoMod',
+                onPressed: _loading || _busy ? null : _load,
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          if (_loading || _busy) const LinearProgressIndicator(),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                if (widget.canConfigure) _rules(),
+                if (widget.canReview) _queue(),
+                if (widget.canConfigure) _blocked(),
+                if (widget.canReview) _activity(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _rules() {
+    final policy = _policy;
+    if (policy == null) return const Center(child: Text('No policy loaded.'));
+    final rules = automodList(policy['rules']);
+    final exemptions = automodList(
+      policy['exempt_roles'],
+    ).map((v) => '$v').toSet();
+    final permissions = automodList(
+      policy['exempt_permissions'],
+    ).map((v) => '$v').toSet();
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        if (_health != null) Text('Detector: ${_health!['scanner']}'),
+        if (_health != null)
+          Text('Video sampler: ${_health!['video_sampler']}'),
+        if (_health != null)
+          Text(
+            'Queue capacity: ${_health!['max_held']} uploads · ${((asInt(_health!['max_held_bytes'])) / (1024 * 1024)).round()} MiB',
+          ),
+        if (_health != null)
+          for (final row in automodList(_health!['uploads']))
+            Text('${row['status']}: ${row['count']} uploads'),
+        if (_health != null && _health!['scanner'] != 'ready')
+          const Text(
+            'Ask the server operator to install/configure the local model and runtime. Enabling rules does not install them.',
+          ),
+        if (_inherited)
+          const Text(
+            'Using the server policy. Saving creates a complete space override.',
+          ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Enable automatic scanning'),
+          value: policy['enabled'] == true,
+          onChanged: _busy ? null : (v) => _edit(() => policy['enabled'] = v),
+        ),
+        const Text(
+          'Explicit file blocks and upload limits work even when scanning is disabled.',
+        ),
+        TextFormField(
+          key: ObjectKey(policy),
+          initialValue: '${policy['retention_days']}',
+          keyboardType: TextInputType.number,
+          decoration: const InputDecoration(
+            labelText: 'Keep held evidence (days, 1–90)',
+          ),
+          onChanged: (v) =>
+              _edit(() => policy['retention_days'] = int.tryParse(v)),
+        ),
+        const SizedBox(height: 12),
+        const Text('Exempt roles'),
+        Wrap(
+          spacing: 6,
+          children: [
+            for (final role in widget.roles)
+              FilterChip(
+                label: Text(role.name),
+                selected: exemptions.contains(role.id),
+                onSelected: _busy
+                    ? null
+                    : (v) => _edit(() {
+                        if (v) {
+                          exemptions.add(role.id);
+                        } else {
+                          exemptions.remove(role.id);
+                        }
+                        policy['exempt_roles'] = exemptions.toList();
+                      }),
+              ),
+            for (final id in exemptions.where(
+              (id) => !widget.roles.any((r) => r.id == id),
+            ))
+              InputChip(
+                label: Text('Role $id'),
+                onDeleted: () => _edit(() {
+                  exemptions.remove(id);
+                  policy['exempt_roles'] = exemptions.toList();
+                }),
+              ),
+          ],
+        ),
+        const Text('Exempt permissions'),
+        Wrap(
+          spacing: 6,
+          children: [
+            for (final permission in {
+              ...permissions,
+              'manage_messages',
+              'manage_channels',
+              'moderate_members',
+            })
+              FilterChip(
+                label: Text(permission.replaceAll('_', ' ')),
+                selected: permissions.contains(permission),
+                onSelected: _busy
+                    ? null
+                    : (v) => _edit(() {
+                        if (v) {
+                          permissions.add(permission);
+                        } else {
+                          permissions.remove(permission);
+                        }
+                        policy['exempt_permissions'] = permissions.toList();
+                      }),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        const Text('Rules run in order; the first match decides the action.'),
+        for (var i = 0; i < rules.length; i++)
+          Card(
+            child: ListTile(
+              title: Text(asString(rules[i]['id'])),
+              subtitle: Text(
+                '${automodTriggers[rules[i]['trigger']['type']] ?? rules[i]['trigger']['type']} · ${automodActions[rules[i]['action']['type']] ?? rules[i]['action']['type']}',
+              ),
+              onTap: _busy ? null : () => _rule(i),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    tooltip: 'Move rule up',
+                    onPressed: _busy || i == 0
+                        ? null
+                        : () => _edit(() {
+                            final r = rules.removeAt(i);
+                            rules.insert(i - 1, r);
+                            policy['rules'] = rules;
+                          }),
+                    icon: const Icon(Icons.arrow_upward),
+                  ),
+                  IconButton(
+                    tooltip: 'Delete rule',
+                    onPressed: _busy
+                        ? null
+                        : () => _edit(() {
+                            rules.removeAt(i);
+                            policy['rules'] = rules;
+                          }),
+                    icon: const Icon(Icons.delete_outline),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        Wrap(
+          spacing: 12,
+          children: [
+            TextButton.icon(
+              onPressed: _busy || rules.length >= 32 ? null : () => _rule(),
+              icon: const Icon(Icons.add),
+              label: const Text('Add rule'),
+            ),
+            FilledButton(
+              onPressed: !_dirty || _busy
+                  ? null
+                  : () {
+                      final error = validateAutomodPolicy(policy);
+                      if (error != null) {
+                        setState(() => _error = error);
+                        return;
+                      }
+                      _mutate(
+                        () => _api.setPolicy(
+                          widget.scope,
+                          copyAutomodJson(policy),
+                        ),
+                        policy: true,
+                      );
+                    },
+              child: const Text('Save policy'),
+            ),
+            if (widget.scope != '*')
+              TextButton(
+                onPressed: _busy
+                    ? null
+                    : () async {
+                        final confirmed = await showConfirmDialog(
+                          context,
+                          title: 'Use server policy?',
+                          message:
+                              'This removes this space’s override and discards unsaved changes.',
+                          confirmLabel: 'Use server policy',
+                        );
+                        if (mounted && confirmed == true) {
+                          await _mutate(
+                            () => _api.resetPolicy(widget.scope),
+                            policy: true,
+                          );
+                        }
+                      },
+                child: const Text('Use server policy'),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _queue() => ListView(
+    padding: const EdgeInsets.all(16),
+    children: [
+      DropdownButton<String>(
+        value: _status,
+        items: [
+          for (final s in [
+            'quarantined',
+            'pending',
+            'rejected',
+            'published',
+            'removed',
+          ])
+            DropdownMenuItem(value: s, child: Text(s)),
+        ],
+        onChanged: _busy
+            ? null
+            : (v) {
+                setState(() => _status = v!);
+                _load();
+              },
+      ),
+      if (_uploads.isEmpty && !_loading)
+        const Text('No uploads with this status.'),
+      for (final upload in _uploads)
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  asString(upload['filename'], 'Attachment'),
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                Text(
+                  'Status: ${upload['status']} · Uploader: ${upload['author_id']}',
+                ),
+                if (asString(upload['reason']).isNotEmpty)
+                  Text(asString(upload['reason'])),
+                if (upload['result'] != null)
+                  Text(_scanSummary(upload['result'])),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    TextButton(
+                      onPressed: _busy || upload['status'] == 'removed'
+                          ? null
+                          : () => _content(upload),
+                      child: const Text('View evidence'),
+                    ),
+                    for (final action in [
+                      'release',
+                      'quarantine',
+                      'reject',
+                      'retry',
+                      'remove',
+                    ])
+                      if (upload['status'] != 'removed' &&
+                          !(action == 'release' &&
+                              upload['status'] == 'published'))
+                        TextButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _review(upload, action),
+                          child: Text(
+                            action[0].toUpperCase() + action.substring(1),
+                          ),
+                        ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      if (_uploads.length >= 100)
+        TextButton(
+          onPressed: _busy ? null : () => _more('uploads'),
+          child: const Text('Load older uploads'),
+        ),
+    ],
+  );
+  Widget _blocked() => ListView(
+    padding: const EdgeInsets.all(16),
+    children: [
+      const Text(
+        'Exact file blocks remain active without model scanning. Modified or re-encoded copies have different hashes.',
+      ),
+      TextButton.icon(
+        onPressed: _busy ? null : _blockDigest,
+        icon: const Icon(Icons.block),
+        label: const Text('Block file digest'),
+      ),
+      if (_hashes.isEmpty && !_loading)
+        const Text('No blocked files in this scope.'),
+      for (final row in _hashes)
+        Card(
+          child: ListTile(
+            title: SelectableText(asString(row['hash'])),
+            subtitle: Text(
+              '${row['reason']}\nAdded by ${row['added_by'] ?? 'unknown'}${row['created_at'] == null ? '' : ' · ${DateTime.fromMillisecondsSinceEpoch(asInt(row['created_at']) * 1000).toLocal()}'}',
+            ),
+            trailing: IconButton(
+              tooltip: 'Unblock file',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: _busy
+                  ? null
+                  : () async {
+                      final ok = await showConfirmDialog(
+                        context,
+                        title: 'Unblock file?',
+                        message:
+                            'Identical copies will be allowed unless another rule or instance block applies.',
+                        confirmLabel: 'Unblock',
+                      );
+                      if (mounted && ok == true) {
+                        await _mutate(
+                          () => _api.unblockHash(
+                            widget.scope,
+                            asString(row['hash']),
+                          ),
+                        );
+                      }
+                    },
+            ),
+          ),
+        ),
+      if (_hashes.length >= 100)
+        TextButton(
+          onPressed: _busy ? null : () => _more('hashes'),
+          child: const Text('Load older blocks'),
+        ),
+    ],
+  );
+  Map<String, dynamic> _decodeDetails(Object? value) {
+    if (value is String) {
+      try {
+        return automodMap(jsonDecode(value));
+      } catch (_) {
+        return {};
+      }
+    }
+    return automodMap(value);
+  }
+
+  String _timestamp(Object? value) => value is num
+      ? DateTime.fromMillisecondsSinceEpoch(
+          value.toInt() * 1000,
+        ).toLocal().toString()
+      : '';
+  String _scanSummary(Object? value) {
+    final result = _decodeDetails(value);
+    final scores = automodMap(result['scores']);
+    return [
+      for (final entry in scores.entries)
+        if (entry.value is num)
+          '${entry.key.replaceAll('_', ' ').toLowerCase()}: ${((entry.value as num) * 100).toStringAsFixed(1)}%',
+      if (automodList(result['sampled_timestamps_ms']).isNotEmpty)
+        'Video samples (seconds): ${automodList(result['sampled_timestamps_ms']).whereType<num>().map((v) => (v / 1000).toStringAsFixed(1)).join(', ')}',
+    ].join('\n');
+  }
+
+  String _detailsSummary(Object? value) {
+    final details = _decodeDetails(value);
+    return [
+      if (details['reason'] != null) asString(details['reason']),
+      if (details['rule_id'] != null) 'Rule: ${details['rule_id']}',
+      if (details['hash'] != null) 'File digest: ${details['hash']}',
+      if (details['error'] != null) asString(details['error']),
+    ].join('\n');
+  }
+
+  Widget _activity() => ListView(
+    padding: const EdgeInsets.all(16),
+    children: [
+      if (_events.isEmpty && !_loading) const Text('No moderation activity.'),
+      for (final row in _events)
+        ListTile(
+          title: Text(asString(row['action'])),
+          subtitle: SelectableText(
+            'Actor: ${row['actor_id'] ?? 'AutoMod'} · ${_timestamp(row['created_at'])}\n${_detailsSummary(row['details'])}',
+          ),
+        ),
+      if (_events.length >= 100)
+        TextButton(
+          onPressed: _busy ? null : () => _more('events'),
+          child: const Text('Load older activity'),
+        ),
+    ],
+  );
+}

--- a/lib/features/automod/views/automod_rule_editor.dart
+++ b/lib/features/automod/views/automod_rule_editor.dart
@@ -1,0 +1,307 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/automod/utils/automod_policy.dart';
+import 'package:flutter/material.dart';
+
+Future<Map<String, dynamic>?> editAutomodRule(
+  BuildContext context, {
+  Map<String, dynamic>? rule,
+  List<AccordChannel> channels = const [],
+}) => showDialog<Map<String, dynamic>>(
+  context: context,
+  builder: (_) => _RuleEditor(rule: rule, channels: channels),
+);
+
+class _RuleEditor extends StatefulWidget {
+  const _RuleEditor({this.rule, required this.channels});
+  final Map<String, dynamic>? rule;
+  final List<AccordChannel> channels;
+  @override
+  State<_RuleEditor> createState() => _RuleEditorState();
+}
+
+class _RuleEditorState extends State<_RuleEditor> {
+  final _form = GlobalKey<FormState>();
+  late final TextEditingController _id;
+  late final TextEditingController _categories;
+  late final TextEditingController _threshold;
+  late final TextEditingController _seconds;
+  late final TextEditingController _accountAge;
+  late final TextEditingController _spaceAge;
+  late String _trigger, _action, _scope;
+  late bool _requireRole;
+  late Set<String> _channelIds;
+  String? _error;
+  @override
+  void initState() {
+    super.initState();
+    final rule = widget.rule ?? <String, dynamic>{};
+    final trigger = automodMap(rule['trigger']),
+        action = automodMap(rule['action']),
+        scope = automodMap(rule['scope']);
+    _id = TextEditingController(text: asString(rule['id']));
+    _trigger = asString(trigger['type'], 'media');
+    _action = asString(action['type'], 'quarantine');
+    _scope = asString(scope['type'], 'non_nsfw');
+    _channelIds = automodList(scope['ids']).map((id) => id.toString()).toSet();
+    _categories = TextEditingController(
+      text: trigger['categories'] == null
+          ? 'FEMALE_BREAST_EXPOSED, FEMALE_GENITALIA_EXPOSED, MALE_GENITALIA_EXPOSED, ANUS_EXPOSED'
+          : automodList(trigger['categories']).join(', '),
+    );
+    _threshold = TextEditingController(text: '${trigger['threshold'] ?? 0.8}');
+    _seconds = TextEditingController(text: '${action['seconds'] ?? 300}');
+    _accountAge = TextEditingController(
+      text: '${trigger['min_account_age_hours'] ?? 24}',
+    );
+    _spaceAge = TextEditingController(
+      text: '${trigger['min_space_age_hours'] ?? 1}',
+    );
+    _requireRole = trigger['require_role'] == true;
+  }
+
+  @override
+  void dispose() {
+    for (final c in [
+      _id,
+      _categories,
+      _threshold,
+      _seconds,
+      _accountAge,
+      _spaceAge,
+    ]) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Widget _number(
+    TextEditingController controller,
+    String label,
+    int min,
+    int max,
+  ) => TextFormField(
+    controller: controller,
+    keyboardType: TextInputType.number,
+    decoration: InputDecoration(labelText: label),
+    validator: (v) {
+      final number = int.tryParse(v ?? '');
+      return number == null || number < min || number > max
+          ? 'Enter $min–$max.'
+          : null;
+    },
+  );
+  void _save() {
+    if (!_form.currentState!.validate()) return;
+    final rule = <String, dynamic>{
+      'id': _id.text.trim(),
+      'trigger': <String, dynamic>{
+        'type': _trigger,
+        if (_trigger == 'media') ...{
+          'categories': _categories.text
+              .split(',')
+              .map((s) => s.trim())
+              .where((s) => s.isNotEmpty)
+              .toList(),
+          'threshold': double.tryParse(_threshold.text),
+        },
+        if (_trigger == 'low_trust') ...{
+          'min_account_age_hours': int.parse(_accountAge.text),
+          'min_space_age_hours': int.parse(_spaceAge.text),
+          'require_role': _requireRole,
+        },
+      },
+      'scope': {
+        'type': _scope,
+        if (_scope == 'channels') 'ids': _channelIds.toList(),
+      },
+      'action': {
+        'type': _action,
+        if (_action == 'timeout') 'seconds': int.parse(_seconds.text),
+      },
+    };
+    final error = validateAutomodPolicy({
+      'retention_days': 7,
+      'rules': [rule],
+    });
+    if (error != null) {
+      setState(() => _error = error);
+      return;
+    }
+    Navigator.pop(context, rule);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Preserve newer rule types rather than silently rewriting them as defaults.
+    if (!automodTriggers.containsKey(_trigger) ||
+        !automodActions.containsKey(_action) ||
+        !['all', 'non_nsfw', 'channels'].contains(_scope)) {
+      return AlertDialog(
+        title: const Text('Update required'),
+        content: const Text('This rule uses options this client cannot edit.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      );
+    }
+    return AlertDialog(
+      title: Text(widget.rule == null ? 'Add rule' : 'Edit rule'),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Form(
+            key: _form,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  controller: _id,
+                  decoration: const InputDecoration(labelText: 'Rule name'),
+                  validator: (v) =>
+                      v == null || v.trim().isEmpty ? 'Enter a name.' : null,
+                ),
+                DropdownButtonFormField<String>(
+                  initialValue: _trigger,
+                  isExpanded: true,
+                  decoration: const InputDecoration(labelText: 'When'),
+                  items: [
+                    for (final e in automodTriggers.entries)
+                      DropdownMenuItem(value: e.key, child: Text(e.value)),
+                  ],
+                  onChanged: (v) => setState(() {
+                    _trigger = v!;
+                    if (!automodAllowsTimeout(v) && _action == 'timeout') {
+                      _action = 'quarantine';
+                    }
+                  }),
+                ),
+                if (_trigger == 'media') ...[
+                  TextFormField(
+                    controller: _categories,
+                    maxLines: 3,
+                    decoration: const InputDecoration(
+                      labelText: 'Detector categories',
+                      helperText:
+                          'Comma-separated category names supported by the server detector.',
+                    ),
+                  ),
+                  TextFormField(
+                    controller: _threshold,
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                    ),
+                    decoration: const InputDecoration(
+                      labelText: 'Threshold (0–1)',
+                    ),
+                  ),
+                  const Text(
+                    'Videos sample five frames at 10%, 30%, 50%, 70% and 90%. Content between samples can be missed.',
+                  ),
+                ],
+                if (_trigger == 'low_trust') ...[
+                  _number(
+                    _accountAge,
+                    'Minimum account age (hours)',
+                    0,
+                    4294967295,
+                  ),
+                  _number(
+                    _spaceAge,
+                    'Minimum membership age (hours)',
+                    0,
+                    4294967295,
+                  ),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Require an assigned role'),
+                    value: _requireRole,
+                    onChanged: (v) => setState(() => _requireRole = v),
+                  ),
+                ],
+                DropdownButtonFormField<String>(
+                  initialValue: _scope,
+                  isExpanded: true,
+                  decoration: const InputDecoration(labelText: 'Channels'),
+                  items: const [
+                    DropdownMenuItem(value: 'all', child: Text('All channels')),
+                    DropdownMenuItem(
+                      value: 'non_nsfw',
+                      child: Text('Outside NSFW channels'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'channels',
+                      child: Text('Selected channels'),
+                    ),
+                  ],
+                  onChanged: (v) => setState(() => _scope = v!),
+                ),
+                if (_scope == 'channels') ...[
+                  if (widget.channels.isEmpty)
+                    const Text(
+                      'Open a space to load its channels before adding a channel-specific rule.',
+                    ),
+                  Wrap(
+                    spacing: 6,
+                    children: [
+                      for (final channel in widget.channels)
+                        FilterChip(
+                          label: Text(channel.name ?? channel.id),
+                          selected: _channelIds.contains(channel.id),
+                          onSelected: (v) => setState(() {
+                            if (v) {
+                              _channelIds.add(channel.id);
+                            } else {
+                              _channelIds.remove(channel.id);
+                            }
+                          }),
+                        ),
+                    ],
+                  ),
+                  for (final id in _channelIds.where(
+                    (id) => !widget.channels.any((c) => c.id == id),
+                  ))
+                    InputChip(
+                      label: Text('Channel $id'),
+                      onDeleted: () => setState(() => _channelIds.remove(id)),
+                    ),
+                ],
+                DropdownButtonFormField<String>(
+                  key: ValueKey('action-$_trigger-$_action'),
+                  initialValue: _action,
+                  isExpanded: true,
+                  decoration: const InputDecoration(labelText: 'Action'),
+                  items: [
+                    for (final e in automodActions.entries)
+                      if (e.key != 'timeout' || automodAllowsTimeout(_trigger))
+                        DropdownMenuItem(value: e.key, child: Text(e.value)),
+                  ],
+                  onChanged: (v) => setState(() => _action = v!),
+                ),
+                if (_action == 'timeout')
+                  _number(_seconds, 'Timeout (seconds)', 1, 86400),
+                if (_error != null)
+                  Text(
+                    _error!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _save, child: const Text('Use rule')),
+      ],
+    );
+  }
+}

--- a/lib/features/automod/views/block_attachment_dialog.dart
+++ b/lib/features/automod/views/block_attachment_dialog.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'package:accordkit/accordkit.dart';
+import 'package:flutter/material.dart';
+
+/// Block first, then delete. Report partial success; a failed delete never
+/// removes the persisted block, and a failed block never deletes the message.
+Future<String?> blockAttachmentsAndDelete({
+  required AccordClient client,
+  required String scope,
+  required String channelId,
+  required String messageId,
+  required List<String> attachmentIds,
+  required String reason,
+  bool Function()? stillActive,
+}) async {
+  var blocked = 0;
+  for (final id in attachmentIds) {
+    if (stillActive != null && !stillActive()) {
+      return 'Account changed; the operation stopped.';
+    }
+    final result = await client.automod.blockAttachment(scope, id, reason);
+    if (!result.ok) {
+      return '${blocked == 0 ? 'No files were blocked.' : '$blocked file(s) are blocked.'} The message was kept. ${result.error?.message ?? 'Blocking failed.'}';
+    }
+    blocked++;
+  }
+  if (blocked == 0) return 'Select at least one attachment.';
+  if (stillActive != null && !stillActive()) {
+    return 'Files are blocked. Account changed before message deletion.';
+  }
+  final deleted = await client.messages.delete(channelId, messageId);
+  return deleted.ok
+      ? null
+      : 'Files are blocked, but the message could not be deleted. ${deleted.error?.message ?? 'Try deleting it again.'}';
+}
+
+Future<bool?> showBlockAttachmentDialog(
+  BuildContext context, {
+  required AccordClient client,
+  required AccordMessage message,
+  required bool isInstanceAdmin,
+  required bool Function() stillActive,
+}) => showDialog<bool>(
+  context: context,
+  builder: (_) => _BlockDialog(
+    client: client,
+    message: message,
+    isAdmin: isInstanceAdmin,
+    stillActive: stillActive,
+  ),
+);
+
+class _BlockDialog extends StatefulWidget {
+  const _BlockDialog({
+    required this.client,
+    required this.message,
+    required this.isAdmin,
+    required this.stillActive,
+  });
+  final AccordClient client;
+  final AccordMessage message;
+  final bool isAdmin;
+  final bool Function() stillActive;
+  @override
+  State<_BlockDialog> createState() => _BlockDialogState();
+}
+
+class _BlockDialogState extends State<_BlockDialog> {
+  final _reason = TextEditingController();
+  late String _scope;
+  late Set<String> _ids;
+  bool _busy = false;
+  String? _error;
+  @override
+  void initState() {
+    super.initState();
+    _scope = widget.message.spaceId ?? '*';
+    _ids = widget.message.attachments
+        .map((a) => a.id)
+        .where((id) => id.isNotEmpty)
+        .toSet();
+  }
+
+  @override
+  void dispose() {
+    _reason.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_reason.text.trim().isEmpty ||
+        utf8.encode(_reason.text.trim()).length > 2000 ||
+        _ids.isEmpty) {
+      setState(
+        () => _error = 'Select a file and enter a reason (1–2000 characters).',
+      );
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final error = await blockAttachmentsAndDelete(
+      client: widget.client,
+      scope: _scope,
+      channelId: widget.message.channelId,
+      messageId: widget.message.id,
+      attachmentIds: _ids.toList(),
+      reason: _reason.text.trim(),
+      stillActive: widget.stillActive,
+    );
+    if (!mounted) return;
+    if (error == null) {
+      Navigator.pop(context, true);
+      return;
+    }
+    setState(() {
+      _busy = false;
+      _error = error;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('Block files and delete message'),
+    content: SizedBox(
+      width: 460,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Block identical re-uploads before deleting this message. Modified copies may have different hashes.',
+            ),
+            if (widget.isAdmin && widget.message.spaceId != null)
+              DropdownButtonFormField<String>(
+                initialValue: _scope,
+                items: [
+                  DropdownMenuItem(
+                    value: widget.message.spaceId!,
+                    child: const Text('This space'),
+                  ),
+                  const DropdownMenuItem(
+                    value: '*',
+                    child: Text('Entire server, including DMs'),
+                  ),
+                ],
+                onChanged: _busy ? null : (v) => setState(() => _scope = v!),
+              ),
+            for (final file in widget.message.attachments)
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(file.filename),
+                value: _ids.contains(file.id),
+                onChanged: _busy || file.id.isEmpty
+                    ? null
+                    : (v) => setState(() {
+                        if (v == true) {
+                          _ids.add(file.id);
+                        } else {
+                          _ids.remove(file.id);
+                        }
+                      }),
+              ),
+            TextField(
+              controller: _reason,
+              enabled: !_busy,
+              maxLength: 2000,
+              decoration: const InputDecoration(labelText: 'Reason'),
+            ),
+            if (_error != null)
+              Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            if (_busy) const LinearProgressIndicator(),
+          ],
+        ),
+      ),
+    ),
+    actions: [
+      TextButton(
+        onPressed: _busy ? null : () => Navigator.pop(context),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(
+        onPressed: _busy ? null : _submit,
+        child: const Text('Block and delete'),
+      ),
+    ],
+  );
+}

--- a/lib/features/member/utils/permissions.dart
+++ b/lib/features/member/utils/permissions.dart
@@ -105,8 +105,7 @@ Set<String> accordEffectiveChannelPermissions({
   required String currentUserId,
 }) {
   final effective = Set<String>.of(permissions);
-  if (channel == null ||
-      effective.contains(AccordPermission.administrator)) {
+  if (channel == null || effective.contains(AccordPermission.administrator)) {
     return effective;
   }
 
@@ -124,8 +123,7 @@ Set<String> accordEffectiveChannelPermissions({
 
   apply(
     channel.permissionOverwrites.where(
-      (overwrite) =>
-          overwrite.type == 'role' && overwrite.id == everyoneRoleId,
+      (overwrite) => overwrite.type == 'role' && overwrite.id == everyoneRoleId,
     ),
   );
   apply(
@@ -145,9 +143,10 @@ Set<String> accordEffectiveChannelPermissions({
 }
 
 /// Whether [perms] should reveal the space settings affordance: any of
-/// manage-space, manage-roles or view-audit-log. The gate shared by the space
+/// manage-space, manage-roles, view-audit-log or moderate-members. The gate shared by the space
 /// header menu and the channel list's settings gear.
 bool canManageSpaceSettings(Set<String> perms) =>
+    accordHasPermission(perms, AccordPermission.moderateMembers) ||
     accordHasPermission(perms, AccordPermission.manageSpace) ||
     accordHasPermission(perms, AccordPermission.manageRoles) ||
     accordHasPermission(perms, AccordPermission.viewAuditLog);

--- a/lib/features/messaging/controllers/thread_replies.dart
+++ b/lib/features/messaging/controllers/thread_replies.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/shared/utils/list_ext.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
@@ -68,20 +69,24 @@ class ThreadRepliesController extends _$ThreadRepliesController {
   /// Optimistically appends the created message (the gateway echo is then
   /// deduped by [addReply]). Returns true on success.
   Future<bool> send(AccordClient client, String content) async {
+    return await sendDetailed(client, content) == null;
+  }
+
+  Future<SendFailure?> sendDetailed(AccordClient client, String content) async {
     final trimmed = content.trim();
-    if (trimmed.isEmpty) return false;
+    if (trimmed.isEmpty) return const SendFailure('Reply is empty.');
     final result = await client.messages.create(channelId, {
       'content': trimmed,
       'thread_id': rootId,
     });
-    if (!ref.mounted) return false;
+    if (!ref.mounted) return const SendFailure('Thread was closed.');
     final message = result.data;
     if (!result.ok || message is! AccordMessage) {
       debugPrint('Failed to reply in thread $rootId: ${result.error}');
-      return false;
+      return SendFailure.fromResult(result, 'Failed to send reply');
     }
     addReply(message);
-    return true;
+    return null;
   }
 
   /// Deletes reply [messageId] via `messages.delete`, removing it from the

--- a/lib/features/messaging/controllers/thread_replies.g.dart
+++ b/lib/features/messaging/controllers/thread_replies.g.dart
@@ -75,7 +75,7 @@ final class ThreadRepliesControllerProvider
 }
 
 String _$threadRepliesControllerHash() =>
-    r'ec1f5dc2d10f4ba23d76cacca68103ebfa0ac65d';
+    r'eec554f49fe73646b02dd6d32507bc54d2dfddb0';
 
 /// A thread's replies (excluding the root message), keyed by
 /// (channelId, rootId), ordered oldest→newest as the server returns them.

--- a/lib/features/messaging/views/forum_view.dart
+++ b/lib/features/messaging/views/forum_view.dart
@@ -1,4 +1,5 @@
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
 import 'package:bonfire/shared/utils/client_access.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
@@ -110,10 +111,12 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
   }
 
   Future<void> _newPost() async {
+    SendFailure? sendFailure;
     final created = await showDialog<AccordMessage>(
       context: context,
       builder: (dialogContext) => PostComposerDialog(
         title: 'New post',
+        sendFailure: () => sendFailure,
         submitLabel: 'Post',
         bodyLabel: 'Body (optional)',
         initialTitle: '',
@@ -129,7 +132,8 @@ class _ForumChannelViewState extends ConsumerState<ForumChannelView> {
             Navigator.of(dialogContext).pop(message);
             return null;
           }
-          return 'Failed to create post';
+          sendFailure = SendFailure.fromResult(result, 'Failed to create post');
+          return sendFailure!.message;
         },
       ),
     );

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -5,6 +5,8 @@
 /// in the `part` files stays private to this library.
 library;
 
+import 'package:bonfire/features/automod/views/block_attachment_dialog.dart';
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -392,8 +394,7 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
       channel: channel,
       exempt: isSlowmodeExempt(
         channelPermissions: perms,
-        isSpaceOwner:
-            currentUserId != null && space?.ownerId == currentUserId,
+        isSpaceOwner: currentUserId != null && space?.ownerId == currentUserId,
         isInstanceAdmin: ref.watchIsAdmin(),
       ),
     );

--- a/lib/features/messaging/views/message_pane/message_row.dart
+++ b/lib/features/messaging/views/message_pane/message_row.dart
@@ -320,6 +320,28 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
     if (!ok) showInfoSnack(context, 'Failed to delete message');
   }
 
+  Future<void> _blockFiles(AccordMessage message) async {
+    final client = ref.accordClient;
+    if (client == null) return;
+    final removed = await showBlockAttachmentDialog(
+      context,
+      client: client,
+      message: message,
+      isInstanceAdmin: ref.readIsAdmin(),
+      stillActive: () => mounted && identical(ref.accordClient, client),
+    );
+    if (mounted && removed == true && identical(ref.accordClient, client)) {
+      ref
+          .read(
+            accordMessagesControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              widget.channelId,
+            ).notifier,
+          )
+          .removeMessage(message.id);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -382,6 +404,12 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
             pinned: message.pinned,
             onEdit: () => _startEdit(message),
             onDelete: () => _delete(message.id),
+            onBlock:
+                (widget.canManageMessages || ref.readIsAdmin()) &&
+                    message.attachments.isNotEmpty &&
+                    (message.spaceId != null || ref.readIsAdmin())
+                ? () => _blockFiles(message)
+                : null,
             onTogglePin: () => _togglePin(message.id, pinned: message.pinned),
             onReport: () => _report(message),
             onMenuStateChanged: _menuStateChanged,
@@ -586,6 +614,14 @@ class _MessageRowState extends ConsumerState<_MessageRow> {
         // Pin sits between Edit and Delete in this menu; it's site-specific
         // (the thread view has no pinning) so it slots in via [beforeDelete].
         beforeDelete: [
+          if ((widget.canManageMessages || ref.readIsAdmin()) &&
+              message.attachments.isNotEmpty &&
+              (message.spaceId != null || ref.readIsAdmin()))
+            AccordMenuEntry(
+              label: 'Block files and delete',
+              icon: Icons.block,
+              onSelected: () => _blockFiles(message),
+            ),
           if (widget.canManageMessages)
             AccordMenuEntry(
               label: message.pinned ? 'Unpin' : 'Pin',

--- a/lib/features/messaging/views/message_pane/message_row_actions.dart
+++ b/lib/features/messaging/views/message_pane/message_row_actions.dart
@@ -124,6 +124,7 @@ class _HoverActions extends StatelessWidget {
     required this.pinned,
     required this.onEdit,
     required this.onDelete,
+    this.onBlock,
     required this.onTogglePin,
     required this.onReport,
     required this.onMenuStateChanged,
@@ -140,6 +141,7 @@ class _HoverActions extends StatelessWidget {
   final bool pinned;
   final VoidCallback onEdit;
   final VoidCallback onDelete;
+  final VoidCallback? onBlock;
   final VoidCallback onTogglePin;
   final VoidCallback onReport;
 
@@ -177,6 +179,7 @@ class _HoverActions extends StatelessWidget {
               pinned: pinned,
               onEdit: onEdit,
               onDelete: onDelete,
+              onBlock: onBlock,
               onTogglePin: onTogglePin,
               onReport: onReport,
               onMenuStateChanged: onMenuStateChanged,
@@ -196,6 +199,7 @@ class _MessageActions extends StatelessWidget {
     required this.pinned,
     required this.onEdit,
     required this.onDelete,
+    this.onBlock,
     required this.onTogglePin,
     required this.onReport,
     required this.onMenuStateChanged,
@@ -208,6 +212,7 @@ class _MessageActions extends StatelessWidget {
   final bool pinned;
   final VoidCallback onEdit;
   final VoidCallback onDelete;
+  final VoidCallback? onBlock;
   final VoidCallback onTogglePin;
   final VoidCallback onReport;
 
@@ -229,6 +234,8 @@ class _MessageActions extends StatelessWidget {
         switch (value) {
           case 'edit':
             onEdit();
+          case 'block':
+            onBlock?.call();
           case 'delete':
             onDelete();
           case 'pin':
@@ -241,6 +248,11 @@ class _MessageActions extends StatelessWidget {
         if (canPin)
           PopupMenuItem(value: 'pin', child: Text(pinned ? 'Unpin' : 'Pin')),
         if (canEdit) const PopupMenuItem(value: 'edit', child: Text('Edit')),
+        if (onBlock != null)
+          const PopupMenuItem(
+            value: 'block',
+            child: Text('Block files and delete'),
+          ),
         if (canDelete)
           const PopupMenuItem(value: 'delete', child: Text('Delete')),
         if (canReport)

--- a/lib/features/messaging/views/post_composer_dialog.dart
+++ b/lib/features/messaging/views/post_composer_dialog.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/messaging/utils/emoticons.dart';
@@ -9,8 +11,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// Performs a post composer's submit with the trimmed [title]/[body]. Returns
 /// the error text to display in the dialog, or null on success — in which case
 /// the callback is responsible for popping the dialog with its result.
-typedef PostComposerSubmit = Future<String?> Function(
-    AccordClient client, String title, String body);
+typedef PostComposerSubmit =
+    Future<String?> Function(AccordClient client, String title, String body);
 
 /// The shared title+body composer dialog behind the forum's "New post" and the
 /// thread view's post/reply editor. [title] is the dialog heading;
@@ -29,12 +31,16 @@ class PostComposerDialog extends ConsumerStatefulWidget {
     this.initialTitle,
     this.initialBody = '',
     this.autofocusTitle = false,
+    this.sendFailure,
+    this.now = DateTime.now,
   });
 
   final String title;
   final String submitLabel;
   final String bodyLabel;
   final PostComposerSubmit onSubmit;
+  final SendFailure? Function()? sendFailure;
+  final DateTime Function() now;
 
   /// Initial text for the title field, or null to omit the field (and its
   /// required-validation) entirely.
@@ -43,28 +49,34 @@ class PostComposerDialog extends ConsumerStatefulWidget {
   final bool autofocusTitle;
 
   @override
-  ConsumerState<PostComposerDialog> createState() =>
-      _PostComposerDialogState();
+  ConsumerState<PostComposerDialog> createState() => _PostComposerDialogState();
 }
 
 class _PostComposerDialogState extends ConsumerState<PostComposerDialog> {
-  late final TextEditingController _title =
-      TextEditingController(text: widget.initialTitle ?? '');
-  late final TextEditingController _body =
-      TextEditingController(text: widget.initialBody);
+  late final TextEditingController _title = TextEditingController(
+    text: widget.initialTitle ?? '',
+  );
+  late final TextEditingController _body = TextEditingController(
+    text: widget.initialBody,
+  );
   bool _busy = false;
   String? _error;
+  SendCooldown? _cooldown;
+  Timer? _timer;
+  bool get _waiting => _cooldown?.isActive(widget.now()) ?? false;
 
   bool get _hasTitleField => widget.initialTitle != null;
 
   @override
   void dispose() {
+    _timer?.cancel();
     _title.dispose();
     _body.dispose();
     super.dispose();
   }
 
   Future<void> _submit() async {
+    if (_busy || _waiting) return;
     final title = _title.text.trim();
     final rawBody = _body.text.trim();
     // Bodies convert emoticons like every other send path. Titles deliberately
@@ -77,8 +89,11 @@ class _PostComposerDialogState extends ConsumerState<PostComposerDialog> {
       setState(() => _error = 'Title is required');
       return;
     }
-    final client = ref.read(accordAuthProvider
-        .select((s) => s is AccordAuthLoggedIn ? s.client : null));
+    final client = ref.read(
+      accordAuthProvider.select(
+        (s) => s is AccordAuthLoggedIn ? s.client : null,
+      ),
+    );
     if (client == null) return;
     setState(() {
       _busy = true;
@@ -90,7 +105,22 @@ class _PostComposerDialogState extends ConsumerState<PostComposerDialog> {
     setState(() {
       _busy = false;
       _error = error;
+      final failure = widget.sendFailure?.call();
+      if (failure != null) {
+        _cooldown = cooldownFromFailure(
+          failure: failure,
+          slowmodeSeconds: 0,
+          now: widget.now(),
+        );
+      }
     });
+    _timer?.cancel();
+    if (_cooldown != null) {
+      _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+        if (!mounted || !_waiting) timer.cancel();
+        if (mounted) setState(() {});
+      });
+    }
   }
 
   @override
@@ -134,22 +164,27 @@ class _PostComposerDialogState extends ConsumerState<PostComposerDialog> {
               ),
               if (_error != null) ...[
                 const SizedBox(height: 12),
-                Text(_error!,
-                    style: theme.textTheme.bodySmall!
-                        .copyWith(color: theme.colorScheme.error)),
+                Text(
+                  _error!,
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
               ],
+              if (_waiting) Text(sendCooldownLabel(_cooldown!, widget.now())),
               const SizedBox(height: 20),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   TextButton(
-                    onPressed:
-                        _busy ? null : () => Navigator.of(context).maybePop(),
+                    onPressed: _busy
+                        ? null
+                        : () => Navigator.of(context).maybePop(),
                     child: const Text('Cancel'),
                   ),
                   const SizedBox(width: 8),
                   FilledButton(
-                    onPressed: _busy ? null : _submit,
+                    onPressed: _busy || _waiting ? null : _submit,
                     child: Text(widget.submitLabel),
                   ),
                 ],

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/messaging/utils/emoticons.dart';
@@ -123,10 +125,14 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
   final FocusNode _inputFocus = FocusNode();
   late AccordMessage _root = widget.root;
   bool _sending = false;
+  SendCooldown? _cooldown;
+  Timer? _cooldownTimer;
+  bool get _waiting => _cooldown?.isActive(DateTime.now()) ?? false;
   bool _closedForHiddenRoot = false;
 
   @override
   void dispose() {
+    _cooldownTimer?.cancel();
     _input.dispose();
     _inputFocus.dispose();
     super.dispose();
@@ -144,7 +150,7 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
         ref.read(settingsControllerProvider.select((s) => s.convertEmoticons))
         ? applyEmoticons(raw)
         : raw;
-    if (text.isEmpty || _sending) return;
+    if (text.isEmpty || _sending || _waiting) return;
     final client = _client;
     if (client == null) return;
     // Clear up front rather than after the round-trip. The field is never
@@ -153,7 +159,7 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     // comes back if the send fails.
     _input.clear();
     setState(() => _sending = true);
-    final ok = await ref
+    final failure = await ref
         .read(
           threadRepliesControllerProvider(
             ref.readActiveServerKey() ?? '',
@@ -161,13 +167,26 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
             widget.root.id,
           ).notifier,
         )
-        .send(client, text);
+        .sendDetailed(client, text);
     if (!mounted) return;
     setState(() => _sending = false);
-    if (!ok) {
+    if (!identical(_client, client)) return;
+    if (failure != null) {
+      _cooldown = cooldownFromFailure(
+        failure: failure,
+        slowmodeSeconds: 0,
+        now: DateTime.now(),
+      );
+      _cooldownTimer?.cancel();
+      if (_cooldown != null) {
+        _cooldownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+          if (!mounted || !_waiting) timer.cancel();
+          if (mounted) setState(() {});
+        });
+      }
       // Hand the reply back so it can be retried instead of retyped.
       restoreFailedSend(_input, text);
-      showInfoSnack(context, 'Failed to send reply');
+      showInfoSnack(context, failure.message);
     }
   }
 
@@ -463,8 +482,13 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
                   },
                 ),
               ),
+              if (_waiting)
+                Text(formatCooldown(_cooldown!.remaining(DateTime.now()))),
               IconButton(
-                onPressed: _sending ? null : _send,
+                tooltip: _waiting
+                    ? sendCooldownLabel(_cooldown!, DateTime.now())
+                    : 'Send reply',
+                onPressed: _sending || _waiting ? null : _send,
                 icon: Icon(Icons.send, size: 20, color: colors.dirtyWhite),
               ),
             ],

--- a/lib/features/spaces/views/accord_space_settings.dart
+++ b/lib/features/spaces/views/accord_space_settings.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/features/automod/views/automod_panel.dart';
 import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/shared/components/async_state_views.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
@@ -309,7 +310,12 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     final client = _client;
     final currentUserId = ref.readUserId();
     if (client == null || currentUserId == null) return;
-    final members = ref.read(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId));
+    final members = ref.read(
+      accordMembersControllerProvider(
+        ref.readActiveServerKey() ?? '',
+        widget.spaceId,
+      ),
+    );
     final me = members?[currentUserId];
     final initial = me?.nickname ?? '';
     final next = (await showTextPromptDialog(
@@ -337,7 +343,12 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     final updated = result.data;
     if (updated is AccordMember) {
       ref
-          .read(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId).notifier)
+          .read(
+            accordMembersControllerProvider(
+              ref.readActiveServerKey() ?? '',
+              widget.spaceId,
+            ).notifier,
+          )
           .upsertMember(updated);
     }
   }
@@ -390,7 +401,12 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
     // Text channels usable as rules/system targets. Reconcile the drafted ids
     // against the live list so a stale id falls back to "None".
     final textChannels =
-        (ref.watch(accordChannelsControllerProvider(ref.readActiveServerKey() ?? '', widget.spaceId)) ??
+        (ref.watch(
+                  accordChannelsControllerProvider(
+                    ref.readActiveServerKey() ?? '',
+                    widget.spaceId,
+                  ),
+                ) ??
                 const <AccordChannel>[])
             .where((c) => c.type == 'text')
             .toList();
@@ -466,6 +482,14 @@ class _SpaceSettingsState extends ConsumerState<_SpaceSettings> {
         ],
         actions: [
           _MembershipSection(onEditNickname: _editOwnNickname),
+          if (accordHasPermission(perms, AccordPermission.manageSpace) ||
+              accordHasPermission(perms, AccordPermission.moderateMembers))
+            ListTile(
+              leading: const Icon(Icons.shield_outlined),
+              title: const Text('AutoMod'),
+              subtitle: const Text('Attachment rules and moderation review'),
+              onTap: () => showAutomodPanel(context, widget.spaceId),
+            ),
           if (canManageRoles ||
               canViewAuditLog ||
               canModerate ||

--- a/packages/accordkit/lib/src/models/attachment.dart
+++ b/packages/accordkit/lib/src/models/attachment.dart
@@ -7,6 +7,7 @@ class AccordAttachment {
   String? description;
   String? contentType;
   int size;
+  String? contentHash;
   String url;
   Object? width;
   Object? height;
@@ -17,6 +18,7 @@ class AccordAttachment {
     this.description,
     this.contentType,
     this.size = 0,
+    this.contentHash,
     this.url = '',
     this.width,
     this.height,
@@ -29,6 +31,7 @@ class AccordAttachment {
       description: d['description'] as String?,
       contentType: d['content_type'] as String?,
       size: asInt(d['size']),
+      contentHash: asStringOrNull(d['content_hash']),
       url: asString(d['url']),
       width: d['width'],
       height: d['height'],
@@ -42,6 +45,7 @@ class AccordAttachment {
       'size': size,
       'url': url,
     };
+    if (contentHash != null) d['content_hash'] = contentHash;
     if (description != null) d['description'] = description;
     if (contentType != null) d['content_type'] = contentType;
     if (width != null) d['width'] = width;

--- a/packages/accordkit/lib/src/rest/accord_rest.dart
+++ b/packages/accordkit/lib/src/rest/accord_rest.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
@@ -128,6 +129,7 @@ class AccordRest {
   Future<RestResult> makeRawRequest(
     String path, {
     Map<String, dynamic> query = const {},
+    int? maxBytes,
   }) async {
     final uri = _buildUri(path, query);
     final headers = <String, String>{
@@ -138,7 +140,22 @@ class AccordRest {
     }
 
     return _executeWithRetry(
-      send: () => _client.get(uri, headers: headers),
+      send: () async {
+        if (maxBytes == null) return _client.get(uri, headers: headers);
+        final request = http.Request('GET', uri)
+          ..headers.addAll(headers)
+          ..followRedirects = false;
+        final streamed = await _client.send(request);
+        final bytes = BytesBuilder(copy: false);
+        await for (final chunk in streamed.stream) {
+          if (bytes.length + chunk.length > maxBytes) {
+            throw StateError('Private evidence exceeds the download limit');
+          }
+          bytes.add(chunk);
+        }
+        return http.Response.bytes(bytes.takeBytes(), streamed.statusCode,
+            headers: streamed.headers);
+      },
       interpret: (response) {
         if (response.statusCode >= 200 && response.statusCode < 300) {
           return RestResult.success(response.statusCode, response.bodyBytes);

--- a/packages/accordkit/lib/src/rest/endpoints/automod_api.dart
+++ b/packages/accordkit/lib/src/rest/endpoints/automod_api.dart
@@ -2,11 +2,7 @@ import '../../models/automod_upload.dart';
 import '../endpoint_base.dart';
 import '../rest_result.dart';
 
-/// AutoMod attachment moderation: the uploader-facing status lookup.
-///
-/// The moderator queue, review, content download, policy and hash-denylist
-/// routes are deliberately not wrapped here — an ordinary sender must never
-/// call them, and the client's moderation UI is separate work.
+/// AutoMod APIs. Moderator/configuration methods require server authorization.
 class AutomodApi extends EndpointBase {
   AutomodApi(super.rest);
 
@@ -20,4 +16,44 @@ class AutomodApi extends EndpointBase {
     );
     return result.deserialize(AccordAutomodUpload.fromJson);
   }
+
+  String _scope(String scope) => '/automod/${Uri.encodeComponent(scope)}';
+  Future<RestResult> getPolicy(String scope) =>
+      rest.makeRequest('GET', '${_scope(scope)}/policy');
+  Future<RestResult> setPolicy(String scope, Map<String, dynamic> policy) =>
+      rest.makeRequest('PUT', '${_scope(scope)}/policy',
+          body: policy, retryOnRateLimit: false);
+  Future<RestResult> resetPolicy(String scope) =>
+      rest.makeRequest('DELETE', '${_scope(scope)}/policy',
+          retryOnRateLimit: false);
+  Future<RestResult> health() => rest.makeRequest('GET', '/automod/health');
+  Future<RestResult> listUploads(String scope,
+          {String? status, String? before}) =>
+      rest.makeRequest('GET', '${_scope(scope)}/uploads', query: {
+        if (status != null) 'status': status,
+        if (before != null) 'before': before,
+      });
+  Future<RestResult> review(String id, String action, String reason) =>
+      rest.makeRequest('PATCH', '/automod/uploads/${Uri.encodeComponent(id)}',
+          body: {'action': action, 'reason': reason}, retryOnRateLimit: false);
+  Future<RestResult> getContent(String id) =>
+      rest.makeRawRequest('/automod/uploads/${Uri.encodeComponent(id)}/content',
+          maxBytes: 64 * 1024 * 1024);
+  Future<RestResult> blockAttachment(String scope, String id, String reason) =>
+      rest.makeRequest('POST',
+          '${_scope(scope)}/attachments/${Uri.encodeComponent(id)}/block',
+          body: {'reason': reason}, retryOnRateLimit: false);
+  Future<RestResult> listHashes(String scope, {String? before}) =>
+      rest.makeRequest('GET', '${_scope(scope)}/hashes',
+          query: {if (before != null) 'before': before});
+  Future<RestResult> blockHash(String scope, String hash, String reason) =>
+      rest.makeRequest(
+          'PUT', '${_scope(scope)}/hashes/${Uri.encodeComponent(hash)}',
+          body: {'reason': reason}, retryOnRateLimit: false);
+  Future<RestResult> unblockHash(String scope, String hash) => rest.makeRequest(
+      'DELETE', '${_scope(scope)}/hashes/${Uri.encodeComponent(hash)}',
+      retryOnRateLimit: false);
+  Future<RestResult> events(String scope, {String? before}) =>
+      rest.makeRequest('GET', '${_scope(scope)}/events',
+          query: {if (before != null) 'before': before});
 }

--- a/packages/accordkit/test/automod_management_test.dart
+++ b/packages/accordkit/test/automod_management_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+import 'package:accordkit/accordkit.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'support/test_helpers.dart';
+
+void main() {
+  test('management routes encode IDs, scope, filters and audit reasons',
+      () async {
+    final log = <CapturedRequest>[];
+    final api =
+        AutomodApi(mockRest(log: log, responder: (_) => jsonData(null)));
+    await api.setPolicy('*', {'enabled': true, 'rules': []});
+    await api.listUploads('space', status: 'rejected', before: '123');
+    await api.review('upload/id', 'release', 'Reviewed');
+    await api.blockAttachment('space', 'file', 'Repeated upload');
+    await api.blockHash('space', 'abcd', 'Blocked');
+    await api.unblockHash('space', 'abcd');
+    await api.resetPolicy('space');
+    expect(log[0].method, 'PUT');
+    expect(log[0].jsonBody, {'enabled': true, 'rules': []});
+    expect(log[1].url.queryParameters, {'status': 'rejected', 'before': '123'});
+    expect(log[2].url.pathSegments.last, 'upload/id');
+    expect(log[2].jsonBody, {'action': 'release', 'reason': 'Reviewed'});
+    expect(log[3].url.path, '/api/v1/automod/space/attachments/file/block');
+    expect(log[4].method, 'PUT');
+    expect(log[5].method, 'DELETE');
+    expect(log[6].url.path, '/api/v1/automod/space/policy');
+  });
+  test('moderator mutations do not silently retry 429', () async {
+    final log = <CapturedRequest>[];
+    final api = AutomodApi(mockRest(
+        log: log,
+        responder: (_) => jsonError('rate_limited', 'Wait', status: 429)));
+    expect((await api.review('u', 'reject', 'Reason')).statusCode, 429);
+    expect(log, hasLength(1));
+  });
+  test('private content uses authenticated binary API and bounds buffering',
+      () async {
+    final log = <CapturedRequest>[];
+    final rest = mockRest(
+        log: log, responder: (_) => http.Response.bytes([0, 255, 1], 200));
+    final result = await AutomodApi(rest).getContent('u');
+    expect(result.data, isA<Uint8List>());
+    expect(result.data, [0, 255, 1]);
+    expect(log.single.url.path, '/api/v1/automod/uploads/u/content');
+    expect(log.single.headers['authorization'], 'Bot test-token');
+    final limited = await rest.makeRawRequest('/private', maxBytes: 2);
+    expect(limited.ok, isFalse);
+    expect(limited.error?.message, contains('download limit'));
+  });
+  test('expired evidence remains an error without public fallback', () async {
+    final log = <CapturedRequest>[];
+    final api = AutomodApi(
+        mockRest(log: log, responder: (_) => http.Response('', 410)));
+    expect((await api.getContent('expired')).statusCode, 410);
+    expect(log, hasLength(1));
+  });
+  test('attachment digest remains optional for older servers', () {
+    final legacy = AccordAttachment.fromJson({'id': 'a', 'filename': 'x'});
+    expect(legacy.contentHash, isNull);
+    expect(legacy.toJson().containsKey('content_hash'), isFalse);
+    final current =
+        AccordAttachment.fromJson({'id': 'a', 'content_hash': 'hash'});
+    expect(current.toJson()['content_hash'], 'hash');
+  });
+  test('private evidence disables redirect following', () async {
+    var attempts = 0;
+    final rest = AccordRest('https://example.test/api/v1', token: 'secret',
+        client: MockClient.streaming((request, stream) async {
+      attempts++;
+      expect(request.followRedirects, isFalse);
+      return http.StreamedResponse(Stream.value(<int>[]), 302,
+          headers: {'location': 'https://elsewhere.test/file'});
+    }));
+    expect((await AutomodApi(rest).getContent('u')).ok, isFalse);
+    expect(attempts, 1);
+  });
+}

--- a/test/features/automod/automod_test.dart
+++ b/test/features/automod/automod_test.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/automod/utils/automod_policy.dart';
+import 'package:bonfire/features/automod/views/automod_panel.dart';
+import 'package:bonfire/features/automod/views/block_attachment_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+AccordClient clientWith(Future<http.Response> Function(http.Request) respond) {
+  final client = AccordClient(
+    baseUrl: 'https://example.test',
+    gatewayUrl: 'wss://example.test/ws',
+    cdnUrl: 'https://example.test/cdn',
+    token: 'private-token',
+    httpClient: MockClient(respond),
+  );
+  addTearDown(client.dispose);
+  return client;
+}
+
+http.Response data(Object? value) =>
+    http.Response(jsonEncode({'data': value}), 200);
+Future<String?> block(
+  AccordClient client, {
+  List<String> ids = const ['a', 'b'],
+  bool Function()? active,
+}) => blockAttachmentsAndDelete(
+  client: client,
+  scope: 's',
+  channelId: 'c',
+  messageId: 'm',
+  attachmentIds: ids,
+  reason: 'Repeated prohibited upload',
+  stillActive: active,
+);
+Map<String, dynamic> policy() => {
+  'enabled': false,
+  'retention_days': 7,
+  'exempt_roles': [],
+  'exempt_permissions': [],
+  'rules': [],
+};
+
+void main() {
+  test('blocks all selected attachments before deleting', () async {
+    final calls = <String>[];
+    final client = clientWith((r) async {
+      calls.add('${r.method} ${r.url.path}');
+      return data(null);
+    });
+    expect(await block(client), isNull);
+    expect(calls, [
+      'POST /api/v1/automod/s/attachments/a/block',
+      'POST /api/v1/automod/s/attachments/b/block',
+      'DELETE /api/v1/channels/c/messages/m',
+    ]);
+  });
+  test(
+    'a failed second block retains message and reports first block',
+    () async {
+      final calls = <String>[];
+      final client = clientWith((r) async {
+        calls.add(r.method);
+        return calls.length == 2
+            ? http.Response('{"error":{"message":"Forbidden"}}', 403)
+            : data(null);
+      });
+      expect(
+        await block(client),
+        contains('1 file(s) are blocked. The message was kept.'),
+      );
+      expect(calls, ['POST', 'POST']);
+    },
+  );
+  test('failed deletion leaves successful blocks intact', () async {
+    final calls = <String>[];
+    final client = clientWith((r) async {
+      calls.add(r.method);
+      return r.method == 'DELETE' ? http.Response('{}', 500) : data(null);
+    });
+    expect(
+      await block(client),
+      contains('Files are blocked, but the message could not be deleted'),
+    );
+    expect(calls, ['POST', 'POST', 'DELETE']);
+  });
+  test('account change and empty selection prevent deletion', () async {
+    final calls = <String>[];
+    final client = clientWith((r) async {
+      calls.add(r.method);
+      return data(null);
+    });
+    expect(await block(client, ids: []), contains('Select'));
+    expect(
+      await block(client, active: () => calls.isEmpty),
+      contains('Account changed'),
+    );
+    expect(calls, ['POST']);
+  });
+  test('malformed and unsupported rules are rejected without crashing', () {
+    expect(validateAutomodPolicy(policy()), isNull);
+    expect(
+      validateAutomodPolicy({
+        ...policy(),
+        'rules': [null],
+      }),
+      isNotNull,
+    );
+    expect(
+      validateAutomodPolicy({
+        ...policy(),
+        'rules': [
+          {'id': 'x'},
+        ],
+      }),
+      isNotNull,
+    );
+    expect(
+      validateAutomodPolicy({
+        ...policy(),
+        'rules': [
+          {
+            'id': 'x',
+            'scope': {'type': 'all'},
+            'trigger': {
+              'type': 'media',
+              'threshold': 0.8,
+              'categories': ['ANUS_EXPOSED'],
+            },
+            'action': {'type': 'timeout', 'seconds': 30},
+          },
+        ],
+      }),
+      contains('Timeouts require'),
+    );
+  });
+  testWidgets('review-only permission never fetches or shows configuration', (
+    tester,
+  ) async {
+    final paths = <String>[];
+    final client = clientWith((r) async {
+      paths.add(r.url.path);
+      return data([]);
+    });
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AutomodWorkbench(
+            client: client,
+            scope: 's',
+            canConfigure: false,
+            canReview: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Rules'), findsNothing);
+    expect(find.text('Blocked files'), findsNothing);
+    expect(paths, ['/api/v1/automod/s/uploads', '/api/v1/automod/s/events']);
+  });
+  testWidgets('configuration-only permission never fetches evidence or queue', (
+    tester,
+  ) async {
+    final paths = <String>[];
+    final client = clientWith((r) async {
+      paths.add(r.url.path);
+      return data(
+        r.url.path.endsWith('/policy')
+            ? {'policy': policy(), 'inherited': true}
+            : [],
+      );
+    });
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AutomodWorkbench(
+            client: client,
+            scope: 's',
+            canConfigure: true,
+            canReview: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Rules'), findsOneWidget);
+    expect(find.text('Review'), findsNothing);
+    expect(find.textContaining('Using the server policy'), findsOneWidget);
+    expect(paths, ['/api/v1/automod/s/policy', '/api/v1/automod/s/hashes']);
+  });
+  testWidgets(
+    'older server displays actionable error instead of editable defaults',
+    (tester) async {
+      final client = clientWith((_) async => http.Response('{}', 404));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AutomodWorkbench(
+              client: client,
+              scope: 's',
+              canConfigure: true,
+              canReview: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Update the server.'), findsOneWidget);
+      expect(find.text('Enable automatic scanning'), findsNothing);
+    },
+  );
+  testWidgets(
+    'private evidence closes when the account workbench is disposed',
+    (tester) async {
+      final client = clientWith((r) async {
+        if (r.url.path.endsWith('/content')) {
+          return http.Response.bytes([1, 2, 3], 200);
+        }
+        return data(
+          r.url.path.endsWith('/uploads')
+              ? [
+                  {
+                    'id': 'u',
+                    'filename': 'private.mp4',
+                    'content_type': 'video/mp4',
+                    'status': 'quarantined',
+                    'author_id': 'a',
+                  },
+                ]
+              : [],
+        );
+      });
+      var active = true;
+      late StateSetter update;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              update = setState;
+              return Scaffold(
+                body: active
+                    ? AutomodWorkbench(
+                        client: client,
+                        scope: 's',
+                        canConfigure: false,
+                        canReview: true,
+                      )
+                    : const Text('New account'),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('View evidence'));
+      await tester.pumpAndSettle();
+      expect(find.text('Download original'), findsOneWidget);
+      update(() => active = false);
+      await tester.pumpAndSettle();
+      expect(find.text('Download original'), findsNothing);
+      expect(find.text('New account'), findsOneWidget);
+    },
+  );
+}

--- a/test/features/automod/send_failure_test.dart
+++ b/test/features/automod/send_failure_test.dart
@@ -1,0 +1,124 @@
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/messaging/controllers/thread_replies.dart';
+import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
+import 'package:bonfire/features/messaging/views/post_composer_dialog.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+class QuietSettings extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings(convertEmoticons: false);
+}
+
+void main() {
+  test('thread reply preserves retry duration and makes one attempt', () async {
+    var attempts = 0;
+    final client = AccordClient(
+      baseUrl: 'https://example.test',
+      gatewayUrl: 'wss://example.test/ws',
+      cdnUrl: 'https://example.test/cdn',
+      httpClient: MockClient((_) async {
+        attempts++;
+        return http.Response(
+          '{"error":{"code":"rate_limited","message":"Wait","retry_after":12}}',
+          429,
+        );
+      }),
+    );
+    addTearDown(client.dispose);
+    final container = ProviderContainer(
+      overrides: [
+        accordAuthProvider.overrideWithValue(const AccordAuthLoggedOut()),
+      ],
+    );
+    addTearDown(container.dispose);
+    final failure = await container
+        .read(threadRepliesControllerProvider('', 'c', 'root').notifier)
+        .sendDetailed(client, 'reply');
+    expect(failure?.rateLimited, isTrue);
+    expect(failure?.retryAfter, const Duration(seconds: 12));
+    expect(attempts, 1);
+  });
+  testWidgets(
+    'post preserves draft and blocks repeat submit until retry expires',
+    (tester) async {
+      final client = AccordClient(
+        baseUrl: 'https://example.test',
+        gatewayUrl: 'wss://example.test/ws',
+        cdnUrl: 'https://example.test/cdn',
+      );
+      addTearDown(client.dispose);
+      var attempts = 0;
+      var now = DateTime.utc(2026);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingsControllerProvider.overrideWith(QuietSettings.new),
+            accordAuthProvider.overrideWithValue(
+              AccordAuthLoggedIn(
+                client: client,
+                session: AccordSession(
+                  server: AccordServer.fromBaseUrl('https://example.test'),
+                  token: 't',
+                  userId: 'u',
+                  username: 'user',
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: PostComposerDialog(
+                title: 'New post',
+                now: () => now,
+                submitLabel: 'Post',
+                bodyLabel: 'Body',
+                initialTitle: 'My post',
+                initialBody: 'Keep this draft',
+                onSubmit: (_, _, _) async {
+                  attempts++;
+                  return 'Wait';
+                },
+                sendFailure: () => const SendFailure(
+                  'Wait',
+                  retryAfter: Duration(seconds: 3),
+                  rateLimited: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Post'));
+      await tester.pump();
+      expect(attempts, 1);
+      expect(find.text('Keep this draft'), findsOneWidget);
+      expect(find.textContaining('try again in 3s'), findsOneWidget);
+      expect(
+        tester
+            .widget<FilledButton>(find.widgetWithText(FilledButton, 'Post'))
+            .onPressed,
+        isNull,
+      );
+      now = now.add(const Duration(seconds: 4));
+      await tester.pump(const Duration(seconds: 4));
+      expect(
+        tester
+            .widget<FilledButton>(find.widgetWithText(FilledButton, 'Post'))
+            .onPressed,
+        isNotNull,
+      );
+      expect(attempts, 1);
+      await tester.pumpWidget(const SizedBox());
+    },
+  );
+}


### PR DESCRIPTION
Completes the client moderation controls for the merged server AutoMod API. Instance admins and space managers can configure ordered rules, explicit detector thresholds, exemptions, retention, and complete space overrides; space reviewers get the review queue without configuration access. Held media stays private, review decisions require reasons, and health/status displays explain operator setup and five-frame video sampling.

Message managers can block selected attachments before deleting a message. Partial failure preserves the message when blocking fails and preserves successful blocks when deletion fails. Configurators can manage known digests and inspect audit activity. Evidence downloads authenticate through the SDK, reject redirects, bound buffering, and close/evict previews on account changes. Optional fields and missing endpoints remain compatible with older servers.

Also preserves structured retry deadlines for thread replies and forum posts, keeping drafts and disabling repeat sends until the server's cooldown expires.

Validation:
- Full Flutter suite: 1,342 tests passed; `flutter analyze` clean.
- Full accordkit suite: 209 tests passed; `dart analyze` clean. Additional redirect regression and focused moderation suite passed (6 SDK / 11 Flutter tests).
- Code generation completed and generated changes checked in.
- Tests cover permission-specific requests, older servers, account/evidence disposal, block/delete partial failure, authenticated bounded downloads, no automatic mutation retry, and draft/cooldown behavior.

Builds on merged #335 and #337. Closes #322.
