### PR TITLE
fix(mcp): acknowledge HTTP notifications without a JSON-RPC body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Cross-cutting startup features wired in `lib/main.dart`:
 - **Server config:** `lib/features/server/models/accord_server.dart` defines `AccordServer` (`baseUrl`/`gatewayUrl`/`cdnUrl`, derived from a base URL). The live per-server `AccordClient` instances are owned by `AccordAuth` (`lib/features/authentication/repositories/accord_auth.dart`, exposed as `accordAuthProvider`); `lib/features/server/controllers/connections.dart` holds the rail's per-connection UI state (session + status + cached spaces), not the clients.
 - **Multi-profile:** the app is wrapped in `AppRestart` for switching between accounts, and `ProfileGate` (the PIN lock) is hosted from the router app's `MaterialApp.builder` via `buildAppShell` (`lib/shared/components/app_shell.dart`) together with the incoming-call banner. Do not wrap `MainWindow` in another `MaterialApp`/Navigator: go_router's navigator must stay the root navigator (#324).
 - **Deep links:** `daccord://` URLs (navigate / connect / invite) are parsed via `ServerUri.parseDeepLink()`. Qualified navigation is held by `pendingDeepLinkProvider` until authentication and the owning connection's live space cache are ready; the `/spaces` route then hands channel/message targeting to `AccordHomeScreen`.
-- **Developer mode:** an MCP server (`mcpServerControllerProvider`) for in-app tooling.
+- **Developer mode:** an MCP server (`mcpServerControllerProvider`) for in-app tooling. HTTP notifications are acknowledged with status 202 and an empty body; see `docs/troubleshooting/common-issues.md` for the local connection settings.
 
 ## Domain mapping: Discord → Accord
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This client is the front door: one native app for every screen you own.
 - 🔐 **Secure sign-in** — session tokens live in the OS credential vault, with optional TOTP two-factor authentication.
 - ⬆️ **In-app updates** — desktop and sideloaded Android builds check for, download, and install new releases themselves.
 - 📱 **Responsive everywhere** — one UI that flows from phone to desktop, sharp at every size.
+- 🛠️ **Local MCP tools** — opt-in desktop automation with bearer authentication and configurable tool groups. See [local MCP troubleshooting](docs/troubleshooting/common-issues.md#local-mcp-tools-not-connecting).
 
 ---
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -22,6 +22,13 @@ daccord automatically attempts to reconnect when the connection drops. If you se
 - Check your internet connection.
 - If the problem persists, close and reopen daccord to establish a fresh session.
 
+## Local MCP Tools Not Connecting
+
+- Enable **Developer mode** in App Settings, then open **Developer** and enable the **Client MCP server**. The default endpoint is `http://127.0.0.1:39101/mcp`.
+- Configure your MCP client with the bearer token from that page. It is separate from any remote Accord server API key.
+- Keep Daccord running and enable the tool groups you need; Read and Navigate are enabled by default.
+- A failure at `notifications/initialized` can indicate an older build returning an invalid response. HTTP notifications must receive status 202 with an empty body. Regression coverage: `flutter test test/features/developer/mcp_server_io_test.dart`.
+
 ## No Sound in Voice Channels
 
 - Check that your microphone and speakers are selected in **App Settings > Voice & Video**.

--- a/lib/features/developer/services/mcp_server_io.dart
+++ b/lib/features/developer/services/mcp_server_io.dart
@@ -134,11 +134,16 @@ class McpServer {
 
     // Streamable HTTP acknowledges notifications without a JSON-RPC response.
     // Returning `{}` here makes strict clients reject the initialized handshake.
+    // `id == null` (rather than a containsKey check) also covers clients that
+    // send an explicit `"id": null` on a notification, matching the leniency
+    // `_dispatch` already applies to `notifications/initialized` below.
     if (parsed['jsonrpc'] == '2.0' &&
         parsed['method'] is String &&
         (parsed['method'] as String).isNotEmpty &&
-        !parsed.containsKey('id')) {
-      request.response.statusCode = HttpStatus.accepted;
+        parsed['id'] == null) {
+      request.response
+        ..statusCode = HttpStatus.accepted
+        ..headers.set(HttpHeaders.connectionHeader, 'close');
       await request.response.close();
       return;
     }

--- a/lib/features/developer/services/mcp_server_io.dart
+++ b/lib/features/developer/services/mcp_server_io.dart
@@ -132,6 +132,17 @@ class McpServer {
       return;
     }
 
+    // Streamable HTTP acknowledges notifications without a JSON-RPC response.
+    // Returning `{}` here makes strict clients reject the initialized handshake.
+    if (parsed['jsonrpc'] == '2.0' &&
+        parsed['method'] is String &&
+        (parsed['method'] as String).isNotEmpty &&
+        !parsed.containsKey('id')) {
+      request.response.statusCode = HttpStatus.accepted;
+      await request.response.close();
+      return;
+    }
+
     final result = await _dispatch(Map<String, dynamic>.from(parsed));
     _send(request, 200, result);
   }

--- a/test/features/developer/mcp_server_io_test.dart
+++ b/test/features/developer/mcp_server_io_test.dart
@@ -60,6 +60,61 @@ void main() {
       HttpStatus.ok,
     );
   });
+
+  test(
+    'handshake notifications have no body and tool discovery still works',
+    () async {
+      token = ''.padLeft(64, 'd');
+      expect(await server.start(0), isTrue);
+      final client = HttpClient();
+      try {
+        Future<(int, String)> post(Map<String, dynamic> message) async {
+          final request = await client.postUrl(
+            Uri.parse('http://127.0.0.1:${server.port}/mcp'),
+          );
+          request.headers.contentType = ContentType.json;
+          request.headers.set(HttpHeaders.authorizationHeader, 'Bearer $token');
+          request.write(jsonEncode(message));
+          final response = await request.close();
+          return (
+            response.statusCode,
+            await utf8.decoder.bind(response).join(),
+          );
+        }
+
+        final initialized = await post({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'method': 'initialize',
+        });
+        expect(initialized.$1, HttpStatus.ok);
+        expect(
+          jsonDecode(initialized.$2)['result']['serverInfo']['name'],
+          'daccord',
+        );
+
+        for (final method in [
+          'notifications/initialized',
+          'notifications/cancelled',
+        ]) {
+          final notification = await post({'jsonrpc': '2.0', 'method': method});
+          expect(notification, (HttpStatus.accepted, ''));
+        }
+
+        final listed = await post({
+          'jsonrpc': '2.0',
+          'id': 2,
+          'method': 'tools/list',
+        });
+        expect(listed.$1, HttpStatus.ok);
+        final body = jsonDecode(listed.$2);
+        expect(body['id'], 2);
+        expect(body['result']['tools'], isNotEmpty);
+      } finally {
+        client.close(force: true);
+      }
+    },
+  );
 }
 
 Future<int> _postInitialize(int port, {String? bearerToken}) async {

--- a/test/features/developer/mcp_server_io_test.dart
+++ b/test/features/developer/mcp_server_io_test.dart
@@ -115,6 +115,34 @@ void main() {
       }
     },
   );
+
+  test(
+    'a notification with an explicit null id is still acknowledged with no body',
+    () async {
+      token = ''.padLeft(64, 'e');
+      expect(await server.start(0), isTrue);
+      final client = HttpClient();
+      try {
+        final request = await client.postUrl(
+          Uri.parse('http://127.0.0.1:${server.port}/mcp'),
+        );
+        request.headers.contentType = ContentType.json;
+        request.headers.set(HttpHeaders.authorizationHeader, 'Bearer $token');
+        request.write(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'method': 'notifications/initialized',
+            'id': null,
+          }),
+        );
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.accepted);
+        expect(await utf8.decoder.bind(response).join(), isEmpty);
+      } finally {
+        client.close(force: true);
+      }
+    },
+  );
 }
 
 Future<int> _postInitialize(int port, {String? bearerToken}) async {


### PR DESCRIPTION
Strict MCP clients reject the local server's initialized handshake because it returned a JSON body for a notification. Authenticated notifications now receive HTTP 202 with an empty body, and ordinary requests still return JSON-RPC responses. Adds a handshake/tool-discovery regression test and local connection documentation.

Validation: 4 MCP server tests pass; flutter analyze --no-fatal-infos is clean.
