### PR TITLE
fix(auth): serialize shared credential-vault operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SD
   should verify commands against `pubspec.yaml` and workflows rather than copy
   volatile dependency versions or test counts.
 - Keep changes minimal and reuse-first; this is a port, not a rewrite.
+- Session credential references remain random and profile-local. Platform vault operations share an isolate-wide queue because the Linux backend rewrites the entire vault; see `test/features/authentication/session_credential_vault_test.dart`.
 - Don't reintroduce Discord endpoints, Discord branding, or Firebase push without explicit instruction.
 
 ## AutoMod

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This client is the front door: one native app for every screen you own.
 - 🎨 **Themes** — Dark, Light, Nord, Monokai, and Solarized built in, plus fully custom colors you can copy, paste, and share in chat.
 - 👥 **Multiple profiles** — keep separate local profiles on one device and switch between them without signing out.
 - 🔐 **Secure sign-in** — session tokens live in the OS credential vault, with optional TOTP two-factor authentication.
+- Credential writes are serialized across local profiles; each profile retains its own credential references, including when the same account is added twice.
 - ⬆️ **In-app updates** — desktop and sideloaded Android builds check for, download, and install new releases themselves.
 - 📱 **Responsive everywhere** — one UI that flows from phone to desktop, sharp at every size.
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ This client is the front door: one native app for every screen you own.
 
 - 🎨 **Themes** — Dark, Light, Nord, Monokai, and Solarized built in, plus fully custom colors you can copy, paste, and share in chat.
 - 👥 **Multiple profiles** — keep separate local profiles on one device and switch between them without signing out.
-- 🔐 **Secure sign-in** — session tokens live in the OS credential vault, with optional TOTP two-factor authentication.
-- Credential writes are serialized across local profiles; each profile retains its own credential references, including when the same account is added twice.
+- 🔐 **Secure sign-in** — session tokens live in the OS credential vault, with optional TOTP two-factor authentication; each device profile keeps its own credential, even for the same account.
 - ⬆️ **In-app updates** — desktop and sideloaded Android builds check for, download, and install new releases themselves.
 - 📱 **Responsive everywhere** — one UI that flows from phone to desktop, sharp at every size.
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -22,6 +22,14 @@ daccord automatically attempts to reconnect when the connection drops. If you se
 - Check your internet connection.
 - If the problem persists, close and reopen daccord to establish a fresh session.
 
+## Unexpected Sign-out
+
+If a saved credential is missing from the OS vault, sign in again to restore it.
+Session metadata reuses its existing opaque reference. Credentials in different
+device profiles stay independent, even for the same account. Vault operations
+are serialized within the app process to prevent overlapping Linux vault writes
+from losing credentials; this does not coordinate separate app processes.
+
 ## No Sound in Voice Channels
 
 - Check that your microphone and speakers are selected in **App Settings > Voice & Video**.

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -55,9 +55,7 @@ daccord collects no first-party analytics, telemetry, or crash data. It does mak
 
 ## Unexpected Sign-out
 
-If a saved credential is missing from the OS vault, sign in again to restore it.
-Session metadata reuses its existing opaque reference. Credentials in different
-device profiles stay independent, even for the same account. Vault operations
-are serialized within the app process to prevent overlapping Linux vault writes
-from losing credentials; this does not coordinate separate app processes.
+- **A saved credential is missing from the OS vault** -- Sign in again; the existing session metadata is repaired in place, without changing your saved reference.
+- **Same account signed in on two device profiles** -- Each profile keeps its own credential, so signing out or clearing one profile never affects the other.
+- **Credentials disappear on Linux under heavy account switching** -- Vault writes are serialized within the app process to stop overlapping writes from silently dropping a credential; this does not coordinate across separate app processes (e.g. two windows of the app running at once).
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -22,14 +22,6 @@ daccord automatically attempts to reconnect when the connection drops. If you se
 - Check your internet connection.
 - If the problem persists, close and reopen daccord to establish a fresh session.
 
-## Unexpected Sign-out
-
-If a saved credential is missing from the OS vault, sign in again to restore it.
-Session metadata reuses its existing opaque reference. Credentials in different
-device profiles stay independent, even for the same account. Vault operations
-are serialized within the app process to prevent overlapping Linux vault writes
-from losing credentials; this does not coordinate separate app processes.
-
 ## No Sound in Voice Channels
 
 - Check that your microphone and speakers are selected in **App Settings > Voice & Video**.
@@ -60,3 +52,12 @@ can use more CPU.
 If you encounter a bug, report it at the [daccord GitHub Issues page](https://github.com/DaccordProject/daccord/issues).
 
 daccord collects no first-party analytics, telemetry, or crash data. It does make documented requests for connected servers, discovery, updates, and user-approved media. See [Network behavior and privacy](../privacy-network.md) for the complete disclosure.
+
+## Unexpected Sign-out
+
+If a saved credential is missing from the OS vault, sign in again to restore it.
+Session metadata reuses its existing opaque reference. Credentials in different
+device profiles stay independent, even for the same account. Vault operations
+are serialized within the app process to prevent overlapping Linux vault writes
+from losing credentials; this does not coordinate separate app processes.
+

--- a/lib/features/authentication/repositories/session_credential_vault.dart
+++ b/lib/features/authentication/repositories/session_credential_vault.dart
@@ -16,16 +16,38 @@ class PlatformSessionCredentialVault implements SessionCredentialVault {
   static const _keyPrefix = 'daccord.session.v1.';
   final FlutterSecureStorage _storage;
 
+  /// Serializes vault operations across all instances in this isolate.
+  ///
+  /// The Linux backend keeps the *whole* vault in a single Secret Service item
+  /// and rewrites it wholesale on each call (read the JSON blob → patch one key
+  /// → store the blob back). Two overlapping operations therefore race on that
+  /// blob and the loser's key is silently dropped — stranding a `credentialRef`
+  /// that Hive still points at, which [AccordSessionStore] can only read as "no
+  /// session", i.e. a surprise logout. Restoring a session does exactly this:
+  /// `_makeActive` fires an un-awaited `persistActive` write that overlaps the
+  /// `listAccounts` migration pass. Chaining keeps the read-modify-write cycles
+  /// from interleaving; on the per-key backends it is simply a no-op cost.
+  static Future<void> _queue = Future<void>.value();
+
+  Future<T> _serialized<T>(Future<T> Function() operation) {
+    final result = _queue.then((_) => operation());
+    // The chain only orders work, so a failed operation must not poison it —
+    // the error still surfaces to the caller through [result].
+    _queue = result.then<void>((_) {}, onError: (_) {});
+    return result;
+  }
+
   String _key(String reference) => '$_keyPrefix$reference';
 
   @override
   Future<void> write(String reference, String token) =>
-      _storage.write(key: _key(reference), value: token);
+      _serialized(() => _storage.write(key: _key(reference), value: token));
 
   @override
-  Future<String?> read(String reference) => _storage.read(key: _key(reference));
+  Future<String?> read(String reference) =>
+      _serialized(() => _storage.read(key: _key(reference)));
 
   @override
   Future<void> delete(String reference) =>
-      _storage.delete(key: _key(reference));
+      _serialized(() => _storage.delete(key: _key(reference)));
 }

--- a/test/features/authentication/accord_session_store_test.dart
+++ b/test/features/authentication/accord_session_store_test.dart
@@ -3,9 +3,9 @@ import 'dart:io';
 import 'package:bonfire/features/authentication/models/accord_session.dart';
 import 'package:bonfire/features/authentication/repositories/accord_session_store.dart';
 import 'package:bonfire/features/authentication/repositories/session_credential_vault.dart';
-import 'package:bonfire/features/server/models/accord_server.dart';
 import 'package:bonfire/features/profiles/models/device_profile.dart';
 import 'package:bonfire/features/profiles/services/profile_store.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 

--- a/test/features/authentication/accord_session_store_test.dart
+++ b/test/features/authentication/accord_session_store_test.dart
@@ -4,6 +4,8 @@ import 'package:bonfire/features/authentication/models/accord_session.dart';
 import 'package:bonfire/features/authentication/repositories/accord_session_store.dart';
 import 'package:bonfire/features/authentication/repositories/session_credential_vault.dart';
 import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/profiles/models/device_profile.dart';
+import 'package:bonfire/features/profiles/services/profile_store.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 
@@ -107,6 +109,40 @@ void main() {
     await store.deleteActive();
     expect(vault.values, isEmpty);
   });
+
+  test(
+    'a new login repairs a missing credential without changing its reference',
+    () async {
+      await store.persist(session());
+      final reference = vault.values.keys.single;
+      vault.values.clear();
+      expect(await store.readRestorableActive(), isNull);
+      await store.persist(session(token: 'fresh-token'));
+      expect(vault.values.keys, [reference]);
+      expect((await store.readRestorableActive())?.token, 'fresh-token');
+    },
+  );
+
+  test(
+    'the same account in two profiles retains independent credentials',
+    () async {
+      await ProfileStore.bootstrap(temporary.path);
+      final first = AccordSessionStore(credentialVault: vault);
+      await first.persist(session(token: 'default-token'));
+      final firstReference = vault.values.keys.single;
+      final workId = ProfileStore.create('Work');
+      await ProfileStore.switchTo(workId);
+      final second = AccordSessionStore(credentialVault: vault);
+      await second.persist(session(token: 'work-token'));
+      expect(vault.values.length, 2);
+      expect((await second.readRestorableActive())?.token, 'work-token');
+      await second.removeAccount(session().key);
+      await second.deleteActive();
+      expect(vault.values, {firstReference: 'default-token'});
+      await ProfileStore.switchTo(DeviceProfile.defaultId);
+      expect((await first.readRestorableActive())?.token, 'default-token');
+    },
+  );
 
   test('native packaging and Web threat documentation stay wired', () {
     expect(

--- a/test/features/authentication/session_credential_vault_test.dart
+++ b/test/features/authentication/session_credential_vault_test.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:bonfire/features/authentication/repositories/session_credential_vault.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('different vault instances serialize shared-store writes', () async {
+    final firstStarted = Completer<void>();
+    final releaseFirst = Completer<void>();
+    var values = <String, String>{};
+    var calls = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      // Model the Linux backend's read-modify-write of the entire vault.
+      final snapshot = Map<String, String>.of(values);
+      calls++;
+      if (calls == 1) {
+        firstStarted.complete();
+        await releaseFirst.future;
+      }
+      final args = call.arguments as Map;
+      snapshot[args['key'] as String] = args['value'] as String;
+      values = snapshot;
+      return null;
+    });
+    final first = PlatformSessionCredentialVault().write('first', 'token-a');
+    await firstStarted.future;
+    final second = PlatformSessionCredentialVault().write('second', 'token-b');
+    await Future<void>.delayed(Duration.zero);
+    final callsWhileBlocked = calls;
+    releaseFirst.complete();
+    await Future.wait([first, second]);
+    expect(callsWhileBlocked, 1);
+    expect(values.values, unorderedEquals(['token-a', 'token-b']));
+  });
+
+  test('a failed operation does not block later writes or reads', () async {
+    var calls = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (++calls == 1) throw PlatformException(code: 'locked');
+      return call.method == 'read' ? 'recovered-token' : null;
+    });
+    final vault = PlatformSessionCredentialVault();
+    await expectLater(
+      vault.write('account', 'old-token'),
+      throwsA(isA<PlatformException>()),
+    );
+    await vault.write('account', 'recovered-token');
+    expect(await vault.read('account'), 'recovered-token');
+    await vault.delete('account');
+    expect(calls, 4);
+  });
+}


### PR DESCRIPTION
Overlapping Linux secure-storage writes can overwrite each other's entries because the backend rewrites the entire vault. Queue reads, writes and deletes across vault instances in the same isolate, and keep the queue usable after failures.

Retains random, profile-local credential references. Tests verify shared-store concurrency, recovery after failure, repairing a missing credential on login, and independent credentials for the same account in two profiles.

Validation: 16 authentication/profile tests pass; flutter analyze --no-fatal-infos is clean. The queue does not coordinate separate app processes.
