### PR TITLE
feat(ios): handle Daccord Universal Links and validate signing capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ The Accord server backend is [`accordserver`](https://github.com/DaccordProject/
 
 ### Layout
 
+- Universal Links use `https://www.daccord.gg/open/`. Before releasing the iOS entitlement, verify the website association file, regenerated signing profile and physical-device launch; see `docs/app-store-deploy.md`.
+
 ```
 lib/
   features/        # feature modules: authentication, spaces, channels, messaging,
@@ -170,7 +172,6 @@ When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SD
   should verify commands against `pubspec.yaml` and workflows rather than copy
   volatile dependency versions or test counts.
 - Keep changes minimal and reuse-first; this is a port, not a rewrite.
-- Universal Links use `https://www.daccord.gg/open/`. Before releasing the iOS entitlement, verify the website association file, regenerated signing profile and physical-device launch; see `docs/app-store-deploy.md`.
 - Don't reintroduce Discord endpoints, Discord branding, or Firebase push without explicit instruction.
 
 ## AutoMod

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SD
   should verify commands against `pubspec.yaml` and workflows rather than copy
   volatile dependency versions or test counts.
 - Keep changes minimal and reuse-first; this is a port, not a rewrite.
+- Universal Links use `https://www.daccord.gg/open/`. Before releasing the iOS entitlement, verify the website association file, regenerated signing profile and physical-device launch; see `docs/app-store-deploy.md`.
 - Don't reintroduce Discord endpoints, Discord branding, or Firebase push without explicit instruction.
 
 ## AutoMod

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Grab the latest build from the **[Releases page](https://github.com/DaccordProje
 
 Every release ships a `SHA256SUMS.txt` so you can verify what you downloaded. Step-by-step instructions per platform live in [Installing daccord](docs/getting-started/installation.md).
 
-Shared app links use `https://www.daccord.gg/open/`. iOS Universal Link handling requires the website association and matching signing profile described in [App Store deployment](docs/app-store-deploy.md#universal-links).
-
 iOS and the store channels are built and submitted by the release workflow; public store listings aren't live yet, so the downloads above are the way in today.
 
 ### Platform support
@@ -131,6 +129,8 @@ The easiest route is the **Accord desktop app**: a tray application that bundles
 ---
 
 ## 📚 Documentation
+
+Shared app links use `https://www.daccord.gg/open/`. iOS Universal Link handling requires the website association and matching signing profile described in [App Store deployment](docs/app-store-deploy.md#universal-links).
 
 End-user documentation lives in [`docs/`](docs/index.md):
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Grab the latest build from the **[Releases page](https://github.com/DaccordProje
 
 Every release ships a `SHA256SUMS.txt` so you can verify what you downloaded. Step-by-step instructions per platform live in [Installing daccord](docs/getting-started/installation.md).
 
+Shared app links use `https://www.daccord.gg/open/`. iOS Universal Link handling requires the website association and matching signing profile described in [App Store deployment](docs/app-store-deploy.md#universal-links).
+
 iOS and the store channels are built and submitted by the release workflow; public store listings aren't live yet, so the downloads above are the way in today.
 
 ### Platform support

--- a/docs/app-store-deploy.md
+++ b/docs/app-store-deploy.md
@@ -60,6 +60,26 @@ generates the certs/profiles and prints the `gh secret set` commands.
 | `MAC_PROFILE_BASE64` | base64 of the **Mac App Store** provisioning profile |
 | `MAC_PROFILE_NAME` | that profile's name |
 
+### Universal Links
+
+The iOS App ID must enable **Associated Domains**. The app claims
+`applinks:www.daccord.gg`; regenerate `IOS_PROFILE_BASE64` after enabling the
+capability. `scripts/bootstrap-signing.sh` verifies the decoded profile permits
+that domain, including profiles granting `*` rather than listing each domain.
+
+Before merging/releasing the entitlement and new share links, verify:
+
+- `https://www.daccord.gg/.well-known/apple-app-site-association` is public,
+  serves JSON without redirects, and associates `/open/*` with the signed
+  app's application identifier (App ID prefix plus bundle ID).
+- `/open/connect/...` and `/open/navigate/...` provide a browser fallback.
+- A freshly signed iOS install opens a link from another app and navigates to
+  the intended server/channel; also test the fallback without the app installed.
+
+The custom `daccord://` scheme remains accepted. Parser tests cover the HTTPS
+host/path allowlist, but cannot establish that Apple's association or signing
+configuration is deployed. See [Apple's Universal Links documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
+
 ### Google Play (`android-play` job)
 
 | Secret | What it is |

--- a/ios/Runner/DebugProfile.entitlements
+++ b/ios/Runner/DebugProfile.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.daccord.gg</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/ios/Runner/Release.entitlements
+++ b/ios/Runner/Release.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.daccord.gg</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/lib/features/messaging/views/thread_view.dart
+++ b/lib/features/messaging/views/thread_view.dart
@@ -228,20 +228,21 @@ class _AccordThreadPaneState extends ConsumerState<AccordThreadPane> {
     return 'Thread';
   }
 
-  /// Offers two share links for this post: a `daccord://` deep link that opens
-  /// directly in a daccord client, and the public `/s/...` web URL that anyone
-  /// (and search-engine crawlers) can open.
+  /// Offers two share links for this post: a Daccord Universal Link that opens
+  /// the installed client (with a website fallback), and the public `/s/...`
+  /// web URL that anyone and search-engine crawlers can open.
   void _showShareMenu([Offset? position]) {
     final spaceId = widget.spaceId;
     if (spaceId == null) return;
 
     final entries = <AccordMenuEntry>[
       AccordMenuEntry(
-        label: 'Share with those who have the app',
+        label: 'Share Daccord link',
         icon: Icons.rocket_launch_outlined,
         onSelected: () => _copyShareLink(
-          'daccord://navigate/$spaceId/${widget.channelId}?msg=${_root.id}',
-          'App link copied to clipboard',
+          'https://www.daccord.gg/open/navigate/$spaceId/'
+              '${widget.channelId}?msg=${_root.id}',
+          'Daccord link copied to clipboard',
         ),
       ),
     ];

--- a/lib/features/server/utils/server_uri.dart
+++ b/lib/features/server/utils/server_uri.dart
@@ -103,7 +103,8 @@ class ServerUri {
     );
   }
 
-  /// Parses a `daccord://` deep link. Supported routes (matching
+  /// Parses either a `daccord://` deep link or its public Universal Link form
+  /// at `https://www.daccord.gg/open/...`. Supported routes (matching
   /// `uri_handler.gd`):
   ///   `daccord://connect/<host>[:<port>][/<space-slug>][?token=&invite=]`
   ///   `daccord://invite/<code>@<host>[:<port>]`
@@ -112,8 +113,21 @@ class ServerUri {
   static ParsedServerUrl? parseDeepLink(String uri) {
     var text = uri.trim();
     const scheme = 'daccord://';
-    if (!text.startsWith(scheme)) return null;
-    text = text.substring(scheme.length);
+    if (text.startsWith(scheme)) {
+      text = text.substring(scheme.length);
+    } else {
+      final web = Uri.tryParse(text);
+      if (web == null ||
+          web.scheme != 'https' ||
+          (web.host != 'www.daccord.gg' && web.host != 'daccord.gg') ||
+          web.userInfo.isNotEmpty ||
+          web.hasPort ||
+          !web.path.startsWith('/open/')) {
+        return null;
+      }
+      text = web.path.substring('/open/'.length);
+      if (web.hasQuery) text += '?${web.query}';
+    }
     if (text.isEmpty) return null;
 
     final slash = text.indexOf('/');
@@ -284,6 +298,5 @@ class ServerUri {
   /// here — a user may legitimately point at a self-hosted dev server.
   static bool _isValidHost(String host) => isValidHost(host);
 
-  static String? _blankToNull(String? v) =>
-      (v == null || v.isEmpty) ? null : v;
+  static String? _blankToNull(String? v) => (v == null || v.isEmpty) ? null : v;
 }

--- a/lib/features/spaces/views/accord_home_tabs.dart
+++ b/lib/features/spaces/views/accord_home_tabs.dart
@@ -229,8 +229,8 @@ class _TabStripState extends ConsumerState<_TabStrip> {
   }
 }
 
-/// Builds a `daccord://connect/<host>[/<slug>][?channel=<name>]` share link,
-/// matching the reference client's `UriHandler.build_connect_url`.
+/// Builds a public Universal Link. It opens the installed app directly on iOS
+/// and falls back to the website launcher elsewhere.
 String _buildConnectLink(
   AccordServer server,
   AccordSpace? space,
@@ -240,7 +240,7 @@ String _buildConnectLink(
   final slash = host.indexOf('/');
   if (slash != -1) host = host.substring(0, slash);
   final slug = (space?.slug.isNotEmpty ?? false) ? space!.slug : '';
-  var url = 'daccord://connect/$host';
+  var url = 'https://www.daccord.gg/open/connect/$host';
   if (slug.isNotEmpty) url += '/${Uri.encodeComponent(slug)}';
   if (channelName.isNotEmpty) {
     url += '?channel=${Uri.encodeComponent(channelName)}';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -226,7 +226,6 @@ class _MainWindowState extends ConsumerState<MainWindow> {
   }
 
   void _handleUri(Uri uri) {
-    if (uri.scheme != 'daccord') return;
     final parsed = ServerUri.parseDeepLink(uri.toString());
     if (parsed == null) return;
 

--- a/scripts/bootstrap-signing.sh
+++ b/scripts/bootstrap-signing.sh
@@ -7,6 +7,8 @@
 # Prereqs:
 #   - An App Store Connect API key (.p8) with Admin or App Manager role.
 #   - The app record + bundle id (com.cattrall.daccord) already exist.
+#   - Associated Domains is enabled for that iOS App ID in Certificates,
+#     Identifiers & Profiles.
 #
 # Usage:
 #   ASC_ISSUER_ID=<uuid> APPLE_TEAM_ID=<10char> \
@@ -17,6 +19,7 @@
 # It is idempotent-ish: fastlane reuses an existing matching cert/profile rather
 # than always creating new ones (Apple caps distribution certs).
 set -euo pipefail
+SIGNING_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 P8="${1:?usage: bootstrap-signing.sh /path/to/AuthKey_XXXX.p8}"
 : "${ASC_ISSUER_ID:?set ASC_ISSUER_ID (App Store Connect → Users and Access → Integrations)}"
@@ -72,6 +75,7 @@ run_profile() {  # <platform> <name> <out_basename>
     platform:"$platform" \
     team_id:"$APPLE_TEAM_ID" \
     provisioning_name:"$name" \
+    force:true \
     filename:"$base.profile" \
     output_path:"$WORK" >/dev/null
 }
@@ -87,6 +91,12 @@ run_cert developer_id_application macos developer_id
 
 echo "==> iOS App Store provisioning profile"
 run_profile ios "$IOS_PROFILE_NAME" ios_profile
+if ! security cms -D -i "$WORK/ios_profile.profile" 2>/dev/null \
+  | python3 "$SIGNING_SCRIPT_DIR/verify-associated-domains.py"; then
+  echo "error: generated iOS profile does not authorize applinks:www.daccord.gg" >&2
+  echo "enable Associated Domains for $BUNDLE_ID in the Apple Developer portal, then rerun" >&2
+  exit 1
+fi
 
 echo "==> Mac App Store provisioning profile"
 run_profile macos "$MAC_PROFILE_NAME" mac_profile

--- a/scripts/verify-associated-domains.py
+++ b/scripts/verify-associated-domains.py
@@ -1,0 +1,22 @@
+"""Check the decoded signing profile's Associated Domains authorization."""
+
+import plistlib
+import sys
+
+
+def permits_applinks(profile):
+    entitlements = profile.get("Entitlements", {})
+    if not isinstance(entitlements, dict):
+        return False
+    domains = entitlements.get("com.apple.developer.associated-domains", [])
+    return isinstance(domains, list) and any(
+        domain in ("*", "applinks:www.daccord.gg") for domain in domains
+    )
+
+
+if __name__ == "__main__":
+    try:
+        allowed = permits_applinks(plistlib.loads(sys.stdin.buffer.read()))
+    except (ValueError, TypeError, AttributeError, plistlib.InvalidFileException):
+        allowed = False
+    sys.exit(0 if allowed else 1)

--- a/test/features/server/server_uri_test.dart
+++ b/test/features/server/server_uri_test.dart
@@ -255,6 +255,48 @@ void main() {
     });
   });
 
+  group('ServerUri.parseDeepLink — Universal Links', () {
+    test('parses a www connect link with encoded destinations', () {
+      final parsed = ServerUri.parseDeepLink(
+        'https://www.daccord.gg/open/connect/chat.example.com:8443/'
+        'my%20space?channel=release%20notes',
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.route, 'connect');
+      expect(parsed.server?.baseUrl, 'https://chat.example.com:8443');
+      expect(parsed.spaceName, 'my space');
+      expect(parsed.channelName, 'release notes');
+    });
+
+    test('parses a root-domain navigation link', () {
+      final parsed = ServerUri.parseDeepLink(
+        'https://daccord.gg/open/navigate/space1/chan1?msg=msg1',
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.spaceId, 'space1');
+      expect(parsed.channelId, 'chan1');
+      expect(parsed.messageId, 'msg1');
+    });
+
+    test('rejects lookalike, insecure, userinfo, and unrelated web URLs', () {
+      for (final url in [
+        'https://daccord.gg.evil.example/open/navigate/space1',
+        'http://www.daccord.gg/open/navigate/space1',
+        'https://attacker@www.daccord.gg/open/navigate/space1',
+        'https://www.daccord.gg:8443/open/navigate/space1',
+        'https://www.daccord.gg/blog/',
+      ]) {
+        expect(
+          ServerUri.parseDeepLink(url),
+          isNull,
+          reason: 'expected $url to be rejected',
+        );
+      }
+    });
+  });
+
   group('ServerUri host validation', () {
     test('a host containing a space is rejected', () {
       expect(ServerUri.parseDeepLink('daccord://connect/bad host'), isNull);


### PR DESCRIPTION
Accept allowlisted https://www.daccord.gg/open/ links alongside daccord:// links, use public app links in sharing menus, and add the iOS Associated Domains entitlement. Signing bootstrap regenerates profiles and verifies that Associated Domains authorizes the app's domain, accepting both an explicit entry and the provisioning-profile wildcard.

Validation: 40 URI tests pass; analyzer is clean; shell syntax and six signing-profile fixtures pass.

Draft release dependency: verify the public apple-app-site-association document, /open/ browser fallback, regenerated iOS provisioning profile, and launch on a signed physical device before merging. Website requests returned HTTP 403 from the review environment; no Apple credentials or remote signing settings were changed. Deployment instructions describe each remaining check.
