### PR TITLE
fix(read-state): synchronize read cursors and suppress repeated notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,13 @@ When in doubt about Accord behaviour, read `packages/accordkit` (the vendored SD
 - Keep changes minimal and reuse-first; this is a port, not a rewrite.
 - Don't reintroduce Discord endpoints, Discord branding, or Firebase push without explicit instruction.
 
+## Read state
+
+Read-state updates live in `accord_message_events.dart`; READY cursors are
+parsed in `accord_ready_sync.dart`. Use `ReadStateController.acknowledge` for
+local reads so retries, monotonic cursors and notification dismissal stay
+consistent. Details: `docs/notification-read-state-audit.md`.
+
 ## AutoMod
 
 `lib/features/automod/` owns the policy/review UI and block-before-delete flow.

--- a/README.md
+++ b/README.md
@@ -358,3 +358,7 @@ Licensed under the **[GNU General Public License v3.0](LICENSE)** (GPLv3), inher
 Configure server and space rules, review held uploads, and block repeated file
 uploads through the AutoMod controls. See [the client AutoMod guide](docs/automod.md)
 for permissions, video sampling, private evidence, and cooldown behavior.
+
+Read positions synchronize across connected devices, with retries for failed
+acknowledgements and replay suppression for notifications. See the
+[read-state audit](docs/notification-read-state-audit.md) for behavior and limits.

--- a/docs/notification-read-state-audit.md
+++ b/docs/notification-read-state-audit.md
@@ -1,0 +1,54 @@
+# Notification and read-state audit
+
+Originally audited 2026-09-07; reconciled with current master on 2026-09-12. Scope: channel and DM unread highlighting, mention counts,
+desktop/app badges, local notification banners and sounds, gateway replay,
+reconnect hydration, and read acknowledgements between devices.
+
+## Client findings and fixes
+
+| Finding | Resulting change |
+| --- | --- |
+| Messages arriving in the visible channel skipped local unread state but never acknowledged the new message to the server. Other devices and reconnects consequently showed already-viewed messages as unread. | The gateway acknowledges the actual incoming message ID while the app is focused on that channel. |
+| Opening a channel acknowledged before history loaded. Text channels had no subsequent acknowledgement when the newer history became available. | The shared message pane acknowledges loaded history, incoming state changes and app resume. This also covers DMs and voice chat rendered by that pane. |
+| Cached history took precedence over newer channel metadata. | Read actions choose the newest position from history, channel metadata and gateway/READY state, using exact snowflake comparison. |
+| A selected channel counted as visible while the app was inactive. | Automatic acknowledgement and notification suppression now require resumed app lifecycle state. |
+| Acknowledgements from another device unconditionally cleared the entire channel. | Read cursors advance monotonically; older acknowledgements retain newer unread messages and known newer mentions. |
+| Gateway replays could increment mention counts and produce alerts repeatedly. | Delivery and read cursors suppress repeated or already-read message events before unread deltas, banners and sounds. Message caches still receive the events. |
+| Acknowledgement failures were ignored and requests could overlap. | A per-server, per-channel queue serializes/coalesces acknowledgements, checks HTTP success, and retries failures while the provider is alive, including on READY. |
+| Delivered local banners outlived read acknowledgements. Timestamp-derived notification IDs could also collide during bursts. | Notifications have distinct IDs and server/channel/message associations. Local reads, remote reads and reconnect reconciliation dismiss matching banners, including races with asynchronous delivery. |
+| The home route could overwrite the visible DM pointer while rebuilding beneath its dialog. | The home route updates visibility only while it is the current route. |
+| The global badge looked up raw IDs in settings stored under server-qualified keys. | Global aggregation applies each connection's own mute and channel settings. |
+| Channels set to “nothing” suppressed banners and highlighting but could still chime. | Incoming-message sounds honor the same per-channel suppression. |
+
+## Server follow-up
+
+The September 7 read-only inspection of the sibling `accordserver` repository found that
+`src/db/read_states.rs::ack_channel` preserves the maximum read cursor but
+unconditionally resets `mention_count` to zero. A delayed or partial acknowledgement
+can therefore erase the persisted count for newer unread mentions. The client now
+preserves newer live mentions locally, but cannot reconstruct a correct count from
+an incorrect READY snapshot after restarting.
+
+The server should calculate the remaining mentions after the effective read
+cursor atomically with the acknowledgement, and broadcast that effective cursor
+and remaining count. The current route in `src/routes/read_states.rs` broadcasts
+the submitted cursor and zero. No server files were changed in this client patch.
+
+## Validation and limits
+
+Regression tests cover serialized acknowledgements, failures/reconnect retries,
+numeric cursor ordering, duplicate events, delayed remote reads, app
+inactivity/resume, history loading, server-specific mute settings, notification
+dismissal races, and the existing own-message and DM call behavior. Run
+`flutter test` and `scripts/codegen.sh --check` when modifying this flow.
+
+Physical devices and native notification centers were not exercised. Notification
+tests use the Android method channel with a mocked platform. Dismissal associations
+and pending acknowledgements are held in memory: an app process killed before an
+ack succeeds can still leave that position unread on the server, and banners from
+a previous process are not tracked by the new process.
+
+Before release, check with two signed-in devices: receive messages while viewing
+the channel, leave and return, switch app focus, read on the other device, and
+reconnect each device. Confirm that genuinely newer messages remain highlighted,
+read messages stay cleared, and old notification banners are dismissed.

--- a/lib/features/channels/controllers/global_unread.dart
+++ b/lib/features/channels/controllers/global_unread.dart
@@ -90,18 +90,25 @@ GlobalUnread globalUnread(Ref ref) {
   );
   // Watch only the two settings slices the mute gate reads, so an unrelated
   // settings write (a draft keystroke) can't churn the badge.
-  final mutedSpaces = ref.watch(
-    settingsControllerProvider.select((s) => s.mutedSpaces),
-  );
-  final channelLevels = ref.watch(
-    settingsControllerProvider.select((s) => s.channelNotifications),
-  );
-  return foldGlobalUnread(
-    [
-      for (final connection in connections)
-        ref.watch(readStateControllerProvider(connection.key)),
-    ],
-    mutedSpaces: mutedSpaces,
-    channelLevels: channelLevels,
-  );
+  ref.watch(settingsControllerProvider.select((s) => s.mutedSpaces));
+  ref.watch(settingsControllerProvider.select((s) => s.channelNotifications));
+  final settings = ref.read(settingsControllerProvider);
+  var hasUnread = false;
+  var mentions = 0;
+  for (final connection in connections) {
+    final snapshot = ref.watch(readStateControllerProvider(connection.key));
+    final unread = foldGlobalUnread(
+      [snapshot],
+      mutedSpaces: {
+        for (final entry in snapshot.entries.values)
+          if (entry.spaceId != null &&
+              settings.isSpaceMuted(connection.key, entry.spaceId!))
+            entry.spaceId!,
+      },
+      channelLevels: settings.channelNotificationsFor(connection.key),
+    );
+    hasUnread = hasUnread || unread.hasUnread;
+    mentions += unread.mentionCount;
+  }
+  return GlobalUnread(hasUnread: hasUnread, mentionCount: mentions);
 }

--- a/lib/features/channels/controllers/global_unread.g.dart
+++ b/lib/features/channels/controllers/global_unread.g.dart
@@ -67,4 +67,4 @@ final class GlobalUnreadProvider
   }
 }
 
-String _$globalUnreadHash() => r'4d164416e7524584ee25944461db0b3ba7993672';
+String _$globalUnreadHash() => r'5ae18eab3fc0a002cc4b1679c7db78617f31e6f9';

--- a/lib/features/channels/controllers/read_state.dart
+++ b/lib/features/channels/controllers/read_state.dart
@@ -1,3 +1,11 @@
+import 'dart:async';
+
+import 'package:bonfire/features/channels/utils/message_position.dart';
+import 'package:bonfire/features/notifications/services/notification.dart';
+export 'package:bonfire/features/channels/utils/message_position.dart';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:flutter/foundation.dart';
 import 'package:bonfire/features/settings/models/accord_settings.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -40,16 +48,26 @@ class UnreadIndicatorGate {
 /// server-level badge up from per-channel state) and how many pending mentions
 /// it carries. [spaceId] is null for DMs, which never appear in the space rail.
 class ReadEntry {
-  const ReadEntry({required this.channelId, this.spaceId, this.mentions = 0});
+  const ReadEntry({
+    required this.channelId,
+    this.spaceId,
+    this.mentions = 0,
+    this.lastMessageId,
+    this.lastReadMessageId,
+  });
 
   final String channelId;
   final String? spaceId;
   final int mentions;
+  final String? lastMessageId;
+  final String? lastReadMessageId;
 
   ReadEntry copyWith({String? spaceId, int? mentions}) => ReadEntry(
     channelId: channelId,
     spaceId: spaceId ?? this.spaceId,
     mentions: mentions ?? this.mentions,
+    lastMessageId: lastMessageId,
+    lastReadMessageId: lastReadMessageId,
   );
 }
 
@@ -149,64 +167,216 @@ class ReadStateSnapshot {
 ///    lights up *background* servers;
 ///  * the gateway message handler [markUnread]s on incoming traffic for live
 ///    updates (every connection, not just the active one);
-///  * the home screen / context menu / voice panel [markRead]s the channel the
-///    user opens, which separately POSTs `channels.ack` to the server.
+///  * visible panes and explicit read actions call [acknowledge], which clears
+///    local state and queues the server read position;
+///  * [applyRemoteRead] consumes acknowledgements from other devices.
 @Riverpod(keepAlive: true)
 class ReadStateController extends _$ReadStateController {
-  @override
-  ReadStateSnapshot build(String serverKey) => const ReadStateSnapshot();
+  final _latest = <String, String>{};
+  final _received = <String, String>{};
+  final _readThrough = <String, String>{};
+  final _syncedThrough = <String, String>{};
+  final _pending = <String, String>{};
+  final _sending = <String>{};
+  final _retries = <String, Timer>{};
+  final _mentionIds = <String, Set<String>>{};
 
-  /// Records a new unseen message in [channelId]. When [isMention] is true the
-  /// channel's mention count is bumped (rendered as a numeric badge). [spaceId]
-  /// lets the rail roll the unread up to the owning server.
-  void markUnread(String channelId, {String? spaceId, bool isMention = false}) {
-    if (channelId.isEmpty) return;
-    final existing = state.entries[channelId];
-    // Already unread and this isn't a mention: nothing to bump, but backfill a
-    // previously-unknown spaceId so the rail rollup stays correct.
-    if (existing != null && !isMention) {
-      if (existing.spaceId == null && spaceId != null) {
-        final entries = Map<String, ReadEntry>.from(state.entries);
-        entries[channelId] = existing.copyWith(spaceId: spaceId);
-        state = ReadStateSnapshot(entries: entries);
+  @override
+  ReadStateSnapshot build(String serverKey) {
+    ref.onDispose(() {
+      for (final timer in _retries.values) {
+        timer.cancel();
       }
-      return;
+    });
+    return const ReadStateSnapshot();
+  }
+
+  String? latestMessageId(String channelId) => _latest[channelId];
+
+  /// Records delivery before notifications/sounds are considered. A replay or
+  /// a message already read on another device must not alert a second time.
+  bool receiveMessage(String channelId, String messageId) {
+    final previous = _received[channelId];
+    _advance(_latest, channelId, messageId);
+    if (_atOrBefore(messageId, previous)) return false;
+    _advance(_received, channelId, messageId);
+    return !_atOrBefore(messageId, _readThrough[channelId]);
+  }
+
+  void markUnread(
+    String channelId, {
+    String? spaceId,
+    bool isMention = false,
+    String? messageId,
+  }) {
+    if (channelId.isEmpty) return;
+    if (messageId != null) {
+      _advance(_latest, channelId, messageId);
+      if (_atOrBefore(messageId, _readThrough[channelId])) return;
+      if (isMention &&
+          !(_mentionIds[channelId] ??= <String>{}).add(messageId)) {
+        return;
+      }
     }
+    final existing = state.entries[channelId];
     final entries = Map<String, ReadEntry>.from(state.entries);
     entries[channelId] = ReadEntry(
       channelId: channelId,
       spaceId: spaceId ?? existing?.spaceId,
       mentions: (existing?.mentions ?? 0) + (isMention ? 1 : 0),
+      lastMessageId: _latest[channelId],
     );
     state = ReadStateSnapshot(entries: entries);
   }
 
-  /// Clears [channelId]'s unread + mention state. Called when the user opens
-  /// the channel; the caller separately POSTs `channels.ack` to update server
-  /// read state.
-  void markRead(String channelId) {
-    if (!state.entries.containsKey(channelId)) return;
-    final entries = Map<String, ReadEntry>.from(state.entries)
-      ..remove(channelId);
+  /// Clears only messages up to the acknowledged position. Old acknowledgements
+  /// from another device cannot hide messages that arrived after that position.
+  void markRead(String channelId, {String? messageId}) {
+    final position = messageId ?? _latest[channelId];
+    if (position != null) _advance(_readThrough, channelId, position);
+    unawaited(
+      dismissReadNotifications(
+        serverKey: serverKey,
+        channelId: channelId,
+        messageId: position,
+      ),
+    );
+    final existing = state.entries[channelId];
+    if (existing == null) return;
+    final entries = Map<String, ReadEntry>.from(state.entries);
+    final latest = existing.lastMessageId ?? _latest[channelId];
+    if (position != null &&
+        latest != null &&
+        compareMessageIds(latest, position) > 0) {
+      final mentions = _mentionIds[channelId];
+      var cleared = 0;
+      mentions?.removeWhere((id) {
+        if (!_atOrBefore(id, position)) return false;
+        cleared++;
+        return true;
+      });
+      entries[channelId] = existing.copyWith(
+        mentions: (existing.mentions - cleared).clamp(0, existing.mentions),
+      );
+    } else {
+      entries.remove(channelId);
+      _mentionIds.remove(channelId);
+    }
     state = ReadStateSnapshot(entries: entries);
   }
 
-  /// Replaces the whole snapshot from the server's authoritative unread list
-  /// (the READY payload's `unread` array, or `GET /users/@me/read-states`).
-  /// This is what gives persistence across restarts.
+  void applyRemoteRead(String channelId, String messageId) {
+    _advance(_syncedThrough, channelId, messageId);
+    markRead(channelId, messageId: messageId);
+  }
+
+  /// Optimistic local read plus a serialized, coalesced server acknowledgement.
+  /// Failed requests remain queued and are retried; they are never considered
+  /// synced just because the local badge disappeared.
+  void acknowledge(AccordClient? client, String channelId, String? messageId) {
+    markRead(channelId, messageId: messageId);
+    if (messageId == null || messageId.isEmpty) return;
+    if (_atOrBefore(messageId, _syncedThrough[channelId])) return;
+    _advance(_pending, channelId, messageId);
+    if (client != null) unawaited(_flush(client, channelId));
+  }
+
+  void retryPending(AccordClient client) {
+    for (final channelId in _pending.keys.toList()) {
+      unawaited(_flush(client, channelId));
+    }
+  }
+
+  Future<void> _flush(AccordClient client, String channelId) async {
+    if (!_sending.add(channelId)) return;
+    _retries.remove(channelId)?.cancel();
+    try {
+      while (ref.mounted) {
+        final position = _pending[channelId];
+        if (position == null) break;
+        if (_atOrBefore(position, _syncedThrough[channelId])) {
+          _pending.remove(channelId);
+          break;
+        }
+        final result = await client.channels.ack(channelId, position);
+        if (!ref.mounted) return;
+        if (!result.ok || result.statusCode < 200 || result.statusCode >= 300) {
+          debugPrint(
+            'Failed to acknowledge channel $channelId: ${result.error}',
+          );
+          break;
+        }
+        _advance(_syncedThrough, channelId, position);
+        if (_pending[channelId] == position) _pending.remove(channelId);
+      }
+    } catch (error) {
+      debugPrint('Failed to acknowledge channel $channelId: $error');
+    } finally {
+      _sending.remove(channelId);
+      if (ref.mounted && _pending.containsKey(channelId)) {
+        _retries[channelId] = Timer(const Duration(seconds: 5), () {
+          if (ref.mounted) unawaited(_flush(client, channelId));
+        });
+      }
+    }
+  }
+
+  /// READY is authoritative, except for local reads still awaiting delivery.
   void hydrate(Iterable<ReadEntry> unread) {
-    state = ReadStateSnapshot(
-      entries: {
-        for (final e in unread)
-          if (e.channelId.isNotEmpty) e.channelId: e,
-      },
-    );
+    _mentionIds.clear();
+    final entries = <String, ReadEntry>{};
+    for (final entry in unread) {
+      final id = entry.channelId;
+      if (id.isEmpty) continue;
+      final last = entry.lastMessageId;
+      final read = entry.lastReadMessageId;
+      if (last != null) {
+        _advance(_latest, id, last);
+        _advance(_received, id, last);
+      }
+      if (read != null) {
+        _advance(_readThrough, id, read);
+        _advance(_syncedThrough, id, read);
+        unawaited(
+          dismissReadNotifications(
+            serverKey: serverKey,
+            channelId: id,
+            messageId: read,
+          ),
+        );
+      }
+      if (last != null && _atOrBefore(last, _readThrough[id])) continue;
+      entries[id] = entry;
+    }
+    // A fresh READY can replace missed remote read events after disconnection.
+    for (final id in state.entries.keys) {
+      if (entries.containsKey(id)) continue;
+      final last = _latest[id];
+      if (last != null) _advance(_readThrough, id, last);
+      unawaited(dismissReadNotifications(serverKey: serverKey, channelId: id));
+    }
+    state = ReadStateSnapshot(entries: entries);
   }
 
-  /// Drops every entry — used when a server disconnects / the account is
-  /// removed so a stale snapshot doesn't linger.
   void clear() {
-    if (state.entries.isEmpty) return;
+    for (final timer in _retries.values) {
+      timer.cancel();
+    }
+    _retries.clear();
+    _pending.clear();
+    _latest.clear();
+    _received.clear();
+    _readThrough.clear();
+    _syncedThrough.clear();
+    _mentionIds.clear();
     state = const ReadStateSnapshot();
   }
+}
+
+bool _atOrBefore(String id, String? position) =>
+    position != null && compareMessageIds(id, position) <= 0;
+
+void _advance(Map<String, String> positions, String channelId, String id) {
+  if (id.isEmpty || _atOrBefore(id, positions[channelId])) return;
+  positions[channelId] = id;
 }

--- a/lib/features/channels/controllers/read_state.dart
+++ b/lib/features/channels/controllers/read_state.dart
@@ -364,6 +364,7 @@ class ReadStateController extends _$ReadStateController {
     }
     _retries.clear();
     _pending.clear();
+    _sending.clear();
     _latest.clear();
     _received.clear();
     _readThrough.clear();

--- a/lib/features/channels/controllers/read_state.g.dart
+++ b/lib/features/channels/controllers/read_state.g.dart
@@ -18,8 +18,9 @@ part of 'read_state.dart';
 ///    lights up *background* servers;
 ///  * the gateway message handler [markUnread]s on incoming traffic for live
 ///    updates (every connection, not just the active one);
-///  * the home screen / context menu / voice panel [markRead]s the channel the
-///    user opens, which separately POSTs `channels.ack` to the server.
+///  * visible panes and explicit read actions call [acknowledge], which clears
+///    local state and queues the server read position;
+///  * [applyRemoteRead] consumes acknowledgements from other devices.
 
 @ProviderFor(ReadStateController)
 const readStateControllerProvider = ReadStateControllerFamily._();
@@ -34,8 +35,9 @@ const readStateControllerProvider = ReadStateControllerFamily._();
 ///    lights up *background* servers;
 ///  * the gateway message handler [markUnread]s on incoming traffic for live
 ///    updates (every connection, not just the active one);
-///  * the home screen / context menu / voice panel [markRead]s the channel the
-///    user opens, which separately POSTs `channels.ack` to the server.
+///  * visible panes and explicit read actions call [acknowledge], which clears
+///    local state and queues the server read position;
+///  * [applyRemoteRead] consumes acknowledgements from other devices.
 final class ReadStateControllerProvider
     extends $NotifierProvider<ReadStateController, ReadStateSnapshot> {
   /// Client-side read/unread tracker, one instance per connected server (keyed by
@@ -48,8 +50,9 @@ final class ReadStateControllerProvider
   ///    lights up *background* servers;
   ///  * the gateway message handler [markUnread]s on incoming traffic for live
   ///    updates (every connection, not just the active one);
-  ///  * the home screen / context menu / voice panel [markRead]s the channel the
-  ///    user opens, which separately POSTs `channels.ack` to the server.
+  ///  * visible panes and explicit read actions call [acknowledge], which clears
+  ///    local state and queues the server read position;
+  ///  * [applyRemoteRead] consumes acknowledgements from other devices.
   const ReadStateControllerProvider._({
     required ReadStateControllerFamily super.from,
     required String super.argument,
@@ -95,7 +98,7 @@ final class ReadStateControllerProvider
 }
 
 String _$readStateControllerHash() =>
-    r'7e600872e2089de2b7a4cc6be94f53a349d80335';
+    r'9243ca1ffdb1d78b0a6732bd86c9330129b960ac';
 
 /// Client-side read/unread tracker, one instance per connected server (keyed by
 /// `serverKey`, i.e. `userId@baseUrl`) so snowflake IDs that collide across
@@ -107,8 +110,9 @@ String _$readStateControllerHash() =>
 ///    lights up *background* servers;
 ///  * the gateway message handler [markUnread]s on incoming traffic for live
 ///    updates (every connection, not just the active one);
-///  * the home screen / context menu / voice panel [markRead]s the channel the
-///    user opens, which separately POSTs `channels.ack` to the server.
+///  * visible panes and explicit read actions call [acknowledge], which clears
+///    local state and queues the server read position;
+///  * [applyRemoteRead] consumes acknowledgements from other devices.
 
 final class ReadStateControllerFamily extends $Family
     with
@@ -138,8 +142,9 @@ final class ReadStateControllerFamily extends $Family
   ///    lights up *background* servers;
   ///  * the gateway message handler [markUnread]s on incoming traffic for live
   ///    updates (every connection, not just the active one);
-  ///  * the home screen / context menu / voice panel [markRead]s the channel the
-  ///    user opens, which separately POSTs `channels.ack` to the server.
+  ///  * visible panes and explicit read actions call [acknowledge], which clears
+  ///    local state and queues the server read position;
+  ///  * [applyRemoteRead] consumes acknowledgements from other devices.
 
   ReadStateControllerProvider call(String serverKey) =>
       ReadStateControllerProvider._(argument: serverKey, from: this);
@@ -158,8 +163,9 @@ final class ReadStateControllerFamily extends $Family
 ///    lights up *background* servers;
 ///  * the gateway message handler [markUnread]s on incoming traffic for live
 ///    updates (every connection, not just the active one);
-///  * the home screen / context menu / voice panel [markRead]s the channel the
-///    user opens, which separately POSTs `channels.ack` to the server.
+///  * visible panes and explicit read actions call [acknowledge], which clears
+///    local state and queues the server read position;
+///  * [applyRemoteRead] consumes acknowledgements from other devices.
 
 abstract class _$ReadStateController extends $Notifier<ReadStateSnapshot> {
   late final _$args = ref.$arg as String;

--- a/lib/features/channels/controllers/read_state.g.dart
+++ b/lib/features/channels/controllers/read_state.g.dart
@@ -98,7 +98,7 @@ final class ReadStateControllerProvider
 }
 
 String _$readStateControllerHash() =>
-    r'9243ca1ffdb1d78b0a6732bd86c9330129b960ac';
+    r'd1d85ccbbda46d95b6a3b611fb237f10354f5479';
 
 /// Client-side read/unread tracker, one instance per connected server (keyed by
 /// `serverKey`, i.e. `userId@baseUrl`) so snowflake IDs that collide across

--- a/lib/features/channels/utils/mark_channel_read.dart
+++ b/lib/features/channels/utils/mark_channel_read.dart
@@ -9,11 +9,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 ///
 /// Both halves matter: the local clear hides the dot now, the ack is what stops
 /// the READY payload's `unread` array from re-lighting it on the next connect.
-/// The acked position is the newest cached message, falling back to
-/// [fallbackMessageId] (the channel's `last_message_id`) when the message cache
-/// is empty — which is the common case for a channel whose messages were never
-/// opened (any voice channel joined without its chat panel) and for a *phantom*
-/// unread whose message has since been deleted.
+/// The acked position is the newest of the cached history, gateway/READY
+/// position, and [fallbackMessageId] (the channel's `last_message_id`). Cached
+/// history may be stale after switching tabs or reconnecting, so it must never
+/// take precedence over a newer known position.
 ///
 /// [serverKey] pins the ack to a specific connection; it defaults to the active
 /// one. Pass it explicitly when the channel may live on a background server
@@ -27,16 +26,21 @@ void markChannelRead(
 }) {
   final key = serverKey ?? ref.read(connectionsControllerProvider).activeKey;
   if (key == null) return;
-  ref.read(readStateControllerProvider(key).notifier).markRead(channelId);
-
+  final tracker = ref.read(readStateControllerProvider(key).notifier);
   final messages = ref.read(accordMessagesControllerProvider(key, channelId));
-  final lastId = messages?.isNotEmpty == true
-      ? messages!.last.id
-      : fallbackMessageId;
-  if (lastId == null) return;
-  ref
-      .read(accordAuthProvider.notifier)
-      .clientForKey(key)
-      ?.channels
-      .ack(channelId, lastId);
+  final candidates = <String>[
+    if (messages?.isNotEmpty == true) messages!.last.id,
+    if (fallbackMessageId != null) fallbackMessageId,
+    if (tracker.latestMessageId(channelId) case final id?) id,
+  ]..removeWhere((id) => id.isEmpty);
+  if (candidates.isEmpty) {
+    tracker.markRead(channelId);
+    return;
+  }
+  candidates.sort(compareMessageIds);
+  tracker.acknowledge(
+    ref.read(accordAuthProvider.notifier).clientForKey(key),
+    channelId,
+    candidates.lastOrNull,
+  );
 }

--- a/lib/features/channels/utils/message_position.dart
+++ b/lib/features/channels/utils/message_position.dart
@@ -1,0 +1,11 @@
+/// Compare snowflakes without losing precision on web or ordering "10" before
+/// "9". Qualified IDs retain their domain as a tie-breaker.
+int compareMessageIds(String a, String b) {
+  final left = BigInt.tryParse(a.split('@').first);
+  final right = BigInt.tryParse(b.split('@').first);
+  if (left != null && right != null) {
+    final order = left.compareTo(right);
+    if (order != 0) return order;
+  }
+  return a.compareTo(b);
+}

--- a/lib/features/events/services/accord_event_handler.dart
+++ b/lib/features/events/services/accord_event_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/channels/controllers/accord_channels.dart';
 import 'package:bonfire/features/channels/controllers/dm_channels.dart';
 import 'package:bonfire/features/channels/controllers/open_tabs.dart';
@@ -82,6 +83,9 @@ VoidCallback handleAccordEvents(
       // and on every reconnect — this is what persists badges across a cold
       // start and what lights up servers the user hasn't opened yet.
       hydrateReadStateFromReady(ref, data, serverKey: serverKey);
+      ref
+          .read(readStateControllerProvider(serverKey).notifier)
+          .retryPending(client);
       // Presence is keyed by [serverKey] like read state, so seed it for every
       // connection too — a background server that READYs while you're looking at
       // another one used to be left permanently showing its whole roster as

--- a/lib/features/events/services/accord_message_events.dart
+++ b/lib/features/events/services/accord_message_events.dart
@@ -56,9 +56,7 @@ void bindMessageEvents(
       final isOwn = isSelf(message.authorId);
       final mentionsMe = mentionsSelf(message.mentions);
       final isVisibleChannel =
-          active &&
-          accordVisibleChannel ==
-              (serverKey: serverKey, channelId: message.channelId);
+          active && isAccordChannelVisible(serverKey, message.channelId);
       final settings = ref.read(settingsControllerProvider);
       final countsAsMention = MessageNotificationGate.countsAsMention(
         mentionsMe: mentionsMe,
@@ -157,22 +155,20 @@ void bindMessageEvents(
       // READY (a restart, or any reconnect that re-identifies). That is what
       // made a channel highlight for messages the user wrote themselves. The
       // ack also echoes to our other sessions via `read_state.update`.
-      if (isOwn) {
-        ref
-            .read(readStateControllerProvider(serverKey).notifier)
-            .markRead(message.channelId);
-        if (message.id.isNotEmpty) {
-          unawaited(client.channels.ack(message.channelId, message.id));
-        }
-      } else if (!isVisibleChannel) {
-        ref
-            .read(readStateControllerProvider(serverKey).notifier)
-            .markUnread(
-              message.channelId,
-              spaceId: message.spaceId,
-              isMention: countsAsMention,
-            );
+      final tracker = ref.read(readStateControllerProvider(serverKey).notifier);
+      final fresh = tracker.receiveMessage(message.channelId, message.id);
+      if (isOwn || isVisibleChannel) {
+        tracker.acknowledge(client, message.channelId, message.id);
+      } else if (fresh) {
+        tracker.markUnread(
+          message.channelId,
+          spaceId: message.spaceId,
+          isMention: countsAsMention,
+          messageId: message.id,
+        );
       }
+      // Keep cache updates for replays, but suppress duplicate alerts.
+      if (!fresh) return;
 
       // Mention notifications: fire for *any* mentioning message, even in
       // channels the UI hasn't opened and on servers that aren't currently
@@ -206,6 +202,9 @@ void bindMessageEvents(
         );
         final body = message.content.trim();
         showMentionNotification(
+          serverKey: serverKey,
+          channelId: message.channelId,
+          messageId: message.id,
           title: name,
           body: body.isEmpty
               ? (isDirectMessage ? 'Sent you a message' : 'mentioned you')
@@ -220,7 +219,11 @@ void bindMessageEvents(
       // (only the active connection owns the visible-channel pointer).
       // A DM chimes like a mention: it is addressed to you, so it should be
       // heard even while the window is focused on something else (#326).
-      if (settings.soundsEnabled && !spaceMuted && !isOwn) {
+      if (settings.soundsEnabled &&
+          !spaceMuted &&
+          !isOwn &&
+          settings.channelNotificationLevel(serverKey, message.channelId) !=
+              'nothing') {
         soundManager.playForMessage(
           isMention: countsAsMention || isDirectMessage,
           isVisibleChannel: isVisibleChannel,
@@ -487,9 +490,11 @@ void bindMessageEvents(
     client.onReadStateUpdate.listen((data) {
       final channelId = data['channel_id']?.toString();
       if (channelId == null || channelId.isEmpty) return;
+      final messageId = data['last_read_message_id']?.toString();
+      if (messageId == null || messageId.isEmpty) return;
       ref
           .read(readStateControllerProvider(serverKey).notifier)
-          .markRead(channelId);
+          .applyRemoteRead(channelId, messageId);
     }),
   );
 

--- a/lib/features/events/services/accord_ready_sync.dart
+++ b/lib/features/events/services/accord_ready_sync.dart
@@ -76,6 +76,8 @@ void hydrateReadStateFromReady(
         channelId: channelId,
         spaceId: (spaceId != null && spaceId.isNotEmpty) ? spaceId : null,
         mentions: mentions,
+        lastMessageId: e['last_message_id']?.toString(),
+        lastReadMessageId: e['last_read_message_id']?.toString(),
       ),
     );
   }

--- a/lib/features/messaging/controllers/accord_messages.dart
+++ b/lib/features/messaging/controllers/accord_messages.dart
@@ -8,7 +8,7 @@ import 'package:bonfire/shared/utils/list_ext.dart';
 import 'package:bonfire/features/messaging/utils/send_cooldown.dart';
 import 'package:bonfire/shared/utils/rest_result_ext.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'accord_messages.g.dart';
@@ -25,6 +25,14 @@ final Set<ServerChannelKey> activeMessageChannels = <ServerChannelKey>{};
 /// consults this to avoid raising a notification for a message in the channel
 /// that's already on screen. Set by the home screen as the selection changes.
 ServerChannelKey? accordVisibleChannel;
+
+bool isAccordChannelVisible(String serverKey, String channelId) {
+  if (accordVisibleChannel != (serverKey: serverKey, channelId: channelId)) {
+    return false;
+  }
+  final lifecycle = WidgetsBinding.instance.lifecycleState;
+  return lifecycle == null || lifecycle == AppLifecycleState.resumed;
+}
 
 /// Whether this channel's history fetch failed, so the message pane can offer a
 /// retry instead of spinning forever. The [LoadFailed] flag for this cache —

--- a/lib/features/messaging/views/message_pane/message_pane.dart
+++ b/lib/features/messaging/views/message_pane/message_pane.dart
@@ -14,6 +14,8 @@ import 'package:accordkit/accordkit.dart';
 import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
 import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/muted_channels.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/channels/utils/toggle_channel_mute.dart';
 import 'package:bonfire/features/member/controllers/accord_members.dart';
 import 'package:bonfire/features/member/utils/member_display.dart';
@@ -149,6 +151,28 @@ class MessagePane extends ConsumerStatefulWidget {
 }
 
 class _MessagePaneState extends ConsumerState<MessagePane> {
+  AppLifecycleListener? _readLifecycle;
+  bool _readScheduled = false;
+
+  void _scheduleRead() {
+    if (_readScheduled) return;
+    _readScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _readScheduled = false;
+      if (!mounted) return;
+      final key = ref.readActiveServerKey();
+      final id = widget.channelId;
+      if (key == null || id == null || !isAccordChannelVisible(key, id)) return;
+      if (ModalRoute.of(context)?.isCurrent == false) return;
+      markChannelRead(
+        ref,
+        id,
+        serverKey: key,
+        fallbackMessageId: widget.channel?.lastMessageId,
+      );
+    });
+  }
+
   AccordMessage? _replyTo;
   final ScrollController _scroll = ScrollController();
 
@@ -163,6 +187,12 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
   void initState() {
     super.initState();
     _scroll.addListener(_onScroll);
+    _readLifecycle = AppLifecycleListener(
+      onResume: () {
+        _scheduleRead();
+        WidgetsBinding.instance.scheduleFrame();
+      },
+    );
   }
 
   @override
@@ -246,6 +276,7 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
   @override
   void dispose() {
     _scroll.removeListener(_onScroll);
+    _readLifecycle?.dispose();
     _scroll.dispose();
     super.dispose();
   }
@@ -313,6 +344,15 @@ class _MessagePaneState extends ConsumerState<MessagePane> {
           style: Theme.of(context).textTheme.bodyMedium,
         ),
       );
+    }
+
+    final serverKey = ref.watchActiveServerKey();
+    if (serverKey != null) {
+      ref.listen(
+        readStateControllerProvider(serverKey),
+        (_, _) => _scheduleRead(),
+      );
+      _scheduleRead();
     }
 
     // In panel mode this pane *is* the voice view's chat panel — delegating

--- a/lib/features/notifications/services/notification.dart
+++ b/lib/features/notifications/services/notification.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/features/channels/utils/message_position.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -14,6 +15,37 @@ const _androidChannel = AndroidNotificationChannel(
 
 bool _initialized = false;
 bool _permissionRequested = false;
+int _nextNotificationId = DateTime.now().millisecondsSinceEpoch.remainder(
+  100000,
+);
+final _messageNotifications =
+    <int, ({String serverKey, String channelId, String messageId})>{};
+
+/// Remove delivered banners when this channel is read here or on another device.
+Future<void> dismissReadNotifications({
+  required String serverKey,
+  required String channelId,
+  String? messageId,
+}) async {
+  final ids = _messageNotifications.entries
+      .where(
+        (entry) =>
+            entry.value.serverKey == serverKey &&
+            entry.value.channelId == channelId &&
+            (messageId == null ||
+                compareMessageIds(entry.value.messageId, messageId) <= 0),
+      )
+      .map((entry) => entry.key)
+      .toList();
+  for (final id in ids) {
+    _messageNotifications.remove(id);
+    try {
+      await flutterLocalNotificationsPlugin.cancel(id);
+    } catch (error) {
+      debugPrint('Failed to dismiss notification: $error');
+    }
+  }
+}
 
 /// Initializes local notifications for every supported platform. No-ops on web
 /// (the plugin is unsupported there).
@@ -49,9 +81,10 @@ Future<void> initializeNotifications() async {
 
   await flutterLocalNotificationsPlugin.initialize(initializationSettings);
 
-  final androidPlugin =
-      flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>();
+  final androidPlugin = flutterLocalNotificationsPlugin
+      .resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin
+      >();
   await androidPlugin?.createNotificationChannel(_androidChannel);
 
   _initialized = true;
@@ -102,6 +135,9 @@ Future<void> requestNotificationPermissions() async {
 Future<void> showMentionNotification({
   required String title,
   required String body,
+  required String serverKey,
+  required String channelId,
+  required String messageId,
 }) async {
   if (UniversalPlatform.isWeb || !_initialized) return;
 
@@ -118,7 +154,20 @@ Future<void> showMentionNotification({
     linux: LinuxNotificationDetails(),
   );
 
-  // A rolling id keeps successive notifications from overwriting each other.
-  final id = DateTime.now().millisecondsSinceEpoch.remainder(100000);
-  await flutterLocalNotificationsPlugin.show(id, title, body, details);
+  final id = _nextNotificationId++;
+  _messageNotifications[id] = (
+    serverKey: serverKey,
+    channelId: channelId,
+    messageId: messageId,
+  );
+  try {
+    await flutterLocalNotificationsPlugin.show(id, title, body, details);
+    // A read event may race the platform's asynchronous delivery.
+    if (!_messageNotifications.containsKey(id)) {
+      await flutterLocalNotificationsPlugin.cancel(id);
+    }
+  } catch (error) {
+    _messageNotifications.remove(id);
+    debugPrint('Failed to show notification: $error');
+  }
 }

--- a/lib/features/spaces/views/accord_home.dart
+++ b/lib/features/spaces/views/accord_home.dart
@@ -167,6 +167,7 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
   @override
   void dispose() {
     mcpHomeBridge.clear();
+    accordVisibleChannel = null;
     super.dispose();
   }
 
@@ -569,9 +570,11 @@ class _AccordHomeScreenState extends ConsumerState<AccordHomeScreen> {
     }
 
     // Let the notification layer skip the channel that's on screen.
-    accordVisibleChannel = activeKey == null || shownChannelId == null
-        ? null
-        : (serverKey: activeKey, channelId: shownChannelId);
+    if (ModalRoute.of(context)?.isCurrent != false) {
+      accordVisibleChannel = activeKey == null || shownChannelId == null
+          ? null
+          : (serverKey: activeKey, channelId: shownChannelId);
+    }
 
     mcpHomeBridge.setStateReader(
       () => (

--- a/lib/features/user/views/accord_direct_messages_conversations.dart
+++ b/lib/features/user/views/accord_direct_messages_conversations.dart
@@ -626,18 +626,6 @@ class _DmConversationState extends ConsumerState<_DmConversation> {
         }
       },
     );
-    ref.listen<List<AccordMessage>?>(
-      accordMessagesControllerProvider(_serverKey, _channel.id),
-      (previous, next) {
-        if (next == null || next.isEmpty) return;
-        markChannelRead(
-          ref,
-          _channel.id,
-          serverKey: _serverKey,
-          fallbackMessageId: next.last.id,
-        );
-      },
-    );
     // The home route remains mounted beneath this dialog and may rebuild while
     // it is open. Reassert the modal conversation as the visible channel so its
     // incoming messages do not produce unread badges/notifications.

--- a/test/features/channels/global_unread_test.dart
+++ b/test/features/channels/global_unread_test.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/shared/models/server_entity_key.dart';
 import 'package:bonfire/features/authentication/models/accord_session.dart';
 import 'package:bonfire/features/channels/controllers/global_unread.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
@@ -12,9 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 // Helpers
 // ---------------------------------------------------------------------------
 
-ReadStateSnapshot _snapshot(List<ReadEntry> entries) => ReadStateSnapshot(
-      entries: {for (final e in entries) e.channelId: e},
-    );
+ReadStateSnapshot _snapshot(List<ReadEntry> entries) =>
+    ReadStateSnapshot(entries: {for (final e in entries) e.channelId: e});
 
 /// Keeps the aggregator off Hive (the real settings controller reads the
 /// `accord-settings` box in `build`) while still allowing mid-test mutes.
@@ -42,11 +42,11 @@ ProviderContainer _container({AccordSettings? settings}) {
 }
 
 AccordSession _session(String userId, String baseUrl) => AccordSession(
-      server: AccordServer.fromBaseUrl(baseUrl),
-      token: 't',
-      userId: userId,
-      username: userId,
-    );
+  server: AccordServer.fromBaseUrl(baseUrl),
+  token: 't',
+  userId: userId,
+  username: userId,
+);
 
 /// Registers [baseUrl] as a connection and returns its `serverKey`.
 String _connect(ProviderContainer c, String userId, String baseUrl) {
@@ -79,7 +79,10 @@ void _markUnread(
 void main() {
   group('foldGlobalUnread', () {
     test('nothing unread anywhere is empty', () {
-      final unread = foldGlobalUnread([_snapshot(const []), _snapshot(const [])]);
+      final unread = foldGlobalUnread([
+        _snapshot(const []),
+        _snapshot(const []),
+      ]);
       expect(unread, GlobalUnread.none);
       expect(unread.isEmpty, isTrue);
     });
@@ -243,7 +246,9 @@ void main() {
       _markUnread(container, key, 'c2', spaceId: 's1');
       expect(container.read(globalUnreadProvider).isEmpty, isFalse);
 
-      final notifier = container.read(readStateControllerProvider(key).notifier);
+      final notifier = container.read(
+        readStateControllerProvider(key).notifier,
+      );
       notifier.markRead('c1');
       expect(
         container.read(globalUnreadProvider),
@@ -255,10 +260,12 @@ void main() {
     });
 
     test('honours the mute settings live, in both directions', () {
-      final container = _container(
-        settings: const AccordSettings(mutedSpaces: ['s1']),
+      final key = _session('u1', 'a.test').key;
+      final muted = AccordSettings(
+        mutedSpaces: [ServerEntityKey(key, 's1').encoded],
       );
-      final key = _connect(container, 'u1', 'a.test');
+      final container = _container(settings: muted);
+      _connect(container, 'u1', 'a.test');
       // Kept alive so the provider recomputes on settings changes rather than
       // only when read.
       container.listen(globalUnreadProvider, (_, _) {});
@@ -277,8 +284,28 @@ void main() {
         const GlobalUnread(hasUnread: true, mentionCount: 4),
       );
 
-      settings.set(const AccordSettings(mutedSpaces: ['s1']));
+      settings.set(muted);
       expect(container.read(globalUnreadProvider), GlobalUnread.none);
+    });
+
+    test('mute overrides apply only to the owning server', () {
+      final a = _session('u1', 'a.test').key;
+      final b = _session('u2', 'b.test').key;
+      final container = _container(
+        settings: AccordSettings(
+          channelNotifications: {ServerEntityKey(a, 'c1').encoded: 'nothing'},
+          mutedSpaces: [ServerEntityKey(b, 's2').encoded],
+        ),
+      );
+      _connect(container, 'u1', 'a.test');
+      _connect(container, 'u2', 'b.test');
+      _markUnread(container, a, 'c1', spaceId: 's1', mentions: 2);
+      _markUnread(container, b, 'c1', spaceId: 's1', mentions: 3);
+      _markUnread(container, b, 'c2', spaceId: 's2', mentions: 4);
+      expect(
+        container.read(globalUnreadProvider),
+        const GlobalUnread(hasUnread: true, mentionCount: 3),
+      );
     });
 
     test('a disconnected server stops contributing', () {

--- a/test/features/channels/mark_channel_read_test.dart
+++ b/test/features/channels/mark_channel_read_test.dart
@@ -42,14 +42,13 @@ void _seedUnread(WidgetRef ref, String serverKey, String channelId) =>
         .read(readStateControllerProvider(serverKey).notifier)
         .markUnread(channelId, spaceId: 's1');
 
-Future<void> _settle() => Future<void>.delayed(Duration.zero);
-
 /// A minimal logged-in [AccordAuth] override whose [clientForKey] resolves
 /// only [key] to [client] — enough to exercise the REST ack without a real
 /// connection/session.
 class _Auth extends AccordAuth {
   _Auth(this.key, this.client);
   final String key;
+  @override
   final AccordClient client;
 
   @override
@@ -175,7 +174,7 @@ void main() {
             .markUnread('c1', spaceId: 's1', messageId: '20');
 
         markChannelRead(ref, 'c1', serverKey: key, fallbackMessageId: '5');
-        await _settle();
+        await tester.pump();
 
         expect(acked, ['20']);
         expect(_isUnread(ref, key, 'c1'), isFalse);

--- a/test/features/channels/mark_channel_read_test.dart
+++ b/test/features/channels/mark_channel_read_test.dart
@@ -1,9 +1,16 @@
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
 import 'package:bonfire/features/channels/utils/mark_channel_read.dart';
 import 'package:bonfire/features/server/controllers/connections.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -34,6 +41,45 @@ void _seedUnread(WidgetRef ref, String serverKey, String channelId) =>
     ref
         .read(readStateControllerProvider(serverKey).notifier)
         .markUnread(channelId, spaceId: 's1');
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+/// A minimal logged-in [AccordAuth] override whose [clientForKey] resolves
+/// only [key] to [client] — enough to exercise the REST ack without a real
+/// connection/session.
+class _Auth extends AccordAuth {
+  _Auth(this.key, this.client);
+  final String key;
+  final AccordClient client;
+
+  @override
+  AccordAuthState build() => const AccordAuthLoggedOut();
+
+  @override
+  AccordClient? clientForKey(String k) => k == key ? client : null;
+}
+
+/// Like [_pumpRef], but with a live [AccordClient] wired to [key] so
+/// acknowledgements actually reach the (mocked) REST layer.
+Future<WidgetRef> _pumpRefWithClient(
+  WidgetTester tester, {
+  required String key,
+  required AccordClient client,
+}) async {
+  late WidgetRef ref;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [accordAuthProvider.overrideWith(() => _Auth(key, client))],
+      child: Consumer(
+        builder: (context, r, _) {
+          ref = r;
+          return const SizedBox();
+        },
+      ),
+    ),
+  );
+  return ref;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -101,6 +147,38 @@ void main() {
 
         expect(_isUnread(ref, pinnedKey, 'c1'), isFalse);
         expect(_isUnread(ref, activeKey, 'c1'), isTrue);
+      },
+    );
+
+    testWidgets(
+      'acknowledges the newest of tracker position and fallback, not a '
+      'stale fallback',
+      (tester) async {
+        final acked = <String>[];
+        final client = AccordClient(
+          baseUrl: 'https://example.test',
+          httpClient: MockClient((request) async {
+            if (request.url.path.endsWith('/ack')) {
+              acked.add(jsonDecode(request.body)['message_id'] as String);
+            }
+            return http.Response('{"data":null}', 200);
+          }),
+        );
+        addTearDown(client.dispose);
+        const key = 'u1@server.test';
+        final ref = await _pumpRefWithClient(tester, key: key, client: client);
+
+        // The gateway already advanced the tracker past the stale
+        // `last_message_id` fallback the caller happens to pass in.
+        ref
+            .read(readStateControllerProvider(key).notifier)
+            .markUnread('c1', spaceId: 's1', messageId: '20');
+
+        markChannelRead(ref, 'c1', serverKey: key, fallbackMessageId: '5');
+        await _settle();
+
+        expect(acked, ['20']);
+        expect(_isUnread(ref, key, 'c1'), isFalse);
       },
     );
   });

--- a/test/features/channels/read_state_sync_test.dart
+++ b/test/features/channels/read_state_sync_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  late ProviderContainer container;
+  late ReadStateController reads;
+  const provider = readStateControllerProvider;
+  setUp(() {
+    container = ProviderContainer();
+    reads = container.read(provider('server').notifier);
+  });
+  tearDown(() => container.dispose());
+
+  ReadStateSnapshot snapshot() => container.read(provider('server'));
+  void receive(String id, {bool mention = true}) {
+    if (reads.receiveMessage('channel', id)) {
+      reads.markUnread('channel', messageId: id, isMention: mention);
+    }
+  }
+
+  AccordClient client(Future<http.Response> Function(http.Request) handler) {
+    final result = AccordClient(
+      baseUrl: 'https://example.test',
+      httpClient: MockClient(handler),
+    );
+    addTearDown(result.dispose);
+    return result;
+  }
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  test('replay cannot double-count mentions or undo a remote read', () {
+    receive('10');
+    receive('10');
+    expect(snapshot().mentionCount('channel'), 1);
+    reads.applyRemoteRead('channel', '10');
+    expect(snapshot().isUnread('channel'), isFalse);
+    expect(reads.receiveMessage('channel', '10'), isFalse);
+    receive('11');
+    expect(snapshot().mentionCount('channel'), 1);
+  });
+
+  test('delayed remote acknowledgement preserves newer mentions', () {
+    receive('9');
+    receive('10');
+    reads.applyRemoteRead('channel', '9');
+    expect(snapshot().isUnread('channel'), isTrue);
+    expect(snapshot().mentionCount('channel'), 1);
+    reads.applyRemoteRead('channel', '8');
+    expect(snapshot().mentionCount('channel'), 1);
+    reads.applyRemoteRead('channel', '10');
+    expect(snapshot().isUnread('channel'), isFalse);
+  });
+
+  test('READY positions suppress replay and retain newer unread', () {
+    reads.hydrate(const [
+      ReadEntry(
+        channelId: 'channel',
+        lastMessageId: '20',
+        lastReadMessageId: '10',
+        mentions: 2,
+      ),
+    ]);
+    expect(reads.receiveMessage('channel', '20'), isFalse);
+    reads.applyRemoteRead('channel', '15');
+    expect(snapshot().isUnread('channel'), isTrue);
+    reads.applyRemoteRead('channel', '20');
+    expect(snapshot().isUnread('channel'), isFalse);
+  });
+
+  test(
+    'acknowledgements serialize and coalesce to the newest message',
+    () async {
+      final requests = <String>[];
+      final first = Completer<http.Response>();
+      final api = client((request) async {
+        requests.add(jsonDecode(request.body)['message_id'] as String);
+        if (requests.length == 1) return first.future;
+        return http.Response('{"data":null}', 200);
+      });
+      receive('9');
+      reads.acknowledge(api, 'channel', '9');
+      reads.acknowledge(api, 'channel', '10');
+      reads.acknowledge(api, 'channel', '11');
+      await settle();
+      expect(requests, ['9']);
+      first.complete(http.Response('{"data":null}', 200));
+      await settle();
+      expect(requests, ['9', '11']);
+      reads.acknowledge(api, 'channel', '10');
+      reads.acknowledge(api, 'channel', '11');
+      await settle();
+      expect(requests, ['9', '11']);
+    },
+  );
+
+  test('failed ack retries on reconnect and stale READY stays read', () async {
+    var fail = true;
+    final requests = <String>[];
+    final api = client((request) async {
+      requests.add(jsonDecode(request.body)['message_id'] as String);
+      return http.Response('{"data":null}', fail ? 403 : 200);
+    });
+    receive('20');
+    reads.acknowledge(api, 'channel', '20');
+    await settle();
+    reads.hydrate(const [
+      ReadEntry(
+        channelId: 'channel',
+        lastMessageId: '20',
+        lastReadMessageId: '10',
+      ),
+    ]);
+    expect(snapshot().isUnread('channel'), isFalse);
+    fail = false;
+    reads.retryPending(api);
+    await settle();
+    expect(requests, ['20', '20']);
+    reads.hydrate(const [
+      ReadEntry(
+        channelId: 'channel',
+        lastMessageId: '21',
+        lastReadMessageId: '20',
+      ),
+    ]);
+    expect(snapshot().isUnread('channel'), isTrue);
+  });
+
+  test('snowflakes compare exactly across digit lengths and web precision', () {
+    expect(compareMessageIds('10', '9'), greaterThan(0));
+    expect(
+      compareMessageIds('9007199254740993', '9007199254740992'),
+      greaterThan(0),
+    );
+  });
+}

--- a/test/features/events/read_state_events_test.dart
+++ b/test/features/events/read_state_events_test.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/events/services/accord_event_handler.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+class _Client extends AccordClient {
+  _Client(List<String> acks)
+    : super(
+        baseUrl: 'https://example.test',
+        httpClient: MockClient((request) async {
+          if (request.url.path.endsWith('/ack')) {
+            acks.add(jsonDecode(request.body)['message_id'] as String);
+          }
+          return http.Response('{"data":[]}', 200);
+        }),
+      );
+  final messageEvents = StreamController<AccordMessage>.broadcast();
+  final reads = StreamController<Map<String, dynamic>>.broadcast();
+  @override
+  Stream<AccordMessage> get onMessageCreate => messageEvents.stream;
+  @override
+  Stream<Map<String, dynamic>> get onReadStateUpdate => reads.stream;
+}
+
+class _Settings extends SettingsController {
+  @override
+  AccordSettings build() =>
+      const AccordSettings(notificationsEnabled: false, soundsEnabled: false);
+}
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  late _Client client;
+  late ProviderContainer container;
+  late List<String> acks;
+  var active = true;
+  const key = 'self@https://example.test';
+  const channel = 'channel';
+  setUp(() {
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    active = true;
+    acks = [];
+    client = _Client(acks);
+    container = ProviderContainer(
+      overrides: [settingsControllerProvider.overrideWith(_Settings.new)],
+    );
+    final handler = Provider<void>((ref) {
+      final dispose = handleAccordEvents(
+        ref,
+        client,
+        serverKey: key,
+        currentUserId: 'self',
+        selfDomain: 'example.test',
+        isActive: () => active,
+      );
+      ref.onDispose(dispose);
+    });
+    container.read(handler);
+    accordVisibleChannel = (serverKey: key, channelId: channel);
+  });
+  tearDown(() async {
+    accordVisibleChannel = null;
+    container.dispose();
+    await client.messageEvents.close();
+    await client.reads.close();
+    client.dispose();
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  });
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+  ReadStateSnapshot snapshot() =>
+      container.read(readStateControllerProvider(key));
+  void message(String id) => client.messageEvents.add(
+    AccordMessage(
+      id: id,
+      channelId: channel,
+      spaceId: 'space',
+      authorId: 'other',
+      mentions: ['self'],
+    ),
+  );
+
+  test(
+    'live messages in the viewed channel ack the actual message ID',
+    () async {
+      message('10');
+      await settle();
+      expect(acks, ['10']);
+      expect(snapshot().isUnread(channel), isFalse);
+      accordVisibleChannel = null;
+      message('10');
+      await settle();
+      expect(snapshot().isUnread(channel), isFalse);
+      message('11');
+      await settle();
+      expect(snapshot().mentionCount(channel), 1);
+    },
+  );
+
+  test('an inactive device leaves its selected channel unread', () async {
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    message('10');
+    await settle();
+    expect(acks, isEmpty);
+    expect(snapshot().mentionCount(channel), 1);
+  });
+
+  test('background-server remote reads retain newer unread messages', () async {
+    active = false;
+    message('10');
+    message('11');
+    await settle();
+    client.reads.add({'channel_id': channel, 'last_read_message_id': '10'});
+    await settle();
+    expect(snapshot().mentionCount(channel), 1);
+    client.reads.add({'channel_id': channel, 'last_read_message_id': '11'});
+    await settle();
+    expect(snapshot().isUnread(channel), isFalse);
+    message('11');
+    await settle();
+    expect(snapshot().isUnread(channel), isFalse);
+    expect(acks, isEmpty);
+  });
+}

--- a/test/features/messaging/message_pane_read_test.dart
+++ b/test/features/messaging/message_pane_read_test.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:accordkit/accordkit.dart';
+import 'package:bonfire/features/authentication/models/accord_auth_state.dart';
+import 'package:bonfire/features/authentication/models/accord_session.dart';
+import 'package:bonfire/features/authentication/repositories/accord_auth.dart';
+import 'package:bonfire/features/channels/controllers/read_state.dart';
+import 'package:bonfire/features/messaging/controllers/accord_messages.dart';
+import 'package:bonfire/features/messaging/views/message_pane/message_pane.dart';
+import 'package:bonfire/features/server/controllers/connections.dart';
+import 'package:bonfire/features/server/models/accord_server.dart';
+import 'package:bonfire/features/settings/controllers/settings.dart';
+import 'package:bonfire/features/settings/models/accord_settings.dart';
+import 'package:bonfire/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+class _Auth extends AccordAuth {
+  _Auth(this.auth);
+  final AccordAuthLoggedIn auth;
+  @override
+  AccordAuthState build() => auth;
+  @override
+  AccordClient? clientForKey(String key) =>
+      key == auth.session.key ? auth.client : null;
+}
+
+class _Settings extends SettingsController {
+  @override
+  AccordSettings build() => const AccordSettings();
+}
+
+void main() {
+  testWidgets(
+    'history load and app resume advance the visible channel read position',
+    (tester) async {
+      final acks = <String>[];
+      final history = Completer<http.Response>();
+      final server = AccordServer.fromBaseUrl('https://example.test');
+      final client = AccordClient(
+        baseUrl: server.baseUrl,
+        httpClient: MockClient((request) async {
+          if (request.url.path.endsWith('/messages')) return history.future;
+          if (request.url.path.endsWith('/ack')) {
+            acks.add(jsonDecode(request.body)['message_id'] as String);
+          }
+          return http.Response('{"data":[]}', 200);
+        }),
+      );
+      final session = AccordSession(
+        server: server,
+        token: 'test',
+        userId: 'self',
+        username: 'Self',
+      );
+      final key = session.key;
+      final container = ProviderContainer(
+        overrides: [
+          accordAuthProvider.overrideWith(
+            () => _Auth(AccordAuthLoggedIn(client: client, session: session)),
+          ),
+          settingsControllerProvider.overrideWith(_Settings.new),
+        ],
+      );
+      addTearDown(() {
+        accordVisibleChannel = null;
+        container.dispose();
+        client.dispose();
+      });
+      container.read(connectionsControllerProvider.notifier).register(session);
+      container.read(connectionsControllerProvider.notifier).setActive(key);
+      accordVisibleChannel = (serverKey: key, channelId: 'channel');
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final reads = container.read(readStateControllerProvider(key).notifier);
+      reads.hydrate(const [
+        ReadEntry(channelId: 'channel', lastMessageId: '10'),
+      ]);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: buildAppTheme(AppThemePreset.dark),
+            home: const Scaffold(
+              body: MessagePane(
+                channel: null,
+                channelId: 'channel',
+                spaceId: null,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(acks, ['10']);
+      history.complete(
+        http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': '20',
+                'channel_id': 'channel',
+                'author_id': 'self',
+                'content': 'Newest message',
+                'timestamp': '2026-09-07T12:00:00Z',
+              },
+            ],
+          }),
+          200,
+        ),
+      );
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      expect(acks, ['10', '20']);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      reads.receiveMessage('channel', '21');
+      reads.markUnread('channel', messageId: '21', isMention: true);
+      container
+          .read(accordMessagesControllerProvider(key, 'channel').notifier)
+          .addMessage(
+            AccordMessage(
+              id: '21',
+              channelId: 'channel',
+              authorId: 'self',
+              content: 'While away',
+            ),
+          );
+      await tester.pump();
+      expect(acks, ['10', '20']);
+      expect(
+        container.read(readStateControllerProvider(key)).isUnread('channel'),
+        isTrue,
+      );
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump();
+      expect(acks, ['10', '20', '21']);
+      expect(
+        container.read(readStateControllerProvider(key)).isUnread('channel'),
+        isFalse,
+      );
+      await tester.pumpWidget(const SizedBox());
+    },
+  );
+}

--- a/test/features/notifications/notification_read_test.dart
+++ b/test/features/notifications/notification_read_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:bonfire/features/notifications/services/notification.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('dexterous.com/flutter/local_notifications');
+  final calls = <MethodCall>[];
+  Completer<void>? delivery;
+
+  setUp(() async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          if (call.method == 'show') await delivery?.future;
+          return true;
+        });
+    await initializeNotifications();
+    calls.clear();
+  });
+  tearDown(() async {
+    delivery = null;
+    for (final key in ['a', 'b']) {
+      await dismissReadNotifications(serverKey: key, channelId: 'channel');
+    }
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  Future<void> show(String key, String id) => showMentionNotification(
+    title: 'Mention',
+    body: 'Hello',
+    serverKey: key,
+    channelId: 'channel',
+    messageId: id,
+  );
+
+  test(
+    'reading dismisses only older notifications on the matching server',
+    () async {
+      await show('a', '9');
+      await show('a', '10');
+      await show('b', '9');
+      final shown = calls.where((call) => call.method == 'show').toList();
+      final ids = shown.map((call) => (call.arguments as Map)['id']).toList();
+      expect(ids.toSet().length, 3);
+      calls.clear();
+      await dismissReadNotifications(
+        serverKey: 'a',
+        channelId: 'channel',
+        messageId: '9',
+      );
+      expect(
+        calls
+            .where((call) => call.method == 'cancel')
+            .map((call) => (call.arguments as Map)['id']),
+        [ids.first],
+      );
+    },
+  );
+
+  test(
+    'a read racing notification delivery still removes the banner',
+    () async {
+      delivery = Completer<void>();
+      final showing = show('a', '20');
+      await Future<void>.delayed(Duration.zero);
+      await dismissReadNotifications(
+        serverKey: 'a',
+        channelId: 'channel',
+        messageId: '20',
+      );
+      delivery!.complete();
+      await showing;
+      expect(calls.where((call) => call.method == 'cancel').length, 2);
+    },
+  );
+}

--- a/test/features/notifications/taskbar_badge_test.dart
+++ b/test/features/notifications/taskbar_badge_test.dart
@@ -1,3 +1,4 @@
+import 'package:bonfire/shared/models/server_entity_key.dart';
 import 'package:bonfire/features/authentication/models/accord_session.dart';
 import 'package:bonfire/features/channels/controllers/global_unread.dart';
 import 'package:bonfire/features/channels/controllers/read_state.dart';
@@ -32,9 +33,9 @@ void main() {
     calls = [];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(taskbarBadgeChannel, (call) async {
-      calls.add(call);
-      return null;
-    });
+          calls.add(call);
+          return null;
+        });
   });
 
   tearDown(() {
@@ -134,10 +135,9 @@ void main() {
 
       // A second unread channel with no mention leaves the badge identical, so
       // the platform is not touched again.
-      c.read(readStateControllerProvider(key).notifier).markUnread(
-            'c2',
-            spaceId: 's1',
-          );
+      c
+          .read(readStateControllerProvider(key).notifier)
+          .markUnread('c2', spaceId: 's1');
       await settle();
       expect(calls.length, 1);
 
@@ -156,7 +156,9 @@ void main() {
     test('muted spaces never reach the platform', () async {
       if (!taskbarBadgeSupported) return;
       final c = container(
-        settings: const AccordSettings(mutedSpaces: ['s1']),
+        settings: AccordSettings(
+          mutedSpaces: [ServerEntityKey('u1@https://a.test', 's1').encoded],
+        ),
       );
       final key = connect(c);
       c.listen(taskbarBadgeControllerProvider, (_, _) {});


### PR DESCRIPTION
Read acknowledgements can be lost or arrive out of order, causing channels and notifications to light up again after reconnecting or reading on another device. Add per-connection read cursors and serialized, coalesced acknowledgement retries; acknowledge focused visible panes after history loads and on resume; suppress replayed alerts and dismiss delivered banners through the acknowledged position.

Recover the existing read-synchronization work onto current master, adapting it to the split message/READY event handlers. Preserve the merged own-message acknowledgements and direct-message notification behavior. Global badges now use server-qualified mute settings.

Validation: all 1,410 Flutter tests pass, including own-message, DM call/PiP, inactive-app, replay, partial remote-read, retry, and notification-delivery race coverage. Static analysis and deterministic generated-code checks pass.

Pending acknowledgements and notification associations remain in memory; process termination can lose an unsent acknowledgement. Physical multi-device/native-notification checks and the historical server-side mention-count follow-up are documented in docs/notification-read-state-audit.md.
