### PR TITLE
fix(members): use space metadata for roster counts

### DIFF
--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -58,19 +58,19 @@ class _Roster extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final members = ref.watch(accordMembersControllerProvider(ref.readActiveServerKey() ?? '', spaceId));
-    final roles = ref.watch(
-      spacesControllerProvider.select(
-        (spaces) =>
-            spaces?.firstWhereOrNull((s) => s.id == spaceId)?.roles ??
-            const <AccordRole>[],
-      ),
-    );
-    final counts = ref.watch(
+    // One selector for everything read off the cached space, so a rebuild
+    // only walks spacesControllerProvider's list once instead of twice.
+    final spaceInfo = ref.watch(
       spacesControllerProvider.select((spaces) {
         final space = spaces?.firstWhereOrNull((s) => s.id == spaceId);
-        return (members: space?.memberCount, presences: space?.presenceCount);
+        return (
+          roles: space?.roles ?? const <AccordRole>[],
+          memberCount: space?.memberCount,
+          presenceCount: space?.presenceCount,
+        );
       }),
     );
+    final roles = spaceInfo.roles;
     final cdnUrl = ref.watchCdnUrl();
     final presences = ref.watch(activePresencesProvider);
 
@@ -111,8 +111,8 @@ class _Roster extends ConsumerWidget {
       members.values.toList(),
       roles,
       presences,
-      memberCount: counts.members,
-      presenceCount: counts.presences,
+      memberCount: spaceInfo.memberCount,
+      presenceCount: spaceInfo.presenceCount,
     );
 
     // Flatten sections into one lazily-built row list so a large roster only
@@ -255,7 +255,6 @@ class _SectionHeader extends StatelessWidget {
     );
   }
 }
-
 
 class _MemberRow extends ConsumerWidget {
   const _MemberRow({

--- a/lib/features/member/views/accord_member_list.dart
+++ b/lib/features/member/views/accord_member_list.dart
@@ -65,6 +65,12 @@ class _Roster extends ConsumerWidget {
             const <AccordRole>[],
       ),
     );
+    final counts = ref.watch(
+      spacesControllerProvider.select((spaces) {
+        final space = spaces?.firstWhereOrNull((s) => s.id == spaceId);
+        return (members: space?.memberCount, presences: space?.presenceCount);
+      }),
+    );
     final cdnUrl = ref.watchCdnUrl();
     final presences = ref.watch(activePresencesProvider);
 
@@ -101,14 +107,22 @@ class _Roster extends ConsumerWidget {
       return const LoadingView();
     }
 
-    final sections = _buildSections(members.values.toList(), roles, presences);
+    final sections = _buildSections(
+      members.values.toList(),
+      roles,
+      presences,
+      memberCount: counts.members,
+      presenceCount: counts.presences,
+    );
 
     // Flatten sections into one lazily-built row list so a large roster only
     // materializes the rows on screen.
     final rows = <Widget Function()>[
       for (final section in sections) ...[
-        () =>
-            _SectionHeader(label: section.label, count: section.members.length),
+        () => _SectionHeader(
+          label: section.label,
+          count: section.count ?? section.members.length,
+        ),
         for (final member in section.members)
           () => _MemberRow(
             member: member,
@@ -138,6 +152,7 @@ class _RosterSection {
   /// it always sorts last.
   final int position;
   final List<AccordMember> members;
+  int? count;
 }
 
 const int _defaultPosition = -1;
@@ -150,8 +165,10 @@ const int _offlinePosition = -2;
 List<_RosterSection> _buildSections(
   List<AccordMember> members,
   List<AccordRole> roles,
-  PresenceMap presences,
-) {
+  PresenceMap presences, {
+  Object? memberCount,
+  Object? presenceCount,
+}) {
   final byKey = <String, _RosterSection>{};
   final defaultSection = _RosterSection(
     label: 'Members',
@@ -179,10 +196,16 @@ List<_RosterSection> _buildSections(
     section.members.add(member);
   }
 
+  offlineSection.count = rosterOfflineCount(
+    memberCount: memberCount,
+    presenceCount: presenceCount,
+    loadedOfflineCount: offlineSection.members.length,
+  );
+
   final sections = byKey.values.toList()
     ..sort((a, b) => b.position.compareTo(a.position));
   if (defaultSection.members.isNotEmpty) sections.add(defaultSection);
-  if (offlineSection.members.isNotEmpty) sections.add(offlineSection);
+  if ((offlineSection.count ?? 0) > 0) sections.add(offlineSection);
 
   for (final section in sections) {
     section.members.sort(
@@ -192,6 +215,23 @@ List<_RosterSection> _buildSections(
     );
   }
   return sections;
+}
+
+/// Uses the server's space summary for the complete offline total while the
+/// roster itself stays bounded to its initial page. Older servers omit these
+/// fields, in which case the visible rows remain the best available count.
+int rosterOfflineCount({
+  required Object? memberCount,
+  required Object? presenceCount,
+  required int loadedOfflineCount,
+}) {
+  final total = memberCount is num ? memberCount.toInt() : null;
+  final online = presenceCount is num ? presenceCount.toInt() : null;
+  if (total == null || online == null || total < 0 || online < 0) {
+    return loadedOfflineCount;
+  }
+  final reported = total > online ? total - online : 0;
+  return reported > loadedOfflineCount ? reported : loadedOfflineCount;
 }
 
 class _SectionHeader extends StatelessWidget {
@@ -215,6 +255,7 @@ class _SectionHeader extends StatelessWidget {
     );
   }
 }
+
 
 class _MemberRow extends ConsumerWidget {
   const _MemberRow({
@@ -361,4 +402,3 @@ Future<void> _showMemberContextMenu(
       if (context.mounted) showInfoSnack(context, 'Username copied');
   }
 }
-

--- a/packages/accordkit/test/models_test.dart
+++ b/packages/accordkit/test/models_test.dart
@@ -284,10 +284,12 @@ void main() {
           {'id': '2', 'name': 'e'},
         ],
         'member_count': 3,
+        'presence_count': 2,
       });
       expect(s.roles.single.name, 'admin');
       expect(s.emojis.single.name, 'e');
       expect(s.memberCount, 3);
+      expect(s.presenceCount, 2);
     });
   });
 

--- a/test/features/member/member_list_count_test.dart
+++ b/test/features/member/member_list_count_test.dart
@@ -1,0 +1,39 @@
+import 'package:bonfire/features/member/views/accord_member_list.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('rosterOfflineCount', () {
+    test('uses complete space metadata instead of the loaded page size', () {
+      expect(
+        rosterOfflineCount(
+          memberCount: 237,
+          presenceCount: 4,
+          loadedOfflineCount: 96,
+        ),
+        233,
+      );
+    });
+
+    test('falls back to visible rows for older servers', () {
+      expect(
+        rosterOfflineCount(
+          memberCount: null,
+          presenceCount: null,
+          loadedOfflineCount: 99,
+        ),
+        99,
+      );
+    });
+
+    test('never reports fewer members than are already loaded', () {
+      expect(
+        rosterOfflineCount(
+          memberCount: 90,
+          presenceCount: 5,
+          loadedOfflineCount: 99,
+        ),
+        99,
+      );
+    });
+  });
+}


### PR DESCRIPTION
The member sidebar used the number of loaded rows for section totals, so a space with more than the 100-member request limit displayed `OFFLINE — 99`. The sidebar now reads the authoritative `member_count` and `presence_count` space metadata and keeps the roster request bounded; older servers continue to fall back to the visible-row count.

Requires DaccordProject/accordserver#83 for authoritative totals.

Validation:

- `flutter analyze --no-pub lib/features/member/views/accord_member_list.dart test/features/member/member_list_count_test.dart packages/accordkit/test/models_test.dart`
- `flutter test test/features/member`
- `flutter test packages/accordkit/test/models_test.dart`
